### PR TITLE
loc(uk): refine terminology and proofreading

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Ukrainian/ukrainian.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Ukrainian/ukrainian.xml
@@ -68,7 +68,7 @@
   <content contentuid="h2fea2840g0902gdf2bg7797g549c20c3d6e3" version="1">Сильний удар</content>
   <content contentuid="hcd10eb1fgc367ga39egd371g5e071e079549" version="1">Ви можете рухатися до половини своєї швидкості прямо до цілі, не провокуючи принагідної атаки.</content>
   <content contentuid="hd5311cf0g6f4fg9a03g45f9gf5ba41e2994c" version="1">Удар підколінного сухожилля</content>
-  <content contentuid="hcba666bcgdd43g5b9agef09gdcfd2c3d20ff" version="1">Швидкість зменшується на [1] до початку наступного ходу атакуючого.</content>
+  <content contentuid="hcba666bcgdd43g5b9agef09gdcfd2c3d20ff" version="1">Швидкість зменшується на [1] до початку наступного ходу нападника.</content>
   <content contentuid="hebad3866ga362g915cge97fg661e8b92ea36" version="1">Рівень 11: Невпинна лють</content>
   <content contentuid="hfd45d1c1g9dd3g206agfb7eg456c6af02ac0" version="1">Один раз за &lt;LSTag Tooltip="ShortRest"&gt;короткий відпочинок&lt;/LSTag&gt;, коли під час &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Люті&lt;/LSTag&gt; ваші &lt;LSTag Tooltip="HitPoints"&gt;очки здоров’я&lt;/LSTag&gt; мали б знизитися до [1], ви натомість відновлюєте їх у кількості, що вдвічі перевищує ваш рівень варвара, і уникаєте стану &lt;LSTag Type="Status" Tooltip="DOWNED"&gt;падіння&lt;/LSTag&gt;.</content>
   <content contentuid="h784061e1gf2a8g748bg99cfg9e391dd4569c" version="1">Рівень 3: Шал</content>
@@ -82,7 +82,7 @@
   <content contentuid="h0e7ef600g82aegeba0g077eg2ddad69731f8" version="1">Вас оточує дика магія варвара. Ваш &lt;LSTag Tooltip="ArmourClass"&gt;Рівень захисту&lt;/LSTag&gt; збільшується на значення вашого бонусу до шкоди від Люті, доки не завершиться ваша &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Лють&lt;/LSTag&gt;.</content>
   <content contentuid="hd75d1783g8062gae55g78a6g651f55455f7f" version="1">Рівень 2: Майстер на всі руки</content>
   <content contentuid="h6002075bg4feegb25ag03b5g8e88a4351c0f" version="1">Рівень 5: Джерело натхнення</content>
-  <content contentuid="h5d1b01ffgd776g8ca4gd2edgb4e5e0068ad7" version="1">Крім того, ви можете використати чарунку заклять (не потрібно ніяких дій), щоб відновити один витрачений прийом Бардівського натхнення.</content>
+  <content contentuid="h5d1b01ffgd776g8ca4gd2edgb4e5e0068ad7" version="1">Крім того, ви можете витратити чарунку заклять (дія не потрібна), щоб відновити одне витрачене застосування Бардівського натхнення.</content>
   <content contentuid="h3c4853cag177dg4ea8g0c15gde7e940ee735" version="1">Джерело натхнення</content>
   <content contentuid="h7c14769cg0f8ag7968g4156g1272fd5b7850" version="3">Витратьте чарунку заклять, щоб відновити одне витрачене використання Бардівського натхнення.</content>
   <content contentuid="he36b3403gbab9gf77fg17fbg32e95953478c" version="1">Рівень 7: Непричарування</content>
@@ -157,7 +157,7 @@
   <content contentuid="hd9e8561fg5920g7f26g9d66g15b2d44e24f3" version="1">Пощада</content>
   <content contentuid="hb742b3aagabfcg536cg10e0g99bbe354e49a" version="1">Зціліть істоту в межах досяжності, яка має 0 очок здоров’я, але ще не померла.</content>
   <content contentuid="hd085b0deg3cc9g0858gdf14geef98a4164c3" version="1">Слово сяйва</content>
-  <content contentuid="hbb7ccd06g2737gdcf2gc167g21f32c9615fb" version="1">Від вас у еманації радіусом [1] виривається пекуче сяйво. Кожна вибрана вами видима істота в еманації повинна успішно виконати кидок протидії статурою, інакше зазнає променевої шкоди.</content>
+  <content contentuid="hbb7ccd06g2737gdcf2gc167g21f32c9615fb" version="1">Від вас виривається пекуче сяйво, утворюючи еманацію радіусом [1]. Кожна вибрана вами видима істота в цій зоні повинна успішно виконати кидок протидії статурою, інакше зазнає променевої шкоди.</content>
   <content contentuid="hf652a768gef39g78fdg661dg8ddbb887d3f3" version="1">Рівень 3: Поборник життя</content>
   <content contentuid="h748a060egc16cg7d82gf97eg22830dd0c9f1" version="1">Коли проказане вами за допомогою чарунки закляття відновлює істоті очки здоров’я, у хід проказування вона відновлює додаткові очки здоров’я в кількості, що дорівнює 2 + рівень чарунки.</content>
   <content contentuid="h45db170cgfec9gad8eg1591gd99ec7aa2b2c" version="1">Рівень 6: Благословенний цілитель</content>
@@ -268,7 +268,7 @@
   <content contentuid="ha16fbd5eg7072g66aeg7f0eg739d38d2a607" version="1">Первісний порядок</content>
   <content contentuid="h22f70fd0g4354g1c46g6712gdc288b7803e5" version="1">Ви присвятили себе одній із наведених нижче священних ролей на ваш вибір.</content>
   <content contentuid="hb670c3bdg0b18g5834g24e2gce9406adf925" version="1">Заряд дикої подоби</content>
-  <content contentuid="h0e2c2a49gb8a7g78d8gf687gb0cdc6987be7" version="1">Показник можливої кількості використаннь дикої подоби.</content>
+  <content contentuid="h0e2c2a49gb8a7g78d8gf687gb0cdc6987be7" version="1">Кількість доступних використань Дикої подоби.</content>
   <content contentuid="h8f1b692bg604cgb34cg9e64g7c5d22aebe85" version="1">Рівень 2: Дика подоба</content>
   <content contentuid="hc6dea6aag9290gf3cegeb8ag0351bd8d0fc5" version="2">Ви можете вторинною дією скористатися «Дикою подобою» і перетворитися на відому вам форму звіра. Ви також можете достроково завершити перетворення вторинною дією. «Дику подобу» можна застосувати двічі. Одне витрачене застосування відновлюється після короткого відпочинку, а всі — після довгого. Набувши Дикої подоби, ви отримуєте тимчасові очки здоров’я в кількості, що дорівнює вашому рівню друїда. У цій формі ви не можете проказувати закляття, але перетворення не перериває вашого зосередження й не заважає вже проказаному закляттю.</content>
   <content contentuid="h1505dff7gb11cg17eageb5dg29f041ed571a" version="1">Рівень 2: Дика подоба</content>
@@ -515,11 +515,11 @@
   <content contentuid="h39de8d3fgd862g0342g0a3ag9205f4e7bf55" version="1">Кара паладина</content>
   <content contentuid="haaa7e52ege832ge271gecfdge010d65df535" version="1">Ви можете проказати «Божу кару», не витрачаючи чарунки, але не зможете зробити це знову до завершення довгого відпочинку.</content>
   <content contentuid="hd777f361gcaa7g7dbegeb0agb9179de1ba4b" version="1">Рівень 5: Вірний скакун</content>
-  <content contentuid="h8d9bb995gd364g7b4fgd6f8gb78ed0bdda9b" version="1">Ви можете покликати на допомогу потойбічного скакуна. Ви завжди маєте підготовленим закляття «Пошук скакуна».
+  <content contentuid="h8d9bb995gd364g7b4fgd6f8gb78ed0bdda9b" version="1">Ви можете покликати на допомогу потойбічного скакуна. Ви завжди маєте підготовленим закляття «Знайти скакуна».
 
 Ви також можете один раз проказати це закляття, не витрачаючи чарунки, і відновлюєте цю змогу після довгого відпочинку.</content>
   <content contentuid="h1e887af9gf132g931bgf5ffgfd331943059d" version="1">Вірний скакун</content>
-  <content contentuid="h0aaffea6g03a3g6185g2b3eg67a082d34700" version="1">Ви також можете один раз проказати «Пошук скакуна», не витрачаючи чарунки, і відновлюєте цю змогу після довгого відпочинку.</content>
+  <content contentuid="h0aaffea6g03a3g6185g2b3eg67a082d34700" version="1">Ви також можете один раз проказати «Знайти скакуна», не витрачаючи чарунки, і відновлюєте цю змогу після довгого відпочинку.</content>
   <content contentuid="h75d1a2deg8c23gb291g4a07g0b23ca7da55c" version="1">Знайти скакуна</content>
   <content contentuid="hca271062g4f0eg4316gc46ag52e3d54b2851" version="3">Ви прикликаєте потойбічного скакуна й одразу сідаєте на нього верхи.
 
@@ -543,9 +543,9 @@
 
 &lt;LSTag Tooltip="AttackRoll"&gt;Кидки атаки&lt;/LSTag&gt; проти ураженої істоти мають &lt;LSTag Tooltip="Disadvantage"&gt;заваду&lt;/LSTag&gt;, а сама вона має &lt;LSTag Tooltip="Advantage"&gt;перевагу&lt;/LSTag&gt; на &lt;LSTag Tooltip="SavingThrow"&gt;кидки протидії&lt;/LSTag&gt; спритністю.</content>
   <content contentuid="h3d4848abgc60eg631cgc713g605af144c9ee" version="1">Рівень 9: Відлякування ворогів</content>
-  <content contentuid="h060adb3eg6617g9283g226fg6d070eb47c88" version="1">Магічною дією ви можете витратити одне використання Обітного наснаження цього класу, щоб приголомшити ворогів благоговінням. Здійнявши священний символ або зброю, виберіть видимих вам істот у межах [1] у кількості, що дорівнює вашому модифікатору харизми (щонайменше одну). Кожна ціль повинна успішно виконати кидок протидії мудрістю, інакше перебуватиме в стані переляку протягом 1 хвилини.</content>
+  <content contentuid="h060adb3eg6617g9283g226fg6d070eb47c88" version="1">Магічною дією ви можете витратити одне використання Обітного наснаження цього класу, щоб сповнити ворогів священним трепетом. Здійнявши священний символ або зброю, виберіть видимих вам істот у межах [1] у кількості, що дорівнює вашому модифікатору харизми (щонайменше одну). Кожна ціль повинна успішно виконати кидок протидії мудрістю, інакше вона набуває стану переляку на 1 хвилину.</content>
   <content contentuid="ha4ade769g56f1g989dg4a5dgc980f0453d08" version="1">Відлякування ворогів</content>
-  <content contentuid="hf0938809g82f6ge8a7gea01gff762cf6f570" version="1">Магічною дією ви можете витратити одне використання Каналу обітниці цього класу, щоб сповнити ворогів священним трепетом. Простягнувши священий символ або зброю, ви можете вибрати цілями кількість видимих істот у межах [1] від вас, що дорівнює вашому модифікатору харизми (щонайменше одну). Кожна ціль повинна успішно виконати кидок протидії мудрістю, інакше вона набуває стану переляку на 1 хвилину.</content>
+  <content contentuid="hf0938809g82f6ge8a7gea01gff762cf6f570" version="1">Магічною дією ви можете витратити одне використання Обітного наснаження цього класу, щоб сповнити ворогів священним трепетом. Здійнявши священний символ або зброю, виберіть видимих вам істот у межах [1] у кількості, що дорівнює вашому модифікатору харизми (щонайменше одну). Кожна ціль повинна успішно виконати кидок протидії мудрістю, інакше вона набуває стану переляку на 1 хвилину.</content>
   <content contentuid="hdd546b3bg87ddg0b0eg91d9g7dd5bb69d0d5" version="1">Рівень 11: Сяючі удари</content>
   <content contentuid="he923c53cgfecbgb456g1ee5gbc97fd5f5a9a" version="1">Тепер ваші удари мають надприродну силу. Коли ви вражаєте ціль за допомогою кидка атаки за допомогою зброї ближнього бою або удару голіруч, ціль зазнає додаткової променевої шкоди 1d8.</content>
   <content contentuid="h1b6d335fg71e3g921bg96efgd3563a3e9d4b" version="1">Паладин і найближчі союзники мають стійкість до некротичної, психічної та променевої шкоди.</content>
@@ -717,7 +717,7 @@
   <content contentuid="hb8aec518g6d45g1454g58cbgbac23fec6617" version="1">Рівень 9: Життєпивця</content>
   <content contentuid="h35551526g84e1g78f3g1277g241f3a6077bb" version="3">Раз за хід, коли ви влучаєте в істоту зброєю договору, можете завдати їй додатково 1d6 шкоди. Крім того, ви можете витратити одну зі своїх кісток здоров’я, кинути її та відновити очки здоров’я в кількості, що дорівнює результату кидка + ваш модифікатор статури (щонайменше 1 очко здоров’я).</content>
   <content contentuid="hb7444fe8g6554g6a31ged37g03cc050ef8d3" version="1">Необхідна умова: Чорнижник рівня 9+, Пакт виклику Клинка</content>
-  <content contentuid="hd69af339g9d2bg91b6gba38g8dbeb8503f7b" version="1">Рівень 12: Поглинаючий клинок</content>
+  <content contentuid="hd69af339g9d2bg91b6gba38g8dbeb8503f7b" version="1">Рівень 12: Пожиральний клинок</content>
   <content contentuid="haf78a66bg2f9bg5fb7g8c9ag5da07aa459f4" version="1">Додаткова атака вашого виклику Спраглий клинок надає дві додаткові атаки замість однієї.</content>
   <content contentuid="hc579ca24g72d1g35dfg46c5g5274d47b30cc" version="1">Необхідна умова: чаклун рівня 12+, виклик Спраглий клинок</content>
   <content contentuid="h007cf464gd375gf74bg38ccgdc14ddbc38cf" version="1">Рівень 1: Звірина мова</content>
@@ -860,7 +860,7 @@
   <content contentuid="h711b7815g70c9g4712ga219g0ff6e0b8c207" version="1">Магічний хист: Кислотні бризки</content>
   <content contentuid="h70fd1410g49a4g44d1g9f8eg7f6bc1c21fea" version="1">Магічний хист: Друзі</content>
   <content contentuid="ha6ce862fg4edeg49f7g9320gb8580541d70a" version="1">Магічний хист: Вогняний заряд</content>
-  <content contentuid="h97d2ab9cgaaf9g4bd4gb544g5862fb5d10b9" version="1">Магічний хист: Танцюючі вогні</content>
+  <content contentuid="h97d2ab9cgaaf9g4bd4gb544g5862fb5d10b9" version="1">Магічний хист: Танок вогників</content>
   <content contentuid="hc5fa63acg91f7g498fg8be8g4f77f6e608e1" version="1">Магічний хист: Крижаний дотик</content>
   <content contentuid="h8cab8439g423ag41e7ga45bg7c1a4c23cde3" version="1">Магічний хист: Вибухові жили</content>
   <content contentuid="h4def798ag029dg4d00g8d1eg8929e03098d6" version="1">Магічний хист: Гуркітливе лезо</content>
@@ -868,7 +868,7 @@
   <content contentuid="hc43d9642g1590g42d6gbab6ga3dc6574eb50" version="1">Магічний хист: Направляння</content>
   <content contentuid="haada0dc8gc767g45e4g98c2g6c5644d040c1" version="1">Магічний хист: Клинок зеленого полум’я</content>
   <content contentuid="h1e7a31c9g35c0g4b54g8f69g25b327a4c999" version="1">Магічний хист: Світло</content>
-  <content contentuid="hee3244d3g6916g4229gb4b7gd98a4f519f8e" version="1">Магічний хист: Рука мага</content>
+  <content contentuid="hee3244d3g6916g4229gb4b7gd98a4f519f8e" version="1">Магічний хист: Магічна рука</content>
   <content contentuid="hd455a5aag6fb4g48ccgbec8gdf13c11a88ab" version="1">Магічний хист: Уламок розуму</content>
   <content contentuid="h965b7dc5ga4acg4b60g9e4bgcd236212e8b4" version="1">Магічний хист: Мала ілюзія</content>
   <content contentuid="hcb1e67e1g69e7g4710g9cd5ga81a12763305" version="1">Магічний хист: Отруйний пирск</content>
@@ -900,10 +900,10 @@
   <content contentuid="hbcff1db6g661fg44b2gaa19ge984fa1cedb3" version="1">Магічний хист: Причарування особи</content>
   <content contentuid="h32091888g9007g441cgb899gf48ab4745ec0" version="1">Магічний хист: Палючі руки</content>
   <content contentuid="hb964961egd956g43e4gb1f4gbbd5199911f7" version="1">Магічний хист: Благословення</content>
-  <content contentuid="hcf286fcbga673g4b58g9ca2g7cb218338271" version="1">Магічний хист: Бейн</content>
+  <content contentuid="hcf286fcbga673g4b58g9ca2g7cb218338271" version="1">Магічний хист: Згуба</content>
   <content contentuid="h40603322g7144g4076ga600g816c1a3bf347" version="1">Магічний хист: Зцілення ран</content>
   <content contentuid="h21dc2164g914fg40f1g96f0g6370fd2112f5" version="1">Магічний хист: Заплутування</content>
-  <content contentuid="h1b472549g17edg4c6bgac27gf0b44463bc4c" version="1">Магічний хист: Стрімкий відступ</content>
+  <content contentuid="h1b472549g17edg4c6bgac27gf0b44463bc4c" version="1">Магічний хист: Поспішний відхід</content>
   <content contentuid="hffc26135gf1a3g4a40ga837gc93edb478e30" version="1">Магічний хист: Чарівний посвіт</content>
   <content contentuid="h4ded108bga017g4608gbf95g21aa64af5306" version="1">Магічний хист: Удаване життя</content>
   <content contentuid="haba60ef6g99aag4749g96b9g8d1f04316129" version="1">Магічний хист: Легкість пір'їни</content>
@@ -917,7 +917,7 @@
   <content contentuid="hdc5cb67eg6726g4f71ga0a5g19d3f916892d" version="1">Магічний хист: Льодяний ніж</content>
   <content contentuid="h86f50d94gf85eg4f54g9043g7300025a6b85" version="1">Магічний хист: Завдання ран</content>
   <content contentuid="h57c34580gbbf4g41acgbcb6g5f4b946ba3e2" version="1">Магічний хист: Стрибок</content>
-  <content contentuid="h931b6d31gbc0cg42a0ga0fdg6bf79513d2f8" version="1">Магічний хист: Довгоніг</content>
+  <content contentuid="h931b6d31gbc0cg42a0ga0fdg6bf79513d2f8" version="1">Магічний хист: Скороходець</content>
   <content contentuid="h3cb9ecd6gc656g434eg9178g4828fbd9e74c" version="1">Магічний хист: Магічна броня</content>
   <content contentuid="hc12ab9b5ga37dg4463g97c9gcfaef383ed25" version="1">Магічний хист: Магічний залп</content>
   <content contentuid="h7380d024gd726g4ecbgaf7bg7053d764150b" version="1">Магічний хист: Захист від зла й добра</content>
@@ -1144,7 +1144,7 @@
   <content contentuid="ha5d92735g8afdga8f3ge1c5g5b06d62a50e6" version="1">Риса: стійкість (сила)</content>
   <content contentuid="he4365c80ga72cgc5ebg1ae0g6a84db454a82" version="1">Риса: стійкість (мудрість)</content>
   <content contentuid="h1015def7gafdbg59d8g86d2g26b83e1c4b9e" version="1">Вартовий</content>
-  <content contentuid="h531047f9gd6d4g5415g3f87gada7b4be2fa4" version="1">Коли ворог у межах ближнього бою атакує союзника, ви можете застосувати &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;реагування&lt;/LSTag&gt; і атакувати цього ворога зброєю. Союзник не повинен мати рису «Вартовий».
+  <content contentuid="h531047f9gd6d4g5415g3f87gada7b4be2fa4" version="1">Коли ворог у межах ближнього бою атакує союзника, ви можете застосувати &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;реагування&lt;/LSTag&gt; й атакувати цього ворога зброєю. Союзник не повинен мати рису «Вартовий».
 
 Ви отримуєте &lt;LSTag Tooltip="Advantage"&gt;перевагу&lt;/LSTag&gt; на &lt;LSTag Tooltip="OpportunityAttack"&gt;Принагідні атаки&lt;/LSTag&gt;. Коли ви влучаєте Принагідною атакою, істота більше не може переміщуватися до кінця свого ходу.</content>
   <content contentuid="h7e48c498g5f4dgcd45g58fdgd35b898ea7df" version="1">Риса: Вартовий (Помста)</content>
@@ -1635,7 +1635,7 @@
   <content contentuid="h480dcb8bge39dg992bgfa3bg9f0cf957ce9c" version="1">Рівень 6: Виплітання заклять</content>
   <content contentuid="h4df2acb8g6e7eg6b07ga5afg05bc5f965277" version="1">Рівень 10: Посилене втілення</content>
   <content contentuid="haf5be1bagceecg0615g9988g0af66eb534ad" version="1">Втілювач</content>
-  <content contentuid="h135ef26bgf199g1ad5g7571gfe75a8983f9c" version="2">Ви вивчаєте магію, що породжує могутні стихійні явища: лютий холод, пекуче полум’я, гуркіт грому, тріск блискавки й їдку кислоту. Деякі втілювачі служать у військах живою артилерією та нищать армії здалеку. Інші спрямовують силу на захист ближніх, а дехто — на власну вигоду.</content>
+  <content contentuid="h135ef26bgf199g1ad5g7571gfe75a8983f9c" version="2">Ви вивчаєте магію, що породжує могутні стихійні явища: лютий холод, пекуче полум’я, гуркіт грому, тріск блискавки та їдку кислоту. Деякі втілювачі служать у військах живою артилерією та нищать армії здалеку. Інші спрямовують силу на захист ближніх, а дехто — на власну вигоду.</content>
   <content contentuid="ha6d01a56gfaf0g86a4g2382g2a35c4b61006" version="1">Стиль бою: стрільба з лука</content>
   <content contentuid="h8ce9b68cg7cf7gd7e9gf97cg858986c85631" version="1">Стиль бою: Захист</content>
   <content contentuid="hc04efb72g5cb0g6a76g382bg0ec7961b5cbd" version="1">Стиль бою: дуель</content>
@@ -1788,7 +1788,7 @@
 
 опір. У вас є стійкість до шкоди від холоду, блискавки та грому.</content>
   <content contentuid="h7f73ecccg72adgef93gb362g40f93abb7b1c" version="1">Пси-воїн</content>
-  <content contentuid="h59454ac0g0de7g8defg7a22g0fd1397b1f85" version="1">Пси-воїни пробуджують силу розуму, щоб зміцнити тіло. Вони спрямовують псіонічну міць у удари зброєю, атакують телекінетичною енергією та створюють заслони ментальної сили.</content>
+  <content contentuid="h59454ac0g0de7g8defg7a22g0fd1397b1f85" version="1">Пси-воїни пробуджують силу розуму, щоб зміцнити тіло. Вони спрямовують псіонічну міць в удари зброєю, атакують телекінетичною енергією та створюють заслони ментальної сили.</content>
   <content contentuid="hf1367018g2ff0g0c06g94e6g7b5a5f21d863" version="1">Воїн Милосердя</content>
   <content contentuid="h815eabb9gc85dg52dcg5f7ag22caae5f76ac" version="1">Воїни Милосердя керують життєвою силою інших. Ці монахи мандрують як цілителі, але швидко кладуть край життю ворогів. Вони часто носять маски й постають безликими провісниками життя та смерті.</content>
   <content contentuid="h25af72e1gf482g34a9g529cg6374b4fb3326" version="1">Обіт Слави</content>
@@ -1871,7 +1871,7 @@
 
 Крім того, щоразу, коли союзник уперше входить у вашу Ауру захисту під час ходу або починає свій хід там, швидкість союзника збільшується на 10 футів до кінця наступного ходу.</content>
   <content contentuid="h39f392e7g879agff67g5eafg1fbe11db0e2a" version="1">Рівень 3: Закляття Обіту слави</content>
-  <content contentuid="hc41356d2g2208g0d0fg0023g8a9c6958aaac" version="1">Магія вашої клятви гарантує, що у вас завжди будуть готові певні закляття. Коли ви досягнете рівнів Паладина, указаних у таблиці заклять Присяги Слави, у вас завжди будуть підготовлені наступні закляття: на 3-му рівні Направляюча стріла та Героїзм; на 5-му рівні, Поліпшення здібності і Магічна зброя; і на 9-му рівні &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Прискорення&lt;/LSTag&gt; і Захист від енергії.</content>
+  <content contentuid="hc41356d2g2208g0d0fg0023g8a9c6958aaac" version="1">Магія вашого обіту гарантує, що ви завжди маєте напоготові певні закляття. На рівнях паладина, указаних у таблиці «Закляття Обіту слави», ви надалі завжди маєте підготовленими такі закляття: на 3-му рівні — «Вказівний заряд» і «Героїзм»; на 5-му — «Поліпшення здібності» й «Магічна зброя»; на 9-му — &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;«Поспіх»&lt;/LSTag&gt; і «Захист від енергії».</content>
   <content contentuid="he69c1c77gfc97gb4e2g7877gb843a6c497b6" version="1">Надихальна слава</content>
   <content contentuid="h46a88a7bg99ddgbfe4gc4aeg5843b027814d" version="2">Ви можете витратити одне використання Обітного наснаження й довільно розподілити між вибраними істотами в межах 30 футів, зокрема собою, тимчасові очки здоров’я в загальній кількості 2d8 + ваш рівень паладина.</content>
   <content contentuid="hb9b1e9b0g8892g5337gacb7g38aabc6e1177" version="1">Надихальна слава</content>
@@ -1928,7 +1928,7 @@
   <content contentuid="h65ae228fgd955g4d7fg5f83g914fe7e83123" version="1">Рівень 3: Псіонічні закляття</content>
   <content contentuid="hd2d76fb0g487cg3ab3g3908g9f58ed8e7217" version="1">На рівнях чародія, указаних у таблиці «Псіонічні закляття», ви отримуєте закляття, які надалі завжди вважаються підготовленими.
 
-На 3-му рівні — «Руки Гадара», «Гамування емоцій», «Виявлення думок», «Нерозбірливий шепіт» і «Скалка розуму»; на 5-му — «Голод Гадара»; на 7-му — «Чорні мацаки Еварда»; на 9-му — «Телекінез».</content>
+На 3-му рівні — «Руки Гадара», «Гамування емоцій», «Виявлення думок», «Нерозбірливий шепіт» і «Уламок розуму»; на 5-му — «Голод Гадара»; на 7-му — «Чорні мацаки Еварда»; на 9-му — «Телекінез».</content>
   <content contentuid="hc47eeb0bg59b3g6c84g97bbg6e37b0afac07" version="1">Рівень 6: псіонічне чаклунство</content>
   <content contentuid="h50cb5cf3g3c73g27b1gaca7g9a573996ab32" version="1">Рівень 6: Психічний захист</content>
   <content contentuid="h9cc59e90gba0dg93e0gfef2g7374298fdf05" version="1">Ви маєте стійкість до психічної шкоди та імунітет до станів причарування й переляку.</content>
@@ -2143,8 +2143,8 @@
   <content contentuid="hbd7f0193ge427g3d75gc0adgfdba8212fb8b" version="1">Виберіть одне закляття 1-го рівня зі школи ілюзій або некромантії. Це закляття та &lt;LSTag Type="Spell" Tooltip="Target_Invisibility"&gt;Невидимість&lt;/LSTag&gt; завжди підготовлені. Ви також отримуєте одну чарунку заклять 1-го рівня й одну чарунку 2-го рівня.</content>
   <content contentuid="hc8800178g3eabg44b8g93a8g0d839444e75f" version="1">Торкнутий феями: Дружба тварин</content>
   <content contentuid="hdc7ba426ge98dg4316g94c9g943ef2f71ef1" version="1">Фейська магія: Дружба тварин</content>
-  <content contentuid="hbe627f0bg708bg47b4gba79gf882af49eaca" version="1">Торкнутий феями: Бейн</content>
-  <content contentuid="hf80f1d43g98c1g4673gb72fgdffcfee338d2" version="1">Фейська магія: &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Бейн&lt;/LSTag&gt;</content>
+  <content contentuid="hbe627f0bg708bg47b4gba79gf882af49eaca" version="1">Торкнутий феями: Згуба</content>
+  <content contentuid="hf80f1d43g98c1g4673gb72fgdffcfee338d2" version="1">Фейська магія: &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Згуба&lt;/LSTag&gt;</content>
   <content contentuid="h8b1e18f1g4012g4e69gb0a3g8425b829678e" version="1">Торкнутий феями: Благословення</content>
   <content contentuid="h87ead348ga862g462agbdd2g7079cbc25ffe" version="1">Фейська магія: Благословення</content>
   <content contentuid="h184c59beg8cefg4990ga08bg9f97071dab68" version="1">Торкнутий феями: Причарування особи</content>
@@ -2159,10 +2159,10 @@
   <content contentuid="h1f496538gbf09g4d50gaffdg135542e5928e" version="1">Фейська магія: Героїзм</content>
   <content contentuid="h58b730d5g4dcbg4b48g971cg5b740e2ffc3d" version="1">Торкнутий феями: Прокльон</content>
   <content contentuid="h4fbc6dd5g38b2g47f9g9735g678004c05e74" version="1">Фейська магія: Прокльон</content>
-  <content contentuid="hdd4dbdd2g4659g4a31g8aa0gc4c445c1be33" version="1">Торкнутий феями: Огидний сміх Таші</content>
-  <content contentuid="h23321941gc35bg4651g9eb6gf98a34d2777f" version="1">Фейська магія: Огидний сміх Таші</content>
-  <content contentuid="hbb161f9ega89fg403eg823fge6c45b2fb19b" version="1">Торкнутий феями: Мітка мисливця</content>
-  <content contentuid="h57d8ec12g3ceeg4061gaf4eg0e05c40d93ef" version="1">Фейська магія: Мітка мисливця</content>
+  <content contentuid="hdd4dbdd2g4659g4a31g8aa0gc4c445c1be33" version="1">Торкнутий феями: Невтримний регіт Таші</content>
+  <content contentuid="h23321941gc35bg4651g9eb6gf98a34d2777f" version="1">Фейська магія: Невтримний регіт Таші</content>
+  <content contentuid="hbb161f9ega89fg403eg823fge6c45b2fb19b" version="1">Торкнутий феями: Мисливська мітка</content>
+  <content contentuid="h57d8ec12g3ceeg4061gaf4eg0e05c40d93ef" version="1">Фейська магія: Мисливська мітка</content>
   <content contentuid="h62dc921dgae66g4db2ga508g1e377eaf2e8c" version="1">Торкнутий феями: Сон</content>
   <content contentuid="h3db64f18g5e4dg4e28g992ag1e784239f0a8" version="1">Фейська магія: Сон</content>
   <content contentuid="h4ce0ba4bg2079g403cg83a5g54abfdb0d35f" version="1">Торкнутий феями: Розмова з тваринами</content>
@@ -2483,7 +2483,7 @@
   <content contentuid="h3da2c0c2ge282gffe0g4fc2gbb39fdf2759a" version="1">Крижаний рибалка</content>
   <content contentuid="h0326e7b1g8c73g586agce87gedf968fe63ea" version="2">Риса: Пильність
 
-Ви походите зі славетного роду підлідних рибалок із Десятимістя в Долині Крижаного Вітру. Ловити лобату форель — не найпочесніше заняття на Півночі, зате чесне. Ви навчилися відчувати найменший рух волосіні, витягали величезних риб із укритих кригою озер і випатрали стільки форелі, що нею можна було б не раз нагодувати все селище. Цей досвід загартував ваше тіло й дух для життя шукача пригод.
+Ви походите зі славетного роду підлідних рибалок із Десятимістя в Долині Крижаного Вітру. Ловити лобату форель — не найпочесніше заняття на Півночі, зате чесне. Ви навчилися відчувати найменший рух волосіні, витягали величезних риб з укритих кригою озер і випатрали стільки форелі, що нею можна було б не раз нагодувати все селище. Цей досвід загартував ваше тіло й дух для життя шукача пригод.
 
 Стояти разом. Коли союзник у межах 5 футів від вас зазнає ефекту, що має штовхнути або притягнути його, ви можете застосувати реагування, щоб завадити цьому переміщенню. Союзник не повинен перебувати в стані недієздатності.</content>
   <content contentuid="hc067f1degeab6gcb46ge111g828cec427e50" version="1">Лицар Панцерної Рукавиці</content>
@@ -2704,7 +2704,7 @@
   <content contentuid="hb450a1d2g4f77g57dbg4c25gd3acee588f18" version="1">Внутрішнє сяйво</content>
   <content contentuid="h4049a129gb079gf0dagb270g0aa72eb1171d" version="1">Ваші очі й рот тимчасово випромінюють пекуче світло. На час дії перетворення ви випромінюєте яскраве світло в радіусі 10 футів і тьмяне світло ще на 10 футів. Наприкінці кожного вашого ходу кожна істота в межах 10 футів зазнає променевої шкоди в кількості, що дорівнює вашому бонусу спеціалізації.</content>
   <content contentuid="h5455adb5gc4c2g9159g585eg6c24762cbd53" version="1">Некротичний саван</content>
-  <content contentuid="h3a16b87eg8dd3g9578gd609gbf2f106aa676" version="1">Ваші очі на мить стають темними безоднями, а зі спини виростають тимчасові нелітаючі крила. Усі істоти, крім ваших союзників, у межах 10 футів від вас мають успішно виконати кидок протидії харизмою, інакше набувають стану переляку до кінця вашого наступного ходу.</content>
+  <content contentuid="h3a16b87eg8dd3g9578gd609gbf2f106aa676" version="1">Ваші очі на мить перетворюються на безодні темряви, а за спиною виростають крила, не здатні до польоту. Усі істоти, крім ваших союзників, у межах 10 футів від вас повинні успішно виконати кидок протидії харизмою, інакше вони набувають стану переляку до кінця вашого наступного ходу.</content>
   <content contentuid="h14b0a7adg6f8dg3aefgbc10ge9f1398e2825" version="1">Внутрішнє сяйво</content>
   <content contentuid="h868292b4g07bag5039g7a39g8b646671c67e" version="2">Має штраф 1d4 до &lt;LSTag Tooltip="SavingThrow"&gt;кидків протидії&lt;/LSTag&gt;.</content>
   <content contentuid="h6ef5198eg577fg6ca6gc4d9gb725efc2c584" version="1">Уламок розуму</content>
@@ -2810,7 +2810,7 @@
 
 Натиск марида. Ціль і кожна вибрана вами істота у 10-футовій еманації від вас виконує кидок протидії силою проти вашої МС протидії закляттям. У разі невдачі істоту відштовхує на 15 футів прямо від вас, і вона набуває стану повалення.</content>
   <content contentuid="hf359a230g9c7ag4b00g9797g85e2e40e5b9f" version="1">Рівень 3: Закляття джинів</content>
-  <content contentuid="he0865db7gfb16g94fegbb02gd941d6db835a" version="1">На певних рівнях паладина магія джина завжди тримає для вас підготовленими певні закляття. На 3-му рівні ви завжди маєте підготовлені «Хроматичну кулю» та «Громову кару». На 5-му рівні до них додаються «Віддзеркалення» і «Примарна сила», а на 9-му — «Політ» і «Газоподібність».</content>
+  <content contentuid="he0865db7gfb16g94fegbb02gd941d6db835a" version="1">На певних рівнях паладина магія джина завжди тримає для вас підготовленими певні закляття. На 3-му рівні ви завжди маєте підготовлені «Хроматична куля» та «Громова кара»; на 5-му до них додаються «Віддзеркалення» і «Примарна сила»; на 9-му — «Політ» і «Газоподібність».</content>
   <content contentuid="h9ef367bcg743fg6596ga14cgdc4842c967b1" version="1">Рівень 3: Пишнота джина</content>
   <content contentuid="h9f395fe8g244dg8ddcgcbe0g3ee47a325f9f" version="1">Поки ви не носите обладунків, ваш базовий РЗ дорівнює 10 + ваші модифікатори спритності й харизми. Щит не позбавляє вас цієї переваги.
 
@@ -2818,7 +2818,7 @@
   <content contentuid="h1ad2ebf2gb473g88deg2fb9gc419b2fa63cf" version="1">Рівень 7: Аура стихійного захисту</content>
   <content contentuid="h4ed8c047g25f9g2d20g185eg45a7a0f16ff5" version="1">Ви та ваші союзники маєте стійкість до шкоди від кислоти, холоду, вогню, блискавки та грому, перебуваючи під вашою аурою захисту.</content>
   <content contentuid="h7ce47465gdfeag71dcgb0bdgeadc0c987cab" version="1">Тиск дао</content>
-  <content contentuid="hb3aa275bga6abgc81agd39bg3d1c211dcc20" version="1">Земля піднімається навколо цілі. Ціль має стан Стримано.</content>
+  <content contentuid="hb3aa275bga6abgc81agd39bg3d1c211dcc20" version="1">Земля здіймається навколо цілі, надаючи їй стан стримування.</content>
   <content contentuid="hd20d93a6g9ec6gc3cdg1890g0e70817191af" version="2">Втеча джина</content>
   <content contentuid="hc2eacb6dgfdd7gb76ag186cgecc6d2ed93b5" version="1">Ви телепортуєтеся у видимий вільний простір у межах 30 футів і набуваєте напівбезтілесної подоби до кінця свого наступного ходу. У цій подобі ви маєте стійкість до забійної, колольної та рубальної шкоди й імунітет до станів повалення та знерухомлення.</content>
   <content contentuid="h41d151e2g9ff2g7903gdcffg74d3df5ec77f" version="2">Лють іфрита</content>
@@ -2868,7 +2868,7 @@
   <content contentuid="hfffd3126gea34g1eb6g8f8dge04162d1ab9b" version="1">Рівень 3: Жага крові</content>
   <content contentuid="hc8d05a2bgbefbg9d12gb34fg7f2025113439" version="1">Коли видимий вам ворог у межах 30 футів зазнає шкоди, після якої стає закривавленим, але не гине одразу, ви можете застосувати реагування й телепортуватися у видимий вам вільний простір у межах 5 футів від нього. Після цього ви можете виконати одну атаку ближнього бою. Кількість застосувань цієї особливості дорівнює вашому модифікатору інтелекту (щонайменше одне), а всі витрачені застосування відновлюються після довгого відпочинку.</content>
   <content contentuid="h7fa7c6fagab40g7237g2bd1g55927793880a" version="1">Рівень 3: Моторошна відданість</content>
-  <content contentuid="h717c2effgcfefg6531g04eeg3d6a10c88329" version="2">Ви укладаєте Моторошну вірність, обираючи одного з Мертвої Трійці: Бейна, Баала або Меркула. Ваш вибір дає стійкість до певного типу шкоди і змогу проказувати відповідне замовляння, базовою характеристикою проказування якого є інтелект.
+  <content contentuid="h717c2effgcfefg6531g04eeg3d6a10c88329" version="2">Ви укладаєте Моторошну вірність, обираючи одного з Мертвої Трійці: Бейна, Баала або Меркула. Ваш вибір дає стійкість до певного типу шкоди й змогу проказувати відповідне замовляння, базовою характеристикою проказування якого є інтелект.
 
 Обравши Бейна, ви отримуєте стійкість до психічної шкоди й можете проказувати &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;«Малу ілюзію»&lt;/LSTag&gt;.
 
@@ -2953,7 +2953,7 @@
   <content contentuid="h7d983a4eg695fg923dg4a7fg825cd8f6143f" version="1">Рівень 2: Ризик</content>
   <content contentuid="hc954e882g16cegbaa5geb0bgf93add6a9f64" version="1">Ваш початковий запас Кісток ризику становить чотири d8. Використана Кістка ризику витрачається, а завершення короткого чи тривалого відпочинку відновлює всі витрачені кістки.
 
-Із підвищенням рівня зростають їхня кількість і розмір: на рівнях 2–5 ви маєте чотири d8, на рівнях 6–9 — п’ять d8, а на рівнях 10–12 — п’ять d10.</content>
+З підвищенням рівня зростають їхня кількість і розмір: на рівнях 2–5 ви маєте чотири d8, на рівнях 6–9 — п’ять d8, а на рівнях 10–12 — п’ять d10.</content>
   <content contentuid="he5fbff85g7fc3g5a80ge481g51072629781a" version="1">Рівень 5: Постріл у живіт</content>
   <content contentuid="h9ce3665eg2bb4g9141g98d5ged02bb1becb1" version="2">Щоразу, коли ви завдаєте критичного влучання істоті великого або меншого розміру далекобійною атакою зброєю, снаряд застрягає в цілі. На 3 ходи її швидкість зменшується вдвічі, а кидки атаки мають заваду.</content>
   <content contentuid="ha0793978g9cb2g100fg7822gda43641de6da" version="1">Постріл у живіт</content>
@@ -3019,7 +3019,7 @@
   <content contentuid="hb4ca4223gcc87g7a48g70f8ge8b72f98226f" version="1">Джекпот</content>
   <content contentuid="h42c83e2fgb526ge712gd8fbg5dd17226f6f9" version="1">Погруддя</content>
   <content contentuid="hedc8f50dg2cfege304g3e25gaf93f9dfc2e9" version="1">Шкода від наступної атаки дистанційної зброї подвоюється.</content>
-  <content contentuid="h396d95d1gb027gae12ge9f1gfd524d0a2828" version="1">Шкода від ваших атак із зброї далекого бою цього ходу зменшується вдвічі.</content>
+  <content contentuid="h396d95d1gb027gae12ge9f1gfd524d0a2828" version="1">Шкода від ваших атак зі зброї далекого бою цього ходу зменшується вдвічі.</content>
   <content contentuid="h852be075ged2egce53g06ddg5c3bd7f0ea3c" version="1">Ризикований бізнес</content>
   <content contentuid="h085e0a00g7d78gfc3dgbd2bg6ac83183e80e" version="1">Один раз за хід, виконуючи кидок атаки проти ворога без завади, ви можете вирішити виконати його із завадою. У такому разі ви відновлюєте одну витрачену кістку ризику.</content>
   <content contentuid="hb415e825g6438g17d3g2957g78ef9a062b18" version="1">Шкіра ваших зубів (Ризикувальник)</content>
@@ -3031,7 +3031,7 @@
   <content contentuid="hcf49c14dg93ceg7906g770dg50e2ea6a3c87" version="1">Білий капелюх</content>
   <content contentuid="h5e8ae88cg3e3fg20acg354bg8c4bea47525e" version="1">Деякі стрільці живуть за кодексом і вимагають того самого від інших. Їх називають Білими Капелюхами. Часом вони служать закону, але ніколи не вагаються вчинити правильно, навіть якщо закон велить інакше. Попри любов до смертоносної зброї, Білі Капелюхи воліють берегти друзів і приборкувати ворогів без кровопролиття — хоча вороги рідко дають їм таку можливість.</content>
   <content contentuid="h39141f86g1ee2ga21ag8d53ga05af28fd1f7" version="3">Пістоль</content>
-  <content contentuid="hf305122ag44adg88bag55cbgd8db4c039656" version="3">Найперший тип одноручної вогнепальної зброї, пістолет, працює як мініатюрний мушкет, заряджаючи та стріляючи одним важким снарядом із смертельними наслідками.</content>
+  <content contentuid="hf305122ag44adg88bag55cbgd8db4c039656" version="3">Найперший тип одноручної вогнепальної зброї, пістолет, працює як мініатюрний мушкет, заряджаючи та стріляючи одним важким снарядом зі смертельними наслідками.</content>
   <content contentuid="h1060906fg1496g1454g9846g4f2197c2c188" version="1">Вогнепальна зброя</content>
   <content contentuid="h05daeb7eg0489g5774g293ag23a57911c159" version="1">Якщо ви не маєте властивості «Експерт з вогнепальної зброї», то не додаєте модифікатор характеристики до кидків шкоди цієї зброї.</content>
   <content contentuid="h7ded197eg2127g6036ge3dcgb2d60fbb65bf" version="1">Вогнепальна зброя</content>
@@ -3072,7 +3072,7 @@
   <content contentuid="hf94de242ge211g147egfef6gf0c946d2ffe0" version="1">Рівень 3: Чутливий спуск</content>
   <content contentuid="h83b92101gfc2bg31e9gf707gf2e81d4a43fc" version="3">Ви отримуєте досвід роботи з вогнепальною зброєю. Крім того, ви можете здійснити одну атаку зброєю в першому ході бою без використання дії.</content>
   <content contentuid="hcc27b910g6850g1264gef1agb05f75743b92" version="1">Рівень 3: Надійний скакун</content>
-  <content contentuid="h4bf647c4g9622g1b59gd3ccg7614d1ac3969" version="1">Закляття «Пошук скакуна» завжди підготовлене для вас. Завдяки цій особливості ви можете проказати його без чарунки й складників, використовуючи інтелект як базову характеристику проказування.
+  <content contentuid="h4bf647c4g9622g1b59gd3ccg7614d1ac3969" version="1">Закляття «Знайти скакуна» завжди підготовлене для вас. Завдяки цій особливості ви можете проказати його без чарунки й складників, використовуючи інтелект як базову характеристику проказування.
 
 Проказавши закляття в такий спосіб, ви не зможете повторити це до завершення короткого відпочинку.</content>
   <content contentuid="h97981f9bgce50gd7e8g2a87gceb5d667aef5" version="1">Рівень 3: Зім’яти на скаку</content>
@@ -3092,11 +3092,11 @@
   <content contentuid="h63ce4017geac0gc60egf8b5g9dce552352fa" version="1">Рівень 3: Додаткова майстерність</content>
   <content contentuid="h51fe1e07g2424g5ddcg0df6g20465b6f7342" version="1">Ви отримуєте спеціалізацію в одній навичці на свій вибір: &lt;LSTag Type="Skills" Tooltip="AnimalHandling"&gt;Догляд за тваринами&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;Історія&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Проникливість&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Артистичність&lt;/LSTag&gt; або &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Переконливість&lt;/LSTag&gt;.</content>
   <content contentuid="h07ffaea2g95cdgb266g0772gc36a0178e777" version="1">Рівень 3: Народжений до сідла</content>
-  <content contentuid="h92ac32f2gae16g6effgdffege7984a067a57" version="1">Закляття «Пошук скакуна» завжди підготовлене для вас. Завдяки цій особливості ви можете проказати його без чарунки й складників, використовуючи інтелект як базову характеристику проказування.
+  <content contentuid="h92ac32f2gae16g6effgdffege7984a067a57" version="1">Закляття «Знайти скакуна» завжди підготовлене для вас. Завдяки цій особливості ви можете проказати його без чарунки й складників, використовуючи інтелект як базову характеристику проказування.
 
 Проказавши закляття в такий спосіб, ви не зможете повторити це до завершення короткого відпочинку.</content>
   <content contentuid="hb0de3a5fgafe3g904agae5fgdfc2d5a9d82b" version="1">Рівень 3: непохитний знак</content>
-  <content contentuid="h39e677d5ged8fgc431g5486g61bd08885fd5" version="1">Ви завжди маєте підготовленим закляття «Мітка мисливця». Кількість його проказувань дорівнює вашому модифікатору сили (щонайменше одне), а всі витрачені застосування відновлюються після довгого відпочинку.</content>
+  <content contentuid="h39e677d5ged8fgc431g5486g61bd08885fd5" version="1">Ви завжди маєте підготовленим закляття «Мисливська мітка». Кількість його проказувань дорівнює вашому модифікатору сили (щонайменше одне), а всі витрачені застосування відновлюються після довгого відпочинку.</content>
   <content contentuid="hbb926017g2b0agbe90g66bcgbf207e483612" version="1">Рівень 7: Охоронний маневр</content>
   <content contentuid="ha2bb03e3g700ag8cdagaff7gd4fdd097b625" version="1">Ви вчитеся відбивати удари, спрямовані на вас, вашого скакуна чи інших істот поблизу. Коли атака влучає у вас або у видиму вам істоту в межах 5 футів, ви можете застосувати реагування й кинути 1d8, якщо тримаєте зброю ближнього бою або щит. Додайте результат до РЗ цілі проти цієї атаки, що може перетворити влучання на промах.</content>
   <content contentuid="hd234d1a5g51feg1581ga07ag43fc0a63f55a" version="1">Рівень 10: Тримати стрій</content>
@@ -3215,17 +3215,17 @@
 
 Елітні агенти архідияволів — ілріґери. Ці лицарі, убивці, маги й пекельні командос панують на полі бою, розколюють ворожі угруповання та виконують пекельну волю свого володаря.</content>
   <content contentuid="h9b53ce98gbf9cg2509g1a23g24549bd6fad7" version="1">Рівень 1: Згубна заборона</content>
-  <content contentuid="ha8eaee0fg754dg1d66g293cgf44cc84312b0" version="1">Ви отримуєте здатність засуджувати істот за допомогою сили пекла. У свою чергу ви можете накласти магічну печатку на істоту в радіусі 30 футів від вас. Ви можете поставити цю печатку, коли вразите цю ціль атакою зі зброї (не потрібно ніяких дій), або ви можете використати вторинну дію, щоб помістити цю печатку на ціль, яку ви бачите в радіусі. Ця печатка зберігається до згоряння. Істота з однією або декількома вашими печатками називається забороненою істотою.
+  <content contentuid="ha8eaee0fg754dg1d66g293cgf44cc84312b0" version="1">Ви набуваєте здатності таврувати істот силою Пекла. Один раз за свій хід ви можете накласти магічну печатку на істоту в межах 30 футів. Ви можете накласти печатку, коли влучаєте в ціль атакою зброєю (дія не потрібна), або вторинною дією — на видиму ціль у межах дальності. Печатка діє, доки її не спалено. Істота з однією чи кількома вашими печатками вважається забороненою істотою.
 
-Ви можете розмістити лише обмежену кількість печаток перед відпочинком, і ви відновите всі витрачені печатки, коли закінчите короткий або довгий відпочинок. Ви можете мати максимум три печатки на 1-му рівні, чотири печатки на 3-му рівні та п’ять печаток на 7-му рівні.
+До відпочинку ви можете накласти лише обмежену кількість печаток. Завершивши короткий або довгий відпочинок, ви відновлюєте всі витрачені печатки. Максимальна кількість печаток становить три на 1-му рівні, чотири на 3-му та п’ять на 7-му.
 
-Якщо заборонена істота помирає, ви повертаєте собі всі печатки, які наклали на неї. Ви можете знову помістити ці печатки на нові цілі, одну за одною, у звичайний спосіб.</content>
+Якщо заборонена істота помирає, ви відновлюєте всі накладені на неї печатки. Потім їх можна по одній накладати на нові цілі у звичайний спосіб.</content>
   <content contentuid="h0294b05egc63bg881age868g1c91eaec6dab" version="1">Печатка</content>
   <content contentuid="hc31eef37gcba0g3dd5g3558g3b4bd0528103" version="1">Ви отримуєте здатність засуджувати істот за допомогою сили пекла.</content>
   <content contentuid="hecedcd5eg3f81g2638g3af5gefcca2c219fb" version="1">Пекучі печатки: вогонь</content>
   <content contentuid="hfca57e47ged90g177fgfc94gdd2a6f69f1a8" version="1">Пекучі печатки: некротична енергія</content>
   <content contentuid="h4b36c8d5g7a7fgf9degbde8ga2790584725d" version="1">Розмістити печатку</content>
-  <content contentuid="h09168b32g9fe8gac39gedf6g93f7c55f5e17" version="1">Накладіть на ціль одну печатку ілриґера.</content>
+  <content contentuid="h09168b32g9fe8gac39gedf6g93f7c55f5e17" version="1">Накладіть на ціль одну печатку ілріґера.</content>
   <content contentuid="hc00e6ea9gfd5egcff2g4900g073fd4c5bd3f" version="2">Ви спалюєте всі накладені на істоту печатки. За кожну спалену печатку вона зазнає 1d6 вогняної або некротичної шкоди на ваш вибір. Спалена печатка негайно зникає.
 
 На 5-му рівні цього класу ваш зв’язок з архідияволом зміцнюється, і кожна спалена печатка завдає додатково 1d6 шкоди — загалом 2d6 за печатку. На 10-му рівні шкода від кожної печатки зростає ще на 1d6 — загалом до 3d6.</content>
@@ -3241,9 +3241,7 @@
   <content contentuid="hb58aa744g9557g7770g99f4g200999b88429" version="2">Рівень 2: жорстокий</content>
   <content contentuid="h58aa4956gcc27g9d75g019cgd0340e796f47" version="2">Рівень 2: Бравада</content>
   <content contentuid="hb80a53b8gbab4ge493ge6fcg80ca85f5cccd" version="1">Поки ви не носите жодних обладунків, ваш рівень захисту дорівнює 10 + ваш модифікатор спритності + ваш модифікатор харизми. Ви можете використовувати щит і все одно отримати цю перевагу.</content>
-  <content contentuid="h69a470cbg07f2g82ddg9603g8091c23a6a5a" version="1">Коли ви застосовуєте «Згубний інтердикт», щоб накласти чи спалити печатку, його дальність становить 60 футів замість 30. Після отримання особливості «Пекельний провідник» на 6-му рівні її дальність становить 30 футів замість дотику.
-
-Крім того, перебування в межах 5 футів від ворожої істоти не дає завади вашим дальнім атакам.</content>
+  <content contentuid="h69a470cbg07f2g82ddg9603g8091c23a6a5a" version="1">Коли ви застосовуєте «Згубну заборону», щоб накласти чи спалити печатку, її дальність становить 60 футів замість 30. Після отримання особливості «Пекельний провідник» на 6-му рівні її дальність становить 30 футів замість дотику.</content>
   <content contentuid="h67c6cf13g3c76g42a4gfac4g3b887eeb9730" version="1">Коли ви влучаєте в істоту атакою зброєю ближнього бою, то можете рухатися, не провокуючи принагідних атак.</content>
   <content contentuid="hdc3b3befg7002g12f7g8757g9c5c9409d33c" version="1">Для кидків атаки й шкоди зброєю ближнього бою ви використовуєте модифікатор харизми замість сили чи спритності.</content>
   <content contentuid="hf1d142d7g41e9g9a72g6d5cgf6c2fa588579" version="2">Ви отримуєте бонус +1 до кидків протидії за кожну ворожу істоту в радіусі 10 футів від вас, до максимального бонусу +5.</content>
@@ -3253,13 +3251,13 @@
   <content contentuid="hb8cf1d46g6834g9baagbf6dg50299be625eb" version="1">Бойова майстерність</content>
   <content contentuid="h5f2491abg74f5g071bgce31ge29ac76995fd" version="1">Ваш архідиявол дарує вам надзвичайну вправність у певному виді бою. Виберіть одну з наведених нижче бойових майстерностей ілріґера:</content>
   <content contentuid="h67853750g16c0g9b13gc3efgbaba43af6259" version="2">Рівень 2: Ущільнення</content>
-  <content contentuid="hddb45062ge037g28d1g354fgec018a665978" version="1">Коли видима істота завдає шкоди вам або союзнику в межах 30 футів від вас, ви можете реагуванням витратити печатку й зменшити цю шкоду на 1d10 + половина вашого рівня ілріґера (з округленням униз).</content>
+  <content contentuid="hddb45062ge037g28d1g354fgec018a665978" version="1">Коли видима істота завдає шкоди вам або союзнику в межах 30 футів від вас, ви можете реагуванням витратити печатку й зменшити цю шкоду на 1d10 + половину вашого рівня ілріґера (з округленням униз).</content>
   <content contentuid="h565e4f77gf679gd18fgcb9bg38afc492e620" version="2">Рівень 2: Морочення</content>
   <content contentuid="hc60731eeg14f1gbf2egea48g01b6d1ad45e8" version="1">Коли ви спалюєте печатку на забороненій істоті, ви можете активувати це благо (не потрібно нічого робити). Ціль повинна відняти число, що дорівнює вашому бонусу спеціалізації, від результату зробленого кидка протидії до кінця свого наступного ходу.</content>
   <content contentuid="h70a4510cgf224gfccfg83dbge051b2c47f34" version="2">Рівень 2: Пожирач душ</content>
-  <content contentuid="hcdb79176g44f6gae88g5df2g09e6221e8525" version="1">Коли ви спалюєте печатку на істоті під інтердиктом, то можете без витрати дії активувати цей дар і отримати тимчасові очки здоров’я в кількості, що дорівнює вашому рівню ілріґера.</content>
+  <content contentuid="hcdb79176g44f6gae88g5df2g09e6221e8525" version="1">Коли ви спалюєте печатку на забороненій істоті, то можете без витрати дії активувати цей дар і отримати тимчасові очки здоров’я в кількості, що дорівнює вашому рівню ілріґера.</content>
   <content contentuid="h16cf04ffg2962g897ag364fgea809b7c8c16" version="2">Рівень 2: Апатія Стікса</content>
-  <content contentuid="haa0a6c9agc413g822cg52f2g69c530bc79d2" version="2">Коли ви спалюєте печатку на забороненій істоті, ви можете затопити ціль потойбічним холодом. До кінця свого наступного ходу він не може виконувати вторинні дії чи реагування.</content>
+  <content contentuid="haa0a6c9agc413g822cg52f2g69c530bc79d2" version="2">Коли ви спалюєте печатку на забороненій істоті, то можете сповнити ціль потойбічним холодом. До кінця свого наступного ходу вона не може виконувати вторинні дії чи реагування.</content>
   <content contentuid="hfa888bb3gb8a0ge2a8g81c2g00ae8844f692" version="4">Рівень 7: Ланцюг Ахерона</content>
   <content contentuid="h8993f01fgfd8fg8b11g17cdg458c682aad00" version="3">Потребує 7-го рівня ілріґера або вищого.
 
@@ -3275,7 +3273,7 @@
   <content contentuid="hf6bff230g1643g366bg93ffg3c9d643ce07c" version="4">Рівень 7: Звільніть пекло</content>
   <content contentuid="h6c2e1510g127eg4a2eg3cbfg9e940ea8f6e8" version="2">Потребує 7-го рівня ілріґера або вищого.
 
-Коли ви спалюєте одну чи кілька печаток на істоті під забороною, то можете застосувати реагування, щоб вивільнити довкола неї вибух пекельної енергії. Кожна вибрана вами істота в межах 10 футів від цілі повинна виконати кидок протидії спритністю. У разі невдачі вона зазнає стільки ж шкоди того самого типу, скільки печатки завдали істоті під забороною; у разі успіху — лише половину.</content>
+Коли ви спалюєте одну чи кілька печаток на забороненій істоті, можете реагуванням вивільнити навколо неї вибух пекельної енергії. Кожна вибрана вами істота в межах 10 футів від цілі повинна виконати кидок протидії спритністю. У разі невдачі вона зазнає стільки ж шкоди того самого типу, скільки печатки завдали забороненій істоті, а в разі успіху — вдвічі менше.</content>
   <content contentuid="he8bb0a53gb20cg63a2g3f35gf408f22a699e" version="4">Рівень 7: Мстивий постріл</content>
   <content contentuid="h4455cd21gb4e4ga171g4a01gfd22b925fb9b" version="2">Потребує 7-го або вищого рівня ілріґера.
 
@@ -3283,10 +3281,10 @@
   <content contentuid="h368ac3efg0988g4f4ag0fa9g6819e55d1577" version="1">Вивільнити пекло: вогонь</content>
   <content contentuid="hebd66c01g7f34g9436g6f68gde5a37620a3f" version="1">Вивільнити пекло: некротична енергія</content>
   <content contentuid="had6ccb0dg99e0ge0b3gfe64g2cc75c0d28a0" version="1">Вивільнити пекло: вогонь</content>
-  <content contentuid="heca0b0d3g54dbgf86cg916cg906977301869" version="1">Коли ви спалюєте одну або більше печаток на істоті, позначеній інтердиктом, можете реагуванням вивільнити навколо неї вибух пекельної енергії. Кожна вибрана вами істота в межах 10 футів від цілі повинна виконати кидок протидії спритністю. У разі невдачі вона зазнає стільки ж шкоди того самого типу, скільки печатки завдали позначеній істоті, а в разі успіху — вдвічі менше.</content>
+  <content contentuid="heca0b0d3g54dbgf86cg916cg906977301869" version="1">Коли ви спалюєте одну чи кілька печаток на забороненій істоті, можете реагуванням вивільнити навколо неї вибух пекельної енергії. Кожна вибрана вами істота в межах 10 футів від цілі повинна виконати кидок протидії спритністю. У разі невдачі вона зазнає стільки ж шкоди того самого типу, скільки печатки завдали забороненій істоті, а в разі успіху — вдвічі менше.</content>
   <content contentuid="hdad51f43g5e81g7f25g4fa0gb0809a43973d" version="1">Вивільнити пекло: некротична енергія</content>
   <content contentuid="h3518e2eeg9593gae20g3e88gff65f6d3e6bb" version="1">Ущільнення</content>
-  <content contentuid="h0f8708dbgeff3g4172g8db1g4d944084b8c1" version="1">Коли видима істота завдає шкоди вам або союзнику в межах 30 футів від вас, ви можете реагуванням витратити печатку й зменшити цю шкоду на 1d10 + половина вашого рівня ілріґера (з округленням униз).</content>
+  <content contentuid="h0f8708dbgeff3g4172g8db1g4d944084b8c1" version="1">Коли видима істота завдає шкоди вам або союзнику в межах 30 футів від вас, ви можете реагуванням витратити печатку й зменшити цю шкоду на 1d10 + половину вашого рівня ілріґера (з округленням униз).</content>
   <content contentuid="he0219d6eg9988g1637g2557g9b2d2d0fa8aa" version="1">Морочення</content>
   <content contentuid="hc323cc9cg84e2g474bg5925g8922b79a3ba5" version="1">Ціль повинна відняти число, що дорівнює бонусу спеціалізації Ілріґера, від результату зробленого кидка протидії до кінця свого наступного ходу.</content>
   <content contentuid="h84a9d67fge555g185dg5c83g4c97364a1cef" version="1">Пожирач душ</content>
@@ -3304,7 +3302,7 @@
   <content contentuid="hdcff639cge97ag87c0gca5dgb607adff562c" version="1">Мстивий постріл</content>
   <content contentuid="hc952c432g8c2cgbbacg18f8gfc587dff1d4d" version="1">Коли істота виконує дальню атаку проти вас або видимого союзника в межах 30 футів, ви можете реагуванням витратити печатку й атакувати нападника далекобійною зброєю. У разі влучання атака додатково завдає шкоди в кількості, що дорівнює половині вашого рівня ілріґера (з округленням униз).</content>
   <content contentuid="h2ab85095gd8e1gd4f8g159bg5479bf29202f" version="1">Заборона</content>
-  <content contentuid="he346a671g0b23g7417g4182g5a8d53b45077" version="1">Ви можете насичувати свої печаті пекельною магією, посилюючи їхню дію.
+  <content contentuid="he346a671g0b23g7417g4182g5a8d53b45077" version="1">Ви можете насичувати свої печатки пекельною магією, посилюючи їхню дію.
 
 Деякі блага потребують певного рівня ілріґера. Досягнувши 7-го рівня, ви отримуєте ще одне благо.</content>
   <content contentuid="h79d9540bg9852g5efdg3c46g65c5ac3dee8d" version="1">Рівень 6: Пекельний провідник</content>
@@ -3326,15 +3324,15 @@
   <content contentuid="hcef63acbg72bag27f7g9fadgf2d9d61c668d" version="1">Рівень 11: Тероризуюча сила (некротична)</content>
   <content contentuid="ha7401e8dg37d9g7b31g97c4gc53803a8288b" version="1">Рівень 11: Тероризуюча сила (отрута)</content>
   <content contentuid="hd8fa84e9gb7b9g487bgeb2agb80c8a9a3f17" version="1">Заповіді крові</content>
-  <content contentuid="hc31d5eb8g73cdgf87bg7969geb0fc56b1687" version="1">Лицарі-сангвініки дають клятву Сутеху, коли приєднуються до Ордену Спустошення. Ці принципи присягають їх володіти профанною магією крові, вимагаючи відданості та наводячи жах.
+  <content contentuid="hc31d5eb8g73cdgf87bg7969geb0fc56b1687" version="1">Лицарі-сангвініки складають обіт Сутеху, вступаючи до Ордену Спустошення. Ці засади зобов’язують їх володіти святотатською магією крові, вимагати відданості й сіяти жах.
 
-Їхня сила — це їхня слабкість. Я націлюсь на найсильнішого з моїх ворогів, бо їхня життєва сила живить мою перемогу.
+Їхня сила — їхня слабкість. Я обираю ціллю найсильнішого ворога, бо його життєва сила живитиме мою перемогу.
 
-Гріх вимагає страждань. Проти мене є єрессю. Перш ніж мої вороги відчують смак поразки, вони повинні заплатити за свою невіру агонією.
+Гріх вимагає страждання. Опиратися мені — єресь. Перш ніж вороги скуштують поразки, вони сплатять за своє невір’я муками.
 
-Лояльність винагороджена. Мої блага змушують моїх союзників покладатися на мене — і на кровопролиття, яке дає мені силу.
+Вірність буде винагороджена. Мої дари привчають союзників покладатися на мене — і на кровопролиття, що наділяє мене силою.
 
-Милосердя — це сила. Надаючи допомогу своїм союзникам, я доводжу, наскільки велика моя сила. Кожного разу, коли я відновлюю життя, це слугує нагадуванням про те, як швидко я можу його позбавити.</content>
+Милосердя — це сила. Допомагаючи союзникам, я доводжу велич своєї могутності. Щоразу, коли я повертаю життя, це нагадує, як швидко я можу його відібрати.</content>
   <content contentuid="h6266397ag443dg94a5g8c87g09accc415506" version="1">Рівень 3: Знекровити</content>
   <content contentuid="hacf9fc8fg665eg2cf7g70aaga3d8cc697843" version="2">Ви можете виснажувати ворогів, наснажуючи союзників. Щоразу, коли ви спалюєте на істоті одну або більше печаток, виберіть видимого союзника в межах 30 футів. Він отримує тимчасові очки здоров’я в кількості, що дорівнює результату кидка однієї кістки шкоди печатки.</content>
   <content contentuid="hea106602g9f5dg8754g958dg4324799b9073" version="1">Знекровити</content>
@@ -3345,16 +3343,16 @@
   <content contentuid="hf1c1d608gab6fgea97g5ce7g12f4e4ddb16c" version="1">Рівень 3: Благословення Сутеха</content>
   <content contentuid="h16ca83e4gd87cge240g4682g2480a4a6ba19" version="1">Коли Сутех визнає вас своїм хижаком, він надає вам доступ до свого святотатства над кров’ю та життям. Ви отримуєте майстерність у навичці &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Релігія&lt;/LSTag&gt;.</content>
   <content contentuid="h08b904f9gd5aeg7159g0bb5g4f1a264718cc" version="1">Рівень 3: Підбадьорити союзників</content>
-  <content contentuid="h1e93a04fgfcb3ge71cg8edcg9d735d49cff7" version="1">Вторинною дією ви відновлюєте загальну кількість очок здоров’я, що дорівнює п’ятикратному рівню вашого ілриґера, довільно розподіляючи їх між собою та іншими істотами в межах 30 футів.</content>
+  <content contentuid="h1e93a04fgfcb3ge71cg8edcg9d735d49cff7" version="1">Вторинною дією ви відновлюєте загальну кількість очок здоров’я, що дорівнює п’ятикратному рівню вашого ілріґера, довільно розподіляючи їх між собою та іншими істотами в межах 30 футів.</content>
   <content contentuid="h3193c1b1g81cegd32cg4ceag8e352d5d18eb" version="1">Підбадьорити союзників</content>
-  <content contentuid="hf94f341dged44gb9bcged64g8666ae8b410e" version="1">Вторинною дією ви відновлюєте загальну кількість очок здоров’я, що дорівнює п’ятикратному рівню вашого ілриґера, довільно розподіляючи їх між собою та іншими істотами в межах 30 футів.</content>
+  <content contentuid="hf94f341dged44gb9bcged64g8666ae8b410e" version="1">Вторинною дією ви відновлюєте загальну кількість очок здоров’я, що дорівнює п’ятикратному рівню вашого ілріґера, довільно розподіляючи їх між собою та іншими істотами в межах 30 футів.</content>
   <content contentuid="ha3823257g1d27g9d0egeff1gb7b607bf03f2" version="1">Підбадьорити союзників</content>
-  <content contentuid="h331a5a4cg366cg82a3g63e0g6899f199c8bb" version="1">Вторинною дією ви відновлюєте загальну кількість очок здоров’я, що дорівнює п’ятикратному рівню вашого ілриґера, довільно розподіляючи їх між собою та іншими істотами в межах 30 футів.</content>
+  <content contentuid="h331a5a4cg366cg82a3g63e0g6899f199c8bb" version="1">Вторинною дією ви відновлюєте загальну кількість очок здоров’я, що дорівнює п’ятикратному рівню вашого ілріґера, довільно розподіляючи їх між собою та іншими істотами в межах 30 футів.</content>
   <content contentuid="h51e32293ge4aagbb61g14d2g23c2e8863236" version="1">Рівень 7: Кров за кров</content>
-  <content contentuid="h450bf76dg7e82gc1f2g03a3g2f6003609ae8" version="1">Щоразу, коли союзник зазнає шкоди від істоти під забороною, та істота зазнає некротичної шкоди в кількості, що дорівнює вашому бонусу спеціалізації.</content>
+  <content contentuid="h450bf76dg7e82gc1f2g03a3g2f6003609ae8" version="1">Щоразу, коли союзник зазнає шкоди від забороненої істоти, вона зазнає некротичної шкоди в кількості, що дорівнює вашому бонусу спеціалізації.</content>
   <content contentuid="h36291e60ge6ddg0237g008dgbfdf54c658c5" version="1">Кров за кров</content>
   <content contentuid="h7aa1b008g6ca0g4a20g5979g21ad1d5571fd" version="1">Кров за кров</content>
-  <content contentuid="hd92480ccg3244g6d8ag80d0g572cbd5b4da3" version="1">Щоразу, коли союзник зазнає шкоди від істоти під забороною, та істота зазнає некротичної шкоди в кількості, що дорівнює вашому бонусу спеціалізації.</content>
+  <content contentuid="hd92480ccg3244g6d8ag80d0g572cbd5b4da3" version="1">Щоразу, коли союзник зазнає шкоди від забороненої істоти, вона зазнає некротичної шкоди в кількості, що дорівнює вашому бонусу спеціалізації.</content>
   <content contentuid="h608611fbg8b32g738cg8750g599765b12de7" version="1">Рівень 11: Кривавий удар</content>
   <content contentuid="ha7e9ac57gfaedg252egecb1g6f787805f11a" version="2">Магія, що захищає ваших союзників, тепер також виснажує сили їхніх ворогів. Коли союзник із тимчасовими очками здоров’я від вашої особливості «Знекровлення» зазнає атаки ближнього бою, нападник зазнає 11 некротичної шкоди.</content>
   <content contentuid="h76541450ge22fg5ec9g80fag5c97af69f959" version="1">Кривавий удар</content>
@@ -3380,7 +3378,7 @@
   <content contentuid="h02827317g8f4fgf0ebgdc73g2e240e81362a" version="1">Рівень 3: Благословення Молоха</content>
   <content contentuid="h4b29ebdegfa87g42bege4a2g3b10f7973640" version="1">Коли Молох визнає вас своїм зловмисником, ви отримуєте &lt;LSTag Tooltip="Expertise"&gt;Експертність&lt;/LSTag&gt; у &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Переконливість&lt;/LSTag&gt; і &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Обман&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Перевірки&lt;/LSTag&gt;.</content>
   <content contentuid="h6dff901fgee2cg0571g1cd5g5cccc5298b3e" version="1">Рівень 3: Причарування ворога</content>
-  <content contentuid="h3eabef8fg88cagb8c2g7625g98663b906cac" version="3">Коли ви використовуєте свою вторинну дію, щоб покласти &lt;LSTag Type="Spell" Tooltip="Target_Seal"&gt;печать&lt;/LSTag&gt; на істоту, ви можете зачарувати її на 10 ходів.</content>
+  <content contentuid="h3eabef8fg88cagb8c2g7625g98663b906cac" version="3">Коли ви вторинною дією накладаєте на істоту &lt;LSTag Type="Spell" Tooltip="Target_Seal"&gt;печатку&lt;/LSTag&gt;, можете причарувати її на 10 ходів.</content>
   <content contentuid="he8f7350dgec9cga3c4g613agaeb7f4a54136" version="1">Рівень 3: Медово-солодкий клинок</content>
   <content contentuid="h6adc649fgbd08g1d76g0aecg4e5c0ef03271" version="2">Атакуючи зброєю причаровану істоту, ви можете отримати перевагу на кидок атаки (дія не потрібна). Якщо атака влучає, вона стає критичним влучанням.</content>
   <content contentuid="h2cf5b57fgaa9bg9d02g3619g774b755bf5d6" version="1">Медово-солодкі леза</content>
@@ -3419,7 +3417,7 @@
 
 Застосувавши цю дію, ви не зможете зробити це знову до завершення короткого або довгого відпочинку.</content>
   <content contentuid="h9dbc5d36ge613gcbd5ga51cg3c2f03e86ea8" version="2">Рівень 7: перевага диспатера</content>
-  <content contentuid="hb48d28a7g8fd1g0221gb778gd0ba3bcb5fb5" version="1">Ваші атаки проти істот під забороною стають критичними влучаннями, якщо на кістці випадає 19 або 20.</content>
+  <content contentuid="hb48d28a7g8fd1g0221gb778gd0ba3bcb5fb5" version="1">Ваші атаки проти заборонених істот стають критичними влучаннями, якщо на кістці випадає 19 або 20.</content>
   <content contentuid="h1e5932b4g971fg88dcg9f73g49b5740e78e1" version="2">Рівень 11: Ти помреш за моїм наказом!</content>
   <content contentuid="h98e2c15eg1bb0g6b5fg7c81ge9b4199a5810" version="1">Коли союзник у радіусі 30 футів від вас, який чує вас, падає до 0 очок здоров’я, не будучи вбитим відразу, ви можете використати своє реагування, щоб викрикнути йому наказ, змусивши його впасти до 1 очок здоров’я. Після того, як ви використаєте це реагування, ви не зможете зробити це знову, доки не закінчите короткий або довгий відпочинок.</content>
   <content contentuid="hac72ef57geda5gbcb7gefd0gd8f3ef7ecd35" version="1">Руйнівник</content>
@@ -3439,29 +3437,29 @@
   <content contentuid="h4dc2f45dg35b4g1e82ga16cg73f1f783e261" version="1">Знеболювач</content>
   <content contentuid="hf1e041c0ga156g608cg02dfg22c1dad1bf3a" version="1">Знеболювачі — важкоозброєні пекельні штурмовики Диспатера, які очолюють наступ у кожній великій інфернальній битві.
 
-Диспатер править Дісом, Містом Війни. Коли Пекло вторгається до іншого світу, саме його військо б’ється й гине. Знеболювачі — майстерні стратеги, які ведуть із передової та вселяють у своїх солдатів жах і благоговіння. Вони владні, сповнені гордині й часто одержимі власною зовнішністю.
+Диспатер править Дісом, Містом Війни. Коли Пекло вдирається до іншого світу, саме його військо б’ється й гине. Знеболювачі — майстерні стратеги, які ведуть із передової та вселяють у своїх солдатів жах і побожний трепет. Вони владні, сповнені гордині й часто одержимі власною зовнішністю.
 
 Хоч Знеболювачі належать до найлицарськіших ілріґерів, їхня шляхетність спотворена. Вони приймають виклики на двобій і швидко карають кожного, хто втрутиться. Та коли програють — без вагань шахрують, а коли перемагають — пихато граються з ворогом перед смертельним ударом.
 
 У мить слабкості чи відчаю правитель іншого світу може побачити неминучу поразку свого війська й звернутися до Диспатера. Той завжди прагне сіяти чвари й розбрат, тож часто відгукується, посилаючи Знеболювача очолити армію зневіреного володаря.</content>
   <content contentuid="h7dba3450g39bag19d3g835ag2ab113b94f26" version="1">Заповіді тіні</content>
-  <content contentuid="h4266d444gc1f9g9997g415cge5bb994864d6" version="1">Володарі Тіней дають клятву Беліалу, коли приєднуються до Ордену Спустошення. Ці правила зобов’язують їх служити ворогам Беліала як союзників, перш ніж виявити себе ворогами.
+  <content contentuid="h4266d444gc1f9g9997g415cge5bb994864d6" version="1">Володарі Тіней складають обіт Беліалу, коли приєднуються до Ордену Спустошення. Ці засади зобов’язують їх служити ворогам Беліала під виглядом союзників, перш ніж викрити себе як ворогів.
 
-Плани в планах. Мої вороги ніколи не повинні дізнатися про мої справжні цілі. Якщо знадобиться, я пожертвую собою, щоб захистити свої схеми.
+Плани в планах. Вороги ніколи не повинні дізнатися про мої справжні цілі. Якщо знадобиться, я пожертвую собою, щоб захистити свої задуми.
 
-Владні позиції. Я контролюю все з тіні, знаючи, кого обдурити і де сховатися на виду.
+Владні позиції. Я керую всім із тіні, бо знаю, кого обдурити й де сховатися на видноті.
 
-Сила в терпінні. Я вивчаю свого ворога і методично зміцнюю його довіру. Моя вірність має бути безсумнівною, тому моя неминуча зрада немислима.
+Сила в терпінні. Я вивчаю ворога й методично здобуваю його довіру. Моя вірність має бути безсумнівною, щоб неминуча зрада здавалася немислимою.
 
-Вагання - це невдача. Хоча я зазвичай покладаюся на агентів, коли з’являється можливість, я можу без вагань вбити з ефективністю та точністю.</content>
+Вагання — це поразка. Хоча зазвичай я покладаюся на посередників, але, коли випадає нагода, убиваю без вагань, дієво й точно.</content>
   <content contentuid="h019023d4g5948g3c2ag571bg962e5e390492" version="2">Рівень 3: Позначено на смерть</content>
   <content contentuid="h4e3d30b7g2c20gf8a7gd14eg44eb335e86b5" version="3">Ви особливо вправні у боротьбі з ворогами, яких ви позначили на смерть. Ви маєте перевагу в кидках атаки проти заборонених істот.</content>
   <content contentuid="h474f2848gc11cga707gce0ag47a7c29bf27f" version="2">Рівень 3: Удар із темряви</content>
-  <content contentuid="hc78792c5gf4b3g8f75gc78fge4e46626954f" version="2">Ви опанували мистецтво удару з тіней. Раз за хід, коли ви з перевагою для кидка атаки влучаєте зброєю ближнього бою в істоту, позначену інтердиктом, можете кинути стільки кісток d4, скільки становить ваш бонус спеціалізації, і завдати додаткової шкоди в кількості, що дорівнює сумі результатів.</content>
+  <content contentuid="hc78792c5gf4b3g8f75gc78fge4e46626954f" version="2">Ви опанували мистецтво удару з тіней. Раз за хід, коли ви з перевагою для кидка атаки влучаєте зброєю ближнього бою в заборонену істоту, можете кинути стільки кісток d4, скільки становить ваш бонус спеціалізації, і завдати додаткової шкоди в кількості, що дорівнює сумі результатів.</content>
   <content contentuid="h000d2b9cg5e7egc014gf141ga2c0e4d9fc4f" version="2">Рівень 3: Не втекти</content>
   <content contentuid="hd8bb9020gf357g83bfgf655g10311ef27325" version="3">Вторинною дією обмотайте горло істоти тіньовою мотузкою й почніть її &lt;LSTag Type="Status" Tooltip="GARROTE_TARGET_HUMANOID"&gt;душити&lt;/LSTag&gt;.</content>
   <content contentuid="h5b1941eeg9c53g0d48g2159g640b7817db72" version="2">Рівень 7: пекельний вбивця</content>
-  <content contentuid="h0405792eg3f88g4dbfg0b92gfcb573fe9525" version="3">Коли кістка шкоди вашої зброї проти істоти під інтердиктом дає результат 1 або 2, ви можете перекинути цю кістку.</content>
+  <content contentuid="h0405792eg3f88g4dbfg0b92gfcb573fe9525" version="3">Коли кістка шкоди вашої зброї проти забороненої істоти дає результат 1 або 2, ви можете перекинути цю кістку.</content>
   <content contentuid="h07d4538fg06e1g87c9geff7gba8b3b97a65f" version="1">Тіньовий убивця</content>
   <content contentuid="hf4eda0d1g9d77gcfb5g49f3g7e6523196336" version="1">Тіні — ваші супутники й помічники у звершеннях. Ви отримуєте такі переваги:
 
@@ -3481,7 +3479,7 @@
 Ви нормально бачите як у магічній, так і у звичайній темряві.
 Ваша швидкість переміщення збільшується на 10 футів.
 Ви маєте перевагу на перевірки спритності (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Непомітність&lt;/LSTag&gt;) для переховування. Коли ефект дає змогу виконати кидок протидії спритністю, щоб зазнати лише половини шкоди, у разі успіху ви натомість не зазнаєте шкоди, а в разі невдачі зазнаєте половини.</content>
-  <content contentuid="h2a979e60g8047g338bg7d21g17a10ae143c0" version="2">Ви опанували мистецтво удару з тіней. Раз за хід, коли ви з перевагою для кидка атаки влучаєте зброєю ближнього бою в істоту, позначену інтердиктом, можете кинути стільки кісток d4, скільки становить ваш бонус спеціалізації, і завдати додаткової шкоди в кількості, що дорівнює сумі результатів.</content>
+  <content contentuid="h2a979e60g8047g338bg7d21g17a10ae143c0" version="2">Ви опанували мистецтво удару з тіней. Раз за хід, коли ви з перевагою для кидка атаки влучаєте зброєю ближнього бою в заборонену істоту, можете кинути стільки кісток d4, скільки становить ваш бонус спеціалізації, і завдати додаткової шкоди в кількості, що дорівнює сумі результатів.</content>
   <content contentuid="h29339e6ag5488gb3c9gf071g0b4a21da192a" version="2">Вторинною дією обмотайте горло істоти тіньовою мотузкою й почніть її &lt;LSTag Type="Status" Tooltip="GARROTE_TARGET_HUMANOID"&gt;душити&lt;/LSTag&gt;.</content>
   <content contentuid="hf7851a9dg2c90ga420g9853gd855b8d447bc" version="1">Удар із темряви</content>
   <content contentuid="h6185df85g28ceg3fe6g4e39g5afb82fc5604" version="1">Не втекти</content>
@@ -3514,7 +3512,7 @@
   <content contentuid="h8d142314g1c16g6319gcdcag74ad54f9f60e" version="1">Мстивий клинок</content>
   <content contentuid="h89a134d0g96d7ga7b7g8000gde7bf71cecdc" version="1">Батіг Пекла</content>
   <content contentuid="h4ee31ebcgb443g419agf6c4gb829136d660a" version="1">Ви б’єте батогом багряної енергії по видимій істоті в межах досяжності й створюєте зв’язок між собою та ціллю. Ціль повинна успішно виконати кидок протидії статурою, інакше зазнає 4d4 вогняної шкоди й буде прив’язана. На початку кожного свого ходу прив’язана істота зазнає 2d4 вогняної шкоди. Наприкінці кожного свого ходу вона може повторити кидок протидії, у разі успіху припиняючи цей ефект.</content>
-  <content contentuid="h4c5188d3gb6e3g5ec6g15ddgca76b9bd33bb" version="1">Якщо ціль позначена інтердиктом, вона виконує кидок протидії із завадою.</content>
+  <content contentuid="h4c5188d3gb6e3g5ec6g15ddgca76b9bd33bb" version="1">Якщо ціль є забороненою істотою, вона виконує кидок протидії із завадою.</content>
   <content contentuid="h79277297gd000gacc5g0460g0f13305310f6" version="1">Батіг Пекла</content>
   <content contentuid="h0799ae05gc440g5f2bg286ega9d23975a5e2" version="1">Скута кайданами, мета бере [1] на початку кожного свого ходу. Ціль може повторити кидок протидії у кінці кожного свого ходу, скидаючи кайдани в разі успіху.</content>
   <content contentuid="hfd5e585egb97dg0f1dg5612g9096a1551c2e" version="1">Архітектор руїни</content>
@@ -3544,7 +3542,7 @@
   <content contentuid="h9727eb4bg1c42g18b1gb937gf2efc10d9fec" version="2">Рівень 7: Аксіоматичні печатки</content>
   <content contentuid="h2bafe613g30e6g3792g15edgaa3d3658c4b6" version="1">Таємниці Асмодея дають змогу наповнювати печатки явленою силою. Коли ви спалюєте одну чи кілька печаток, щоб завдати істоті шкоди, то можете активувати цей дар (дія не потрібна) й додати свій модифікатор харизми (щонайменше 1) до кидка шкоди кожної печатки.</content>
   <content contentuid="h528f5094gf88ag08d3ge649gc14b423059e7" version="2">Рівень 11: Покора</content>
-  <content contentuid="h0688f440gd1d1g007egd6e0g79bf22aff2aa" version="1">Коли ви проказуєте відоме вам закляття ілріґера, то можете спалити дві печатки на істоті під забороною (дія не потрібна), щоб накласти заваду на її кидок протидії проти цього закляття.</content>
+  <content contentuid="h0688f440gd1d1g007egd6e0g79bf22aff2aa" version="1">Коли ви проказуєте відоме вам закляття ілріґера, то можете спалити дві печатки на забороненій істоті (дія не потрібна), щоб накласти заваду на її кидок протидії проти цього закляття.</content>
   <content contentuid="h8c14193dg02e1g6afbg94c5g63fe44038fa3" version="1">Аксіоматичні печатки: вогонь</content>
   <content contentuid="h3e91d02cg9178geb72g919bgd2f45a5bb6ea" version="1">Аксіоматичні печатки: некротична шкода</content>
   <content contentuid="h4272602ag3fa1g398bgb969g13be228622d0" version="1">Застаріле</content>
@@ -3561,16 +3559,16 @@
   <content contentuid="hf53d0a43g624eg7762g6910g0264f0ae7c73" version="1">Ви вивчаєте 2 &lt;LSTag Tooltip="Cantrip"&gt;замовляння&lt;/LSTag&gt; та одне закляття 1-го рівня зі списку заклять чарівника.</content>
   <content contentuid="hb45ab210g4dfeg44aage273g11ab2c83f7b8" version="1">Охоронні печатки</content>
   <content contentuid="hd8757627g198cg4659gbdcbgf8c916e4b023" version="1">Коли ви вторинною дією накладаєте на істоту печатку ілріґера або спалюєте накладену печатку, то на 2 ходи отримуєте ефект &lt;LSTag Type="Spell" Tooltip="Shout_BladeWard"&gt;«Оберегу від зброї»&lt;/LSTag&gt;.</content>
-  <content contentuid="h6fbb1933ge0e0gc26ag9144gcde944d43651" version="1">Магічною дією ви здіймаєте священний символ і витрачаєте одне використання Божого наснаження, випускаючи від себе спалах світла у 30-футовій еманації. Уся магічна Темрява в цій зоні — зокрема створена закляттям «Темрява» — розвіюється. Крім того, кожна вибрана вами істота в зоні повинна виконати кидок протидії статурою. У разі невдачі вона зазнає променевої шкоди в кількості 2d10 + ваш рівень клірика, а в разі успіху — вдвічі менше.</content>
+  <content contentuid="h6fbb1933ge0e0gc26ag9144gcde944d43651" version="1">Магічною дією ви здіймаєте священний символ і витрачаєте одне використання Божого наснаження, випускаючи від себе спалах світла у 30-футовій еманації. Уся магічна пітьма в цій зоні — зокрема створена закляттям «Пітьма» — розвіюється. Крім того, кожна вибрана вами істота в зоні повинна виконати кидок протидії статурою. У разі невдачі вона зазнає променевої шкоди в кількості 2d10 + ваш рівень клірика, а в разі успіху — вдвічі менше.</content>
   <content contentuid="h42e7e44fge041g864egc55fgbbdba0e4da67" version="1">Щоразу, коли ви зазнаєте променевої шкоди, нападник зазнає силової шкоди в кількості, що дорівнює його бонусу спеціалізації.</content>
   <content contentuid="h40874a69g2e20g65d7g2444g9bccdb153fa5" version="5">Справжнє ім'я</content>
-  <content contentuid="h00c98c60g1486ge30fge973g756a8dffc456" version="5">"Зброя, відома як "Справжнє ім'я", пов'язана з історією Семи міст. Коли дияволи укладали угоду, одержувач запечатував своє справжнє ім'я в лезі, залишаючи його тому, хто пропонував. Якщо угоду було порушено, лезо відкриває це ім'я, надаючи владу над зрадником.
+  <content contentuid="h00c98c60g1486ge30fge973g756a8dffc456" version="5">«Зброя, відома як “Справжнє ім’я”, пов’язана з історією Семи міст. Коли дияволи укладали угоду, той, хто її приймав, запечатував своє справжнє ім’я в клинку й залишав його тому, хто запропонував угоду. Якщо угоду порушено, клинок розкриває це ім’я, надаючи владу над зрадником.
 
-Кажуть, що той, хто дізнається справжню назву зброї, може претендувати на кожну назву, пов’язану з нею з моменту її створення. Уявіть панування, яке б дало.
+Кажуть, той, хто дізнається справжнє ім’я самої зброї, зможе заволодіти всіма іменами, пов’язаними з нею від часу створення. Лише уявіть, яку владу це дасть.
 
-Я шукав це ім’я століттями. Коли я його знайду, лезо — і його носій — будуть моїми».
+Я шукав це ім’я століттями. Коли знайду його, клинок — і його носій — належатимуть мені».
 
-— Особисті записи інфернального канцлера Лазивоса</content>
+— з особистих записів пекельного канцлера Лазивоса</content>
   <content contentuid="h8fa0180fg1bfeg4cb6g825fgb20e099e6947" version="2">Висмоктування печатки</content>
   <content contentuid="h939756c4g3811gf6f5g9665gfb0f0b1bae16" version="1">Один раз за короткий відпочинок, коли ви вбиваєте істоту з Істинним ім’ям, то відновлюєте одну Печатку ілріґера.</content>
   <content contentuid="h80d34500g1a50gfebfgbc79g489d53187849" version="1">Потужна печатка</content>
@@ -3705,7 +3703,7 @@
   <content contentuid="h33a83d2bg7e97g9bebg4b1ag640c88459c92" version="1">Завдайте додаткової шкоди кислотою в кількості, що дорівнює вашому &lt;LSTag Tooltip="ProficiencyBonus"&gt;бонусу спеціалізації&lt;/LSTag&gt;. У разі влучання довкола цілі утворюється калюжа кислоти, яка зменшує &lt;LSTag Tooltip="ArmourClass"&gt;РЗ&lt;/LSTag&gt; на [1].</content>
   <content contentuid="h93ef7658ga110g9063ga99fg02ab90d1135d" version="1">Отруйна мла</content>
   <content contentuid="hbbc19e32g5427g3585gaaabg3a72c966a807" version="1">Завдайте додаткової шкоди від отрути, яка дорівнює вашому &lt;LSTag Tooltip="ProficiencyBonus"&gt; бонусу спеціалізації &lt;/LSTag&gt;. Після влучання оточіть ціль шкідливою хмарою, яка, можливо, &lt;LSTag Type="Status" Tooltip="POISONED"&gt;отруює&lt;/LSTag&gt; тих, хто в ній знаходиться.</content>
-  <content contentuid="hed352d94g7b9dg3b87g2d2bgb0b679111113" version="1">При влучанні є шанс накласти стан горіння. Надає додатковий [1] палаючим цілям.</content>
+  <content contentuid="hed352d94g7b9dg3b87g2d2bgb0b679111113" version="1">У разі влучання є шанс надати цілі стан горіння. Завдає додатково [1] цілям у стані горіння.</content>
   <content contentuid="hfc73e10fg17e9g9f07gc85fg541d0d54d67b" version="1">Один раз за хід ви можете помістити ціль у &lt;LSTag Type="Status" Tooltip="FAERIE_FIRE"&gt;Чарівний посвіт&lt;/LSTag&gt; на ходи [1], якщо ви пропустите атаку проти неї.</content>
   <content contentuid="h420e8530gf543gee3dg23ebg5105a14fcc37" version="1">Винахідник</content>
   <content contentuid="h2fdc2689g1529ge2b4gd969g4df570df4ae6" version="1">Винахідники — майстри новаторства, які завдяки кмітливості й магії відкривають надзвичайні можливості звичайних предметів. Вони сприймають магію як складну систему, що чекає на розшифрування й застосування у закляттях і винаходах.</content>
@@ -3720,7 +3718,7 @@
 
 Кількість застосувань цього реагування дорівнює вашому модифікатору інтелекту (щонайменше одне), а всі витрачені застосування відновлюються після довгого відпочинку.</content>
   <content contentuid="h1dd30fd2g8d32g2cf1g4cbdg6df0134f3697" version="1">Рівень 11: Предмет, що зберігає чари</content>
-  <content contentuid="h74ec9648ga223g71b5g6f79gcbbc5f6ca2bb" version="1">Ваша зростаюча майстерність над настоями та таємнича майстерність поглиблюють ваш колодязь магічної сили. Ви отримуєте одну додаткову чарунку заклять 1-го, 2-го і 3-го рівня кожен. Ці додаткові чарунки заклять відображають підвищену ефективність і стабільність, з якою ви направляєте магію через свої творіння.</content>
+  <content contentuid="h74ec9648ga223g71b5g6f79gcbbc5f6ca2bb" version="1">Дедалі глибше опанування магічних інфузій і таємного ремесла збільшує ваш запас магічної сили. Ви отримуєте по одній додатковій чарунці заклять 1-го, 2-го й 3-го рівнів. Ці додаткові чарунки відображають підвищену ефективність і стабільність, з якими ви спрямовуєте магію крізь свої творіння.</content>
   <content contentuid="h48281e48g96a3g1f6dgdc66gbdf48065cede" version="1">Рівень 2: алхімічний глек</content>
   <content contentuid="hbcfe7e3dg0633g6665g1f15ge22c9cf7dbb7" version="1">Рівень 2: бездонна торба</content>
   <content contentuid="h90c82523g4a46gb71ag6f88gc835ddaae5d8" version="1">Рівень 2: окуляри нічного бачення</content>
@@ -3947,7 +3945,7 @@
   <content contentuid="h7564a2a6g104bg423egf734g715e17a86450" version="1">Надано [1].</content>
   <content contentuid="h90cf192bga720g4832g6e4dg0c99af7066d2" version="1">Приплив адреналіну</content>
   <content contentuid="heb8b42dfgf791g5695g2d5bg94d944d01b24" version="1">Артилерист</content>
-  <content contentuid="he4ee4e0eg19a4gb02cgb58agdfdbd170d103" version="1">Артилерист спеціалізується на магії, що обрушує на поле бою енергію, снаряди й вибухи.</content>
+  <content contentuid="he4ee4e0eg19a4gb02cgb58agdfdbd170d103" version="1">Артилерист спеціалізується на бойовій магії, що жбурляє енергію та снаряди й спричиняє вибухи.</content>
   <content contentuid="hb2e1a5b6gf536gee48g07d0g84251df2a247" version="1">Рівень 3: Закляття артилеристів</content>
   <content contentuid="hb830b235g9469g7dd2ga75agc175eb448a0b" version="3">Коли ви досягаєте певних рівнів Майстра, у вас завжди є підготовлені спеціальні закляття. На 3-му рівні ви отримуєте щит і грозову хвилю. На 5-му рівні ви отримуєте Палюче проміння і Розтрощення. На 9-му рівні ви отримуєте Вогняна куля і Прикликаний обстріл.</content>
   <content contentuid="h8972d6f1gb973gb24eg4f39ga448bf22f9f4" version="1">Рівень 3: Потойбічна гармата</content>
@@ -3982,11 +3980,11 @@
   <content contentuid="h0e4f0ac6g2f7egd603gf1dfgbe7d59c073b3" version="1">Коло мрій</content>
   <content contentuid="h59958a6fg7ff5g9780g1b47g688c0909621b" version="1">Друїди Кола Мрій походять із країв, тісно пов’язаних із Феєлоном та його сновидними царствами. Захист природи природно зближує їх із доброзичливими феями. Ці друїди прагнуть сповнити світ дивами, подібними до снів. Їхня магія загоює рани й приносить радість засмученим серцям, а підзахисні землі сяють і квітнуть — там сон зливається з дійсністю, а стомлені знаходять спочинок.</content>
   <content contentuid="h853388a0g259bga78age028g6a93fbf44c57" version="1">Рівень 3: Бальзам Літнього двору</content>
-  <content contentuid="hfdecb2bbgb554g7caage8a5ga7a203a6533c" version="1">Вас сповнюють благословення Літнього двору, перетворюючи на джерело цілющої енергії. Ви маєте запас фейської енергії у вигляді d6 в кількості, що дорівнює вашому рівню друїда.
+  <content contentuid="hfdecb2bbgb554g7caage8a5ga7a203a6533c" version="1">Вас сповнює благословення Літнього двору, перетворюючи на джерело цілющої енергії. Ви маєте запас фейської енергії, представлений кількістю кісток d6, що дорівнює вашому рівню друїда.
 
-Вторинною дією ви можете вибрати видиму істоту в межах 60 футів і витратити не більше половини свого рівня друїда цих кісток. Киньте витрачені кістки й підсумуйте результати: ціль відновлює стільки очок здоров’я та отримує по 1 тимчасовому очку здоров’я за кожну витрачену кістку.
+Вторинною дією виберіть видиму істоту в межах 60 футів і витратьте кількість цих кісток, що не перевищує половини вашого рівня друїда. Киньте витрачені кістки й підсумуйте результати. Ціль відновлює відповідну кількість очок здоров’я, а також отримує 1 тимчасове очко здоров’я за кожну витрачену кістку.
 
-Завершивши тривалий відпочинок, ви відновлюєте всі витрачені кістки.</content>
+Завершивши довгий відпочинок, ви відновлюєте всі витрачені кістки.</content>
   <content contentuid="h6002b32ag74ffg3470g0a2cg9afe92b897e5" version="1">Рівень 6: Осередок місячного сяйва й тіні</content>
   <content contentuid="he2f58070g7662g8b76gc3d9gce5303f3d8c8" version="2">Ваш дім — там, де ви. Ви звертаєтеся до тихої влади Присмеркового двору над тінню й таємницями, огортаючи себе та союзників його непомітним захистом. Дією ви прикликаєте цю силу, створюєте захищений прихисток і негайно отримуєте всі переваги короткого відпочинку.
 
@@ -4010,7 +4008,7 @@
   <content contentuid="hb6ad15b6g6a5cgc8edg95d4gd631318ac05a" version="1">Приховані шляхи</content>
   <content contentuid="h318e3ac4g7a18ga5edgf912g65c014f1354e" version="2">Вампірський укус</content>
   <content contentuid="h64543ab1gec40g4962g092eg85f690ed7102" version="2">Ви можете смоктати кров у живої істоти, щоб відновити очки здоров’я.</content>
-  <content contentuid="h9936bfdfgad15g113bged99g9778bc8cba86" version="1">Вампірський голод тимчасово вгамовано. +1 до всіх &lt;LSTag Tooltip="AttackRoll"&gt;кидків атаки&lt;/LSTag&gt;, &lt;LSTag Tooltip="SavingThrow"&gt;кидків протидії&lt;/LSTag&gt; і більшості &lt;LSTag Tooltip="AbilityCheck"&gt;перевірок характеристик&lt;/LSTag&gt;.</content>
+  <content contentuid="h9936bfdfgad15g113bged99g9778bc8cba86" version="1">Вампірський голод тимчасово вгамовано. +1 до всіх &lt;LSTag Tooltip="AttackRoll"&gt;кидків атаки&lt;/LSTag&gt;, &lt;LSTag Tooltip="SavingThrow"&gt;кидків протидії&lt;/LSTag&gt; й більшості &lt;LSTag Tooltip="AbilityCheck"&gt;перевірок характеристик&lt;/LSTag&gt;.</content>
   <content contentuid="ha48ff32fg388ag1220g80cbgc8e2ec3cd1c7" version="2">Відлучення від снів</content>
   <content contentuid="h9105e090ga08cg9a3fgb40ag60da6cec8ae0" version="2">Завершивши тривалий відпочинок, ви отримуєте спеціалізацію в одній навичці на свій вибір. Вона діє до завершення наступного тривалого відпочинку.</content>
   <content contentuid="hb3e89e41gbe95gff0dgb116gf17d00181a3d" version="1">Відлучення від снів</content>
@@ -4074,7 +4072,7 @@
   <content contentuid="hd5cef72fg7633gfff7g44f5g7c4e863fdc13" version="1">Готовий до бою</content>
   <content contentuid="h9e3e17e5gec22g340bgdae4g359fcaa6dc68" version="1">Коли ви атакуєте магічною зброєю, ви можете використовувати модифікатор інтелекту замість модифікатора сили або спритності для кидків атаки та шкоди.</content>
   <content contentuid="h41d2ff5cgefb3g4750gfbbfg9ce76cd22456" version="1">Рівень 3: Сталевий захисник</content>
-  <content contentuid="h0844a944gf85ag2577g8e77g23dcd6a6e387" version="1">Ваші майстерні роботи дали вам напарника: сталевого захисника. Він дружній до вас і ваших супутників і підкоряється вашим командам. Якщо він загинув, ви можете використати інструменти свого коваля як дію та використати чарунку заклять 1-го рівня або вище, щоб оживити його.</content>
+  <content contentuid="h0844a944gf85ag2577g8e77g23dcd6a6e387" version="1">Ваше майстрування подарувало вам супутника — Сталевого захисника. Він дружній до вас і ваших супутників та виконує ваші накази. Якщо він загине, ви можете дією скористатися ковальськими інструментами й витратити чарунку заклять 1-го або вищого рівня, щоб оживити його.</content>
   <content contentuid="h7b9311b6gf2bag9d7eg4407g3cb8f90b5541" version="1">Відбити атаку</content>
   <content contentuid="hda3785acgb4c8g1e09g6f52ga7964ee4a86e" version="1">Коли істота в межах 5 футів від захисника, яку він бачить, виконує кидок атаки проти іншої цілі, ця істота виконує кидок із завадою.</content>
   <content contentuid="hf909a1bage22fg8286gcfedg0f187d283bee" version="1">Підсилене силою роздирання</content>
@@ -4084,9 +4082,9 @@
   <content contentuid="h074e1d16gaccag0b0bg55e9g233c194cbe67" version="1">Бойовий коваль</content>
   <content contentuid="h4bf8da96g64a3g0f5eg135bg7645978583b0" version="1">Бойовий коваль поєднує ролі захисника й цілителя: боронить інших і лагодить як спорядження, так і живих соратників. У цьому йому допомагає Сталевий захисник — створений власноруч вірний охоронець.</content>
   <content contentuid="h6d2cfddegb7bag99e2g6ffbg6a101cdf219d" version="1">Рівень 9: Магічний поштовх</content>
-  <content contentuid="h1ad514dega841gc35dg8804ga474e60b45ea" version="2">Коли ви вражаєте ціль кидком атаки за допомогою магічної зброї або коли ваш &lt;LSTag Type="Spell" Tooltip="Target_SteelDefender"&gt;Сталевий захисник&lt;/LSTag&gt; влучає в ціль, ви можете направити магічну енергію через удар, щоб вивільнити руйнівну енергію. Ціль отримує додаткову силу 2d6.
+  <content contentuid="h1ad514dega841gc35dg8804ga474e60b45ea" version="2">Коли ви влучаєте в ціль атакою магічною зброєю або ваш &lt;LSTag Type="Spell" Tooltip="Target_SteelDefender"&gt;Сталевий захисник&lt;/LSTag&gt; влучає в ціль, можете спрямувати крізь удар магічну енергію та вивільнити Руйнівну енергію. Ціль додатково зазнає 2d6 силової шкоди.
 
-Крім того, ви можете вивільнити відновлюючу енергію, вибравши одну істоту чи об’єкт, який ви бачите в радіусі 30 футів від вас. Цілюща енергія надходить у вибраного одержувача, відновлюючи йому 2d6 очки здоров’я.</content>
+Натомість ви можете вивільнити Відновлювальну енергію, вибравши одну видиму істоту чи об’єкт у межах 30 футів. Цілюща енергія вливається у вибрану ціль і відновлює їй 2d6 очок здоров’я.</content>
   <content contentuid="h4f02276agb1b7g8939g8d33g4138f4f9a52f" version="1">Кількість застосувань цієї енергії дорівнює вашому модифікатору інтелекту (щонайменше одне), але не більш ніж одне за хід. Усі витрачені застосування відновлюються після довгого відпочинку.</content>
   <content contentuid="hfcff03d7g3b43gc2c2g568eg228ec39a2a92" version="2">Деструктивна енергія</content>
   <content contentuid="h7a33c7b9g8cc0g6c2bg348fg50d1aa50e0f5" version="2">Коли ви вражаєте ціль кидком атаки за допомогою магічної зброї, ви можете направити магічну енергію через удар, щоб вивільнити руйнівну енергію. Ціль отримує додаткову силу 2d6.</content>
@@ -4229,8 +4227,8 @@
   <content contentuid="hb94ed556g5e70g8c49g722fge57833fe8a79" version="1">Гільдія окультистів</content>
   <content contentuid="ha52e0ea7g613bg7d1egefc0gbcb5735e1445" version="1">В Етарісі одні бояться магії, а інші прагнуть її осягнути. Мисливці на чудовиськ із Гільдії окультистів знають: обидві сторони однаково небезпечні. Окультист досліджує містичне, надприродне й незбагненне, не піддаючись забобонам та ідеологіям. Попри славу мисливців на магів, окультисти не палять ворогів на вогнищі — вони вражають їх мечем, адже мечі саме для цього. Знання й магія дають їм перевагу над містичними супротивниками. Закляття допомагають виявляти небезпечні чари й захищатися від них, а головне — знищувати чудовиськ, яким не шкодить сталь.</content>
   <content contentuid="hd5511bb2gf4b8g0709g6e56g92eaa3079df9" version="1">Рівень 3: Закляття домену Апокаліпсису</content>
-  <content contentuid="h3b8a1f9dg4458ga3d3ga263gf4e1b90b9524" version="1">Ваш зв’язок із цим божественним доменом гарантує, що у вас завжди підготовлені певні закляття. Досягнувши рівня клірика, указаного в таблиці заклять Домену апокаліпсису, ви завжди матимете підготовлені наведені закляття. На 3-му рівні це Темрява, Пекельний докір, Примарна сила та Грозова хвиля. На 5-му рівні додаються Голод Хадара й Страх; на 7-му — Мор і Крижана буря; на 9-му — Згубна хмара та Нашестя комах.</content>
-  <content contentuid="h7c50337fg49e2g1d8agf87ag04e30ad44c96" version="1">На 3-му рівні ви завжди маєте підготовлені Темряву, Пекельний докір, Примарну силу та Грозову хвилю. На 5 рівні додаються Голод Гадара і Страх. На 7-му рівні ви отримуєте Мор і Крижана буря, а на 9-му рівні Згубна хмара і Комашина чума.</content>
+  <content contentuid="h3b8a1f9dg4458ga3d3ga263gf4e1b90b9524" version="1">Ваш зв’язок із цим божественним доменом гарантує, що у вас завжди підготовлені певні закляття. Досягнувши рівня клірика, указаного в таблиці заклять Домену апокаліпсису, ви надалі завжди матимете підготовленими такі закляття: на 3-му рівні — «Пітьма», «Жорстока розправа», «Примарна сила» та «Громохвиля»; на 5-му — «Голод Гадара» й «Страх»; на 7-му — «Гниль» і «Крижана буря»; на 9-му — «Убивча хмара» та «Комашина чума».</content>
+  <content contentuid="h7c50337fg49e2g1d8agf87ag04e30ad44c96" version="1">На 3-му рівні ви завжди маєте підготовленими «Пітьму», «Жорстоку розправу», «Примарну силу» та «Громохвилю»; на 5-му — «Голод Гадара» й «Страх»; на 7-му — «Гниль» і «Крижану бурю»; на 9-му — «Убивчу хмару» та «Комашину чуму».</content>
   <content contentuid="h46ff1dc0g3fb4g0e61g3544g195538ce2ff9" version="1">Рівень 3: Видіння знищення</content>
   <content contentuid="h55235fc0g6321g25e2gcdefgc2244237ac56" version="3">Ви навчаєтеся провіщати загибель істоти. Вторинною дією виберіть видиму істоту в межах 120 футів. Кидки атаки проти неї мають перевагу до початку вашого наступного ходу.</content>
   <content contentuid="h947ed943ge9abg4881g2010ge2b6da6351b6" version="1">Кількість застосувань цієї особливості дорівнює вашому модифікатору мудрості (щонайменше одне). Усі витрачені застосування відновлюються після довгого відпочинку.</content>
@@ -4352,7 +4350,7 @@
 
 Тривожна аура. Коли ви перетворюєтеся та на початку кожного наступного свого ходу, кожна вибрана вами істота в 10-футовій еманації від вас виконує кидок протидії мудрістю проти вашої МС протидії закляттям. У разі невдачі істота перебуває в стані переляку до початку вашого наступного ходу.</content>
   <content contentuid="h6bf206d3ga5dag2afag19eegf2c35e7a534e" version="1">Ви завжди маєте підготовленою «Мітку мисливця». Ви можете проказати її, не витрачаючи чарунки, стільки разів, скільки вказано у стовпці «Улюблений ворог» таблиці особливостей слідопита. Усі витрачені застосування відновлюються після довгого відпочинку.</content>
-  <content contentuid="h0707320dgdc67g5261gca84g8c7ba39b2add" version="1">Ви можете використати Мітка мисливця, не витрачаючи чарунку заклять, двічі на 1-му рівні, тричі на 5-му рівні та чотири рази на 9-му рівні.</content>
+  <content contentuid="h0707320dgdc67g5261gca84g8c7ba39b2add" version="1">Ви можете проказувати «Мисливську мітку», не витрачаючи чарунку заклять: двічі на 1-му рівні, тричі на 5-му та чотири рази на 9-му.</content>
   <content contentuid="h41856fd8g557fg1204g89c3gd79299a20aba" version="1">Гнів дикої природи</content>
   <content contentuid="h5b50bb5cg8fd5g63ccgdf38gc338449b5822" version="1">Ви черпаєте силу з дивних прадавніх жахів землі: на вас виростають неприродні криваві роги чи гнилі ікла, а тінь видовжується й звивається довкола. Вторинною дією ви можете витратити одне використання «Обраного ворога» й набути моторошної подоби. Наведені нижче переваги діють 1 хвилину, доки ви не набудете стану недієздатності, не помрете або не завершите перетворення без витрати дії.</content>
   <content contentuid="hf1d97e50g4266g20d2gfa31gc28b01a57f91" version="1">Відплата мисливця</content>
@@ -4375,8 +4373,8 @@
 
 Жахливе втілення. Раз за хід, коли ви влучаєте в істоту атакою, можете змусити її виконати кидок протидії мудрістю проти вашої СК протидії закляттям. У разі невдачі ціль перебуває в стані переляку до кінця вашого наступного ходу.</content>
   <content contentuid="hcd558b81gae7eg26dag6eaegf0f7e3dd0197" version="1">Рівень 3: Закляття невмерлого покровителя</content>
-  <content contentuid="h72a8bf1agc8fbgec94g5bd1g5c0893342c80" version="1">Магія вашого покровителя гарантує, що у вас завжди будуть готові певні закляття; коли ви досягаєте рівня чаклуна, зазначеного в таблиці заклять нежиті, у вас завжди є підготовлені закляття з списку. На 3-му рівні ви вивчаєте &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Бейн&lt;/LSTag&gt;, &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;Сліпота&lt;/LSTag&gt;, Примарна сила і Струмінь хвороби. На 5-му рівні ви дізнаєтеся «Поговорити з мертвим» і &lt;LSTag Type="Spell" Tooltip="Target_AnimateDead"&gt;Анімувати мертвого&lt;/LSTag&gt;. На 7-му рівні ви вивчаєте &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Велика невидимість&lt;/LSTag&gt; і Примарний убивця. На 9-му рівні ви вивчаєте Танок смерті і Згубна хмара.</content>
-  <content contentuid="h423f4d8eg647cg79b9g302bg9ad97549087a" version="2">На 3-му рівні ви вивчаєте Бейн, &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;Сліпота&lt;/LSTag&gt;, Примарна сила і Струмінь хвороби. На 5-му рівні ви навчитеся розмовляти з мертвими та оживляти мертвих. На 7-му рівні ви вивчаєте &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Велика невидимість&lt;/LSTag&gt; і Примарний убивця. На 9-му рівні ви вивчаєте Танок смерті і Згубна хмара.</content>
+  <content contentuid="h72a8bf1agc8fbgec94g5bd1g5c0893342c80" version="1">Магія вашого покровителя гарантує, що у вас завжди підготовлені певні закляття. На рівнях чаклуна, указаних у таблиці «Закляття невмерлого покровителя», ви надалі завжди маєте підготовленими такі закляття: на 3-му рівні — &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;«Згуба»&lt;/LSTag&gt;, &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;«Сліпота»&lt;/LSTag&gt;, «Примарна сила» та «Струмінь хвороби»; на 5-му — «Розмова з мертвими» й &lt;LSTag Type="Spell" Tooltip="Target_AnimateDead"&gt;«Пробудження мерця»&lt;/LSTag&gt;; на 7-му — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt; і «Примарний убивця»; на 9-му — «Танок смерті» й «Убивча хмара».</content>
+  <content contentuid="h423f4d8eg647cg79b9g302bg9ad97549087a" version="2">На 3-му рівні ви вивчаєте «Згубу», &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;«Сліпоту»&lt;/LSTag&gt;, «Примарну силу» та «Струмінь хвороби»; на 5-му — «Розмову з мертвими» й «Пробудження мерця»; на 7-му — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велику невидимість»&lt;/LSTag&gt; і «Примарного убивцю»; на 9-му — «Танок смерті» й «Убивчу хмару».</content>
   <content contentuid="h51d8435ag421eg4abdg2702ga3868c2dab5c" version="1">Рівень 6: Торкнутий могилою</content>
   <content contentuid="h9978d0deg7d77g5755g43fbg0caf50e3b407" version="3">Сила вашого покровителя глибоко впливає на ваше тіло та магію, надаючи вам наступні переваги.
 
@@ -4457,8 +4455,8 @@
   <content contentuid="ha989ddfeg14aege15egc09fgf298fc8f086e" version="1">Покровитель — Величний древній</content>
   <content contentuid="h3504f51eg1ac0gd563g881eg515b53b1f37b" version="1">Обравши цей підклас, ви могли пов’язати себе з невимовною істотою з Далекої царини або прадавнім богом — наприклад, Таріздуном, Прикутим Богом; Зарґоном, Поверненим; Гадаром, Темним Голодом; чи Великим Ктулху. А може, ви закликаєте кількох сутностей, не служачи жодній із них. Їхні мотиви незбагненні, а Величний Древній може навіть не зважати на ваше існування. Та пізнані вами таємниці однаково дають змогу черпати від нього дивну магію.</content>
   <content contentuid="h68dcfb27g52ddg20aag7977g147e317f34ce" version="1">Рівень 3: Закляття Відьомського клинка</content>
-  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">Магія вашого покровителя гарантує, що у вас завжди підготовлені певні закляття. Досягнувши рівня чаклуна, указаного в таблиці заклять Відьомського клинка, ви завжди матимете підготовлені наведені закляття. На 3-му рівні ви вивчаєте &lt;LSTag Type="Spell" Tooltip="Shout_ArcaneVigor"&gt;Містичну снагу&lt;/LSTag&gt;, Прокльон, Магічну зброю, Щит і Гнівну кару. На 5-му — Накладання прокляття та Прикликаний обстріл. На 7-му — Свободу руху й Нищівну кару. На 9-му — Удар сталевого вітру.</content>
-  <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">На 3-му рівні ви вивчаєте Містичну снагу, Прокльон, Магічну зброю, Щит і Гнівну кару. На 5-му — Накладання прокляття та Прикликаний обстріл. На 7-му — Свободу руху й Нищівну кару. На 9-му — Удар сталевого вітру.</content>
+  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">Магія вашого покровителя гарантує, що у вас завжди підготовлені певні закляття. На рівнях чаклуна, указаних у таблиці «Закляття Відьомського клинка», ви надалі завжди маєте підготовленими такі закляття: на 3-му рівні — &lt;LSTag Type="Spell" Tooltip="Shout_ArcaneVigor"&gt;«Містична снага»&lt;/LSTag&gt;, «Прокльон», «Магічна зброя», «Щит» і «Гнівна кара»; на 5-му — «Накладання прокляття» та «Прикликаний обстріл»; на 7-му — «Свобода руху» й «Нищівна кара»; на 9-му — «Удар сталевого вітру».</content>
+  <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">На 3-му рівні ви вивчаєте «Містичну снагу», «Прокльон», «Магічну зброю», «Щит» і «Гнівну кару»; на 5-му — «Накладання прокляття» та «Прикликаний обстріл»; на 7-му — «Свободу руху» й «Нищівну кару»; на 9-му — «Удар сталевого вітру».</content>
   <content contentuid="hfa17cac1gac88g9d72gf29eg0946ab8c0bb4" version="1">Рівень 3: Втілення Відьомського клинка</content>
   <content contentuid="ha92a78f3ge96agd47egb8ddg6ad716d3cc56" version="3">Прокляття відьомського клинка. Ви можете проказувати «Прокляття», не витрачаючи чарунки. Кількість застосувань дорівнює вашому модифікатору харизми (щонайменше одне), а всі витрачені застосування відновлюються після довгого відпочинку. Коли ви проказуєте «Прокляття», довкола проклятої цілі кружляє примарна зброя, подібна до вашого покровителя.
 
@@ -4514,7 +4512,7 @@
   <content contentuid="h01e56ec9g7adfgbda5ge6f7g054b1074d4e7" version="1">Формувальник рун: пагорб</content>
   <content contentuid="h78b41137g5f4ag08e5g9bf9ge8675ebd393a" version="1">Магія рун: Гудберрі</content>
   <content contentuid="h3b97affag0be7g4766g647fgabd94ceeab08" version="1">Творець рун: подорож</content>
-  <content contentuid="h2c48aa26gfa3eg1b84g4eebg5a36ae964f3a" version="1">Магія рун: Довгоніг</content>
+  <content contentuid="h2c48aa26gfa3eg1b84g4eebg5a36ae964f3a" version="1">Магія рун: Скороходець</content>
   <content contentuid="h2f95a42aga999g405cg5db7g3c5d7d433885" version="1">Формувальник рун: король</content>
   <content contentuid="hf7673e7dg1596g8d36g94a7gf2cd7cacba6c" version="1">Рунічна магія: Наказ</content>
   <content contentuid="h145f13b6g8f61g8a7dg3b9bgedacd9e5018a" version="1">Формувальник рун: Гора</content>
@@ -4682,8 +4680,8 @@
   <content contentuid="h1498d59bg1126gb9c5gd9b1ga55c4cbb3816" version="1">Раз за хід, коли ви влучаєте в істоту зброєю договору, можете витратити чарунку Магії договору, щоб завдати цілі додатково 1d8 силової шкоди + ще 1d8 за кожен рівень чарунки. Якщо ціль величезна або менша, ви також можете повалити її.</content>
   <content contentuid="h91a9a031gbb78g3004g2f6cg6dcdb8f2cea3" version="1">Ви можете битися двома одиницями зброї, навіть якщо вони не &lt;LSTag Tooltip="Light"&gt;легкі&lt;/LSTag&gt;. Водночас не можна битися двома одиницями &lt;LSTag Tooltip="TwoHanded"&gt;дворучної&lt;/LSTag&gt; зброї.&lt;br&gt;&lt;br&gt;Коли у свій хід ви виконуєте дію «Атака» й атакуєте зброєю ближнього бою, пізніше цього самого ходу можете вторинною дією здійснити одну атаку другою рукою. Якщо ви опанували властивість «Надріз» і тримаєте в другій руці зброю з нею, можете здійснювати до двох атак другою рукою за хід.</content>
   <content contentuid="h7f4aa580ga87dg16dcgfbe8g89f017ded271" version="1">Рівень 3: Тіньові закляття</content>
-  <content contentuid="h822a72b8g17f5g73a6gd5f7g245ac996eb94" version="1">На рівнях чародія, указаних у таблиці «Тіньові закляття», ви отримуєте закляття, які надалі завжди вважаються підготовленими: на 3-му рівні — &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;«Бейн»&lt;/LSTag&gt;, «Пітьма», «Завдання ран» і «Безслідна хода»; на 5-му — «Голод Гадара» та «Страх»; на 7-му — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt; і «Примарний убивця»; на 9-му — &lt;LSTag Type="Spell" Tooltip="Target_Contagion"&gt;«Зараза»&lt;/LSTag&gt; та «Убивча хмара».</content>
-  <content contentuid="hce90f19eg2ee2g0ff4g4c21g7ebf85d46c9d" version="1">Чародії Тіньової магії отримують додаткові закляття: на 3-му рівні — «Бейн», «Пітьма», «Завдання ран» і «Безслідна хода»; на 5-му — «Голод Гадара» та «Страх»; на 7-му — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt; і «Примарний убивця»; на 9-му — «Зараза» та «Убивча хмара».</content>
+  <content contentuid="h822a72b8g17f5g73a6gd5f7g245ac996eb94" version="1">На рівнях чародія, указаних у таблиці «Тіньові закляття», ви отримуєте закляття, які надалі завжди вважаються підготовленими: на 3-му рівні — &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;«Згуба»&lt;/LSTag&gt;, «Пітьма», «Завдання ран» і «Безслідна хода»; на 5-му — «Голод Гадара» та «Страх»; на 7-му — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt; і «Примарний убивця»; на 9-му — &lt;LSTag Type="Spell" Tooltip="Target_Contagion"&gt;«Зараза»&lt;/LSTag&gt; та «Убивча хмара».</content>
+  <content contentuid="hce90f19eg2ee2g0ff4g4c21g7ebf85d46c9d" version="1">Чародії Тіньової магії отримують додаткові закляття: на 3-му рівні — «Згуба», «Пітьма», «Завдання ран» і «Безслідна хода»; на 5-му — «Голод Гадара» та «Страх»; на 7-му — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt; і «Примарний убивця»; на 9-му — «Зараза» та «Убивча хмара».</content>
   <content contentuid="h312226b3g88ffg25afg2137g749c468fee54" version="1">Рівень 3: Очі темряви</content>
   <content contentuid="ha1f41cf1g38dagde18ga234gcff8d509b5e3" version="1">Рівень 3: Могильна сила</content>
   <content contentuid="h8169cd0cg492cg6dbeg7bafg507ce72f8ac4" version="1">Тіньове чаклунство</content>
@@ -4829,10 +4827,10 @@
   <content contentuid="h7db07aaegcba0g874eg8391ge8926782e7f8" version="1">Вогняна руна</content>
   <content contentuid="h241ed709g7588g2cc5g9cd2gbc1ec16c5753" version="1">У разі влучання атаки прикликаною зброєю додатково завдають 1d8 вогняної шкоди.</content>
   <content contentuid="h06dbb138g6afagfebbg9a03gd5d229bb475e" version="1">Ошелешливий вибух</content>
-  <content contentuid="h36e08fceg5a47gf889gc415g5a67ba284ba1" version="1">Із ваших долонь виривається силова хвиля в істоту в межах досяжності. Ціль повинна виконати кидок протидії статурою. У разі невдачі істота зазнає 2d6 силової шкоди й перебуває у стані &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;Приголомшення&lt;/LSTag&gt; до кінця свого наступного ходу. У разі успіху істота зазнає лише шкоди.</content>
+  <content contentuid="h36e08fceg5a47gf889gc415g5a67ba284ba1" version="1">З ваших долонь виривається силова хвиля в істоту в межах досяжності. Ціль повинна виконати кидок протидії статурою. У разі невдачі істота зазнає 2d6 силової шкоди й перебуває у стані &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;Приголомшення&lt;/LSTag&gt; до кінця свого наступного ходу. У разі успіху істота зазнає лише шкоди.</content>
   <content contentuid="h1d86fe95gbfdbg4380gabf5g485af2f71992" version="1">Рівень 3: закляття тіньового домену</content>
-  <content contentuid="h7b73f5fagb632g4dd6gbb1bg52e10cb075ff" version="1">Ваш зв’язок із Тіньовим доменом завжди тримає певні закляття підготовленими. На рівнях клірика, указаних у таблиці «Закляття Тіньового домену», ви отримуєте такі закляття: на 3-му рівні — &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;«Бейн»&lt;/LSTag&gt;, «Удаване життя», &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;«Сліпота»&lt;/LSTag&gt; та «Пітьма»; на 5-му — «Миготіння» й «Страх»; на 7-му — «Чорні мацаки» та &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt;; на 9-му — «Конус холоду» й «Сон».</content>
-  <content contentuid="hb05d9f4bgc914g4d44g95b9ga646b28fd85b" version="1">Тіньовий домен надає такі закляття: на 3-му рівні клірика — «Бейн», «Удаване життя», &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;«Сліпота»&lt;/LSTag&gt; та «Пітьма»; на 5-му — «Миготіння» й «Страх»; на 7-му — «Чорні мацаки» та &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt;; на 9-му — «Конус холоду» й «Сон».</content>
+  <content contentuid="h7b73f5fagb632g4dd6gbb1bg52e10cb075ff" version="1">Ваш зв’язок із Тіньовим доменом завжди тримає певні закляття підготовленими. На рівнях клірика, указаних у таблиці «Закляття Тіньового домену», ви отримуєте такі закляття: на 3-му рівні — &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;«Згуба»&lt;/LSTag&gt;, «Удаване життя», &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;«Сліпота»&lt;/LSTag&gt; та «Пітьма»; на 5-му — «Миготіння» й «Страх»; на 7-му — «Чорні мацаки» та &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt;; на 9-му — «Конус холоду» й «Сон».</content>
+  <content contentuid="hb05d9f4bgc914g4d44g95b9ga646b28fd85b" version="1">Тіньовий домен надає такі закляття: на 3-му рівні клірика — «Згуба», «Удаване життя», &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;«Сліпота»&lt;/LSTag&gt; та «Пітьма»; на 5-му — «Миготіння» й «Страх»; на 7-му — «Чорні мацаки» та &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt;; на 9-му — «Конус холоду» й «Сон».</content>
   <content contentuid="h1064bb85gee8cg09fbge5ebg6e90aa761e30" version="1">Тіньовий домен</content>
   <content contentuid="h904f48b3g5c0bg6e25g75bcg2b014d46c23f" version="2">Тінь</content>
   <content contentuid="h034102c0gf054g2c35ga023g5f4e2e8fbffd" version="1">Тіньовий домен приймає темряву, що огортає все суще, і керує мінливою сірістю на межі світла й мороку. Його клірики ступають непримітним шляхом, часто змінюють союзників і воліють діяти невидимо.</content>
@@ -5185,7 +5183,7 @@
   <content contentuid="h4b9b2ad5ga9e1g44f8gb33ag5235039db854" version="1">Протягом наступної хвилини цей ефект Сплеск дикої магії спрацьовує знову на початку кожного вашого ходу.</content>
   <content contentuid="h383d0ae6g7900g4f11gbf34gb183e51f5749" version="1">Протягом наступної хвилини цей ефект Сплеск дикої магії спрацьовує знову на початку кожного вашого ходу.</content>
   <content contentuid="hcb3ea2f5geb40g4f6eg893eg1fe3d94c8c45" version="1">Знайома собака, доброзичлива до вас, з'являється поруч і зникає через 1 хвилину.</content>
-  <content contentuid="h3e25f595g3a54g42e1gb67cgc51e7babaf61" version="1">Поруч з вами з’являється дружній до вас бес, який зникає через 1 хвилину.</content>
+  <content contentuid="h3e25f595g3a54g42e1gb67cgc51e7babaf61" version="1">Поруч із вами з’являється дружнє до вас чортеня, яке зникає через 1 хвилину.</content>
   <content contentuid="hd1c1c274gc558g4a5fg888fgadfc3d67f57b" version="1">Інтелект-пожирач, доброзичливий до вас, з’являється поруч і зникає через 1 хвилину.</content>
   <content contentuid="h0e6cf6c3g3696g400bg9730g8c9dbe0d258c" version="1">Голліфант, доброзичливий до вас, з’являється поруч і зникає через 1 хвилину.</content>
   <content contentuid="h74c74ba4gb774g4edag93c5gf0a9fc7cca3c" version="1">Протягом наступної хвилини ви відновлюєте 5 очок здоров’я на початку кожного свого ходу.</content>
@@ -5298,7 +5296,7 @@
   <content contentuid="hb2bb0f2eg9d2ag5515gead7g44579222fb75" version="1">Примарний щит зависає поруч із вами протягом наступної хвилини, надаючи бонус +2 до РЗ та імунітет до «Магічного залпу».</content>
   <content contentuid="h33261258g796fg3395g69a4gaddfad4937eb" version="1">Протягом наступної хвилини ви можете проказувати закляття навіть у стані безмовності.</content>
   <content contentuid="hb2a8f231g4f09g0714g0977ga484944bbb45" version="1">Сплеск дикої магії: прискорене закляття</content>
-  <content contentuid="hf35665d0g7373g4d2dga1f3g0b7fc11ce883" version="1">Кваліфікований: Ви оволоділи трьома навичками. Добре підібрано.</content>
+  <content contentuid="hf35665d0g7373g4d2dga1f3g0b7fc11ce883" version="1">Риса «Обдарований»: ви здобули володіння трьома навичками. Вдалий вибір.</content>
   <content contentuid="h5205e9a5g2faag4116g9482g9d62b12da058" version="1">Досвідчений: Ви досягли кваліфікації у вибраній навичці.</content>
   <content contentuid="hffac3ddcg8327g4829g8b8fgec3bb18e4a7e" version="1">Магічний хист (клірик): ви вивчили два замовляння. Гарний вибір.</content>
   <content contentuid="h64af36efg690cg437bg9309gc6f9d243ddc7" version="1">Магічний хист (клірик): ви вивчили вибране замовляння.</content>
@@ -5394,7 +5392,7 @@
   <content contentuid="h6bd9db98g1e8fg33a3g0a09gadb7f2151497" version="1">Надріз</content>
   <content contentuid="h939f5eb1gd3c5g103bg2cdage99686250a71" version="1">Ви можете зробити свою атаку рукою як частину вашої дії атаки цього ходу, не витрачаючи вторинну дію.</content>
   <content contentuid="h5e1086d5gb686g5218gd9b8g8728d0edb265" version="1">Надріз: атаку другою рукою використано</content>
-  <content contentuid="h112fb3e9g734ag7e2dg4366g1a44c9038a26" version="1">Ви вже зробили свою безкоштовну атаку руками від Ніка цього ходу і не можете зробити іншу.</content>
+  <content contentuid="h112fb3e9g734ag7e2dg4366g1a44c9038a26" version="1">Цього ходу ви вже виконали безплатну атаку другою рукою завдяки «Надрізу» й не можете виконати ще одну.</content>
   <content contentuid="h004828cbg6ae4g9d9fgef10g00102cb4f553" version="1">Двозбройне фехтування: атака другою рукою</content>
   <content contentuid="h3a446706g6505g19b1g3826gb313d8b63d3f" version="1">Цього ходу вторинною дією ви можете виконати додаткову Атаку другою рукою.</content>
   <content contentuid="hf7c771bbgba46g05a3g6c15g9c7c4ebba6b6" version="1">Поглинання стихій</content>
@@ -5481,7 +5479,7 @@
   <content contentuid="h4b636d62g474cg4604ga98egff95e23fd181" version="1">Ви отримали це закляття завдяки рисі «Магічний хист».</content>
   <content contentuid="he4a975ccg5d4fg45f9g97d5g3f061079b267" version="1">Магічний хист: Поглинання стихій</content>
   <content contentuid="h52a19910g3cc7g493eg8fabg8b7f5c9d64ba" version="1">Магічний хист: Дружба тварин</content>
-  <content contentuid="hd00a8e92gfc21g4f3eg9974gf9e0c3d6edbb" version="1">Магічний хист: Бейн</content>
+  <content contentuid="hd00a8e92gfc21g4f3eg9974gf9e0c3d6edbb" version="1">Магічний хист: Згуба</content>
   <content contentuid="h6dafbdc7g7942g4ac3g9634ga623f2f279cc" version="1">Магічний хист: Благословення</content>
   <content contentuid="hbda17fc5g7024g467aga87bg388df5baebc3" version="1">Магічний хист: Викривлення тіла Ґорґорота</content>
   <content contentuid="h7a2fb537g5fc5g43f8gab0cgc2fafe4b4935" version="1">Магічний хист: Палючі руки</content>
@@ -5496,7 +5494,7 @@
   <content contentuid="h470526c7g8652g4997g92f7ga0742432639f" version="1">Магічний хист: Маскування</content>
   <content contentuid="h838f68ccgef72g4870ga9e0g4663276becd0" version="1">Магічний хист: Посилений стрибок</content>
   <content contentuid="h75a2429eg5e2dg4528g91a9gc3a7fe4ecdc1" version="1">Магічний хист: Заплутування</content>
-  <content contentuid="h616e65feg4aa9g4dabg85c6g0011a08ab3c0" version="1">Магічний хист: Стрімкий відступ</content>
+  <content contentuid="h616e65feg4aa9g4dabg85c6g0011a08ab3c0" version="1">Магічний хист: Поспішний відхід</content>
   <content contentuid="h115b8b53g622bg479ag9fd7g14390d34dc89" version="1">Магічний хист: Чарівний посвіт</content>
   <content contentuid="h452ef02bg8072g459eg855cge264eb47d661" version="1">Магічний хист: Удаване життя</content>
   <content contentuid="h9dc30fd4g3582g480bgba3dg482edb0a6f4e" version="1">Магічний хист: Легкість пір'їни</content>
@@ -5509,7 +5507,7 @@
   <content contentuid="hb920e5dbgbbccg4712g9904g35edd94a4d41" version="1">Магічний хист: Батіг Пекла</content>
   <content contentuid="hd623321egb083g4f76g8de6g854fb06bd2fa" version="1">Магічний хист: Льодяний ніж</content>
   <content contentuid="h3e205f1agd960g4959g948fg29bb942db979" version="1">Магічний хист: Завдання ран</content>
-  <content contentuid="h36704839gee4ag41f3g9e73gc61a6ec696a0" version="1">Магічний хист: Довгоніг</content>
+  <content contentuid="h36704839gee4ag41f3g9e73gc61a6ec696a0" version="1">Магічний хист: Скороходець</content>
   <content contentuid="h67a78096g5504g4397ga7e3g50d4c70ef812" version="1">Магічний хист: Магічна броня</content>
   <content contentuid="h84567768gbb92g4a5cg94a3ga7549989b4f5" version="1">Магічний хист: Магічний залп</content>
   <content contentuid="h1dcac678ge441g4e18ga33fgbbe5e379795d" version="1">Магічний хист: Захист від зла й добра</content>
@@ -5520,7 +5518,7 @@
   <content contentuid="h48c46a3cg3ed8g4cb8g8a9cgfc211a2c0f09" version="1">Магічний хист: Сон</content>
   <content contentuid="h76a8c640ge73dg4733g817cg19c49fb9c591" version="1">Магічний хист: Розмова з тваринами</content>
   <content contentuid="h64a62e32ge165g4a0bgba51g3a56f6fbc678" version="1">Магічний хист: Чаровогняний спалах</content>
-  <content contentuid="h5cfc7c46g0600g459cg9131g7a3b7a33eef5" version="1">Магічний хист: Огидний сміх Таші</content>
+  <content contentuid="h5cfc7c46g0600g459cg9131g7a3b7a33eef5" version="1">Магічний хист: Невтримний регіт Таші</content>
   <content contentuid="h6eeebe55g29fcg4be9g95cfga37c5a2a251e" version="1">Магічний хист: Тернові обладунки</content>
   <content contentuid="hcde29b6bgba06g491agb023g5f000272d40b" version="1">Магічний хист: Громохвиля</content>
   <content contentuid="hc7c9d88egba6dg4b3dg9f9cgc6db9ab23824" version="1">Магічний хист: Приплив темряви</content>
@@ -5715,7 +5713,7 @@
   <content contentuid="h442b48b7g5fd1g45bfgb68bgc8dc56f80471" version="1">Доступні класи: бард, чародій, чаклун, чарівник</content>
   <content contentuid="h9e4e7db2g8e7bg46eega5f1gdb891d8cf6e0" version="1">Сувій "Вибухові жили"</content>
   <content contentuid="hf86775abg3ed7g414cga752g2779876b3c2b" version="1">Доступні класи: клірик, чародій, чарівник</content>
-  <content contentuid="h78290588g0282g4151g95cag5baef69c1634" version="1">Сувій "Танцюючі вогні"</content>
+  <content contentuid="h78290588g0282g4151g95cag5baef69c1634" version="1">Сувій «Танок вогників»</content>
   <content contentuid="ha1e89b4eg8d92g4aecg97e6g412ea9b904ac" version="1">Доступні класи: винахідник, бард, чародій, чарівник</content>
   <content contentuid="h2104ae25g8fedg4919gb897gadbc9e42ee72" version="1">Сувій "Друзі"</content>
   <content contentuid="h8b7b0898gbdedg4063g9934gc756b66c18e9" version="1">Доступні класи: бард, чародій, чаклун, чарівник</content>
@@ -5723,7 +5721,7 @@
   <content contentuid="h81ca2d82g0058g40b9g822eg48d00fa390f1" version="1">Доступні класи: винахідник, клірик, друїд</content>
   <content contentuid="hb579f1c3gfd84g4b25ga4eagc3746dba60c9" version="1">Сувій "Світло"</content>
   <content contentuid="hbbfea48fg9939g4a68g9f77g75b827833bb9" version="1">Доступні класи: винахідник, бард, клірик, чародій, чарівник</content>
-  <content contentuid="h72cfddcagd9adg46e5g9370g300ae4624cf3" version="1">Сувій "Рука мага"</content>
+  <content contentuid="h72cfddcagd9adg46e5g9370g300ae4624cf3" version="1">Сувій «Магічна рука»</content>
   <content contentuid="h64daa63ag9736g4405gbd0fgb7a1a6818a53" version="1">Доступні класи: винахідник, бард, чародій, чаклун, чарівник</content>
   <content contentuid="h06c20aa3ga24ag4712g8d65gef0c57b09d88" version="1">Сувій "Мала ілюзія"</content>
   <content contentuid="h51f7caaeg9372g4e86gaf59g32f47c7ca3fd" version="1">Доступні класи: бард, чародій, чаклун, чарівник</content>
@@ -5749,9 +5747,9 @@
   <content contentuid="h5b8d54d1ga5f7g44ebgb131g294190f528a8" version="1">Доступні класи: бард</content>
   <content contentuid="h13714915ge8a8g4f94g810egd8c9ba002446" version="1">Сувій "Обладунки Агатіс"</content>
   <content contentuid="h5ab42ef9g6590g4406g96c5g85893df14e9d" version="1">Доступні класи: чаклун</content>
-  <content contentuid="h05676470gf169g4cf0g9d65g403316fae14c" version="1">Сувій "Руки Хадара"</content>
+  <content contentuid="h05676470gf169g4cf0g9d65g403316fae14c" version="1">Сувій «Руки Гадара»</content>
   <content contentuid="h3911d261g028eg4d6eg81a7g190f0c68e29b" version="1">Доступні класи: чаклун</content>
-  <content contentuid="hbe0bca25ge643g45e5g8678gfc458da357f4" version="1">Сувій "Бейн"</content>
+  <content contentuid="hbe0bca25ge643g45e5g8678gfc458da357f4" version="1">Сувій «Згуба»</content>
   <content contentuid="h6463c609gb0b9g4640g8d41g75423740e731" version="1">Доступні класи: бард, клірик, чаклун</content>
   <content contentuid="he3c7d0a6g96b1g42c9g83e1g78c6366800d2" version="1">Сувій "Благословення"</content>
   <content contentuid="hc6a4456cg98a4g45e5g9913g29050df55476" version="1">Доступні класи: клірик, паладин</content>
@@ -5767,7 +5765,7 @@
   <content contentuid="h882af9a4gb72dg433fg81bfg913a9ca05fb3" version="1">Доступні класи: бард</content>
   <content contentuid="hc05fd5f0gabeag4800gad2eg36539cdcef6e" version="1">Сувій "Божественна милість"</content>
   <content contentuid="hea95aad3g8011g4695g98fbgb7e528739872" version="1">Доступні класи: паладин</content>
-  <content contentuid="h92a5b85bgbf5ag46c6g815fgaa776936f6b9" version="1">Сувій "Обплутувальний удар"</content>
+  <content contentuid="h92a5b85bgbf5ag46c6g815fgaa776936f6b9" version="1">Сувій «Обвивальний приступ»</content>
   <content contentuid="h240835ffg849dg4c2agb157g4665f8dc5787" version="1">Доступні класи: слідопит</content>
   <content contentuid="h4d2440a7g773eg4df5ga298ge47b7cb7545d" version="1">Сувій "Заплутування"</content>
   <content contentuid="heb239ae8gb512g4a22gb543g9b98c9f2df9d" version="1">Доступні класи: друїд, слідопит</content>
@@ -5775,19 +5773,19 @@
   <content contentuid="h53a09d3agfa14g4382ga82bga385c31825d6" version="1">Доступні класи: винахідник, бард, друїд</content>
   <content contentuid="h7ef4ab92ge90ag48bdgb4deg1e7f771f5319" version="1">Сувій "Вказівний заряд"</content>
   <content contentuid="hef54eecfgdce9g4473gb994g4113b91775fb" version="1">Доступні класи: клірик</content>
-  <content contentuid="h5271ce83g7c0fg4956gb2afg0a429f41a26e" version="1">Сувій "Терновий град"</content>
+  <content contentuid="h5271ce83g7c0fg4956gb2afg0a429f41a26e" version="1">Сувій «Шквал шипів»</content>
   <content contentuid="hbe4b287bg4438g4a3dg9254g7f67718dba54" version="1">Доступні класи: слідопит</content>
   <content contentuid="h6e9279b3ge5f5g46a2gb43aga7a7cff5b37a" version="1">Сувій "Цілюще слово"</content>
   <content contentuid="hcd5a67dfg2658g49f0g9f75g091450907eda" version="1">Доступні класи: бард, клірик, друїд</content>
   <content contentuid="h1d614ddagb290g44e4g90c4gf1d0dbff174e" version="1">Сувій "Героїзм"</content>
   <content contentuid="h6e43759ag12b4g42f0ga135g15ce363eeb40" version="1">Доступні класи: бард, паладин</content>
-  <content contentuid="he80f0a15g5df9g44bbg92e7g880e56e9ea3f" version="1">Сувій "Мітка мисливця"</content>
+  <content contentuid="he80f0a15g5df9g44bbg92e7g880e56e9ea3f" version="1">Сувій «Мисливська мітка»</content>
   <content contentuid="h94fcd654gb691g4f27g89e4gf9ff5a1de879" version="1">Доступні класи: слідопит</content>
   <content contentuid="hf42b7ddfg2028g4ec4gb854g9528bb39b818" version="1">Сувій "Завдання ран"</content>
   <content contentuid="h17266dddg8a8bg426bgb096g6b9bf2eca717" version="1">Доступні класи: клірик</content>
   <content contentuid="he05c72e9g0761g4a5cgbe1bgfe115ce91c95" version="1">Сувій "Прихисток"</content>
   <content contentuid="h6dab634bg7fcdg455bg97fag943f3d768fb1" version="1">Доступні класи: винахідник, клірик</content>
-  <content contentuid="hf58661b8gab76g47ebg8450g07dbcd2e223e" version="1">Сувій "Пекуча кара"</content>
+  <content contentuid="hf58661b8gab76g47ebg8450g07dbcd2e223e" version="1">Сувій «Палюча кара»</content>
   <content contentuid="hb5ca2a00g713ag4654g8663g5f27ac95a237" version="1">Доступні класи: паладин</content>
   <content contentuid="h68efba27gab0dg43f4ga260gea1789a83134" version="1">Сувій "Щит віри"</content>
   <content contentuid="hb7865f71gc9dbg4beega25agd429d35c82a0" version="1">Доступні класи: клірик, паладин</content>
@@ -5795,25 +5793,25 @@
   <content contentuid="hf972a7c0ge2f1g4e13g84cbgb2eb21931d53" version="1">Доступні класи: бард, друїд, слідопит, чаклун</content>
   <content contentuid="hd630115dg356eg4f68g8a96g710ed0b808e7" version="1">Сувій "Громова кара"</content>
   <content contentuid="hf65383c6g0bc1g428cg9721g7922e6de4cfa" version="1">Доступні класи: паладин</content>
-  <content contentuid="hea19e09cg0f06g47b9gb3c2g7fb62c2c96e2" version="1">Сувій "Дубова кора"</content>
+  <content contentuid="hea19e09cg0f06g47b9gb3c2g7fb62c2c96e2" version="1">Сувій «Дубова шкіра»</content>
   <content contentuid="hb15c91a6g6880g44a9g8fb0gce00ff78e460" version="1">Доступні класи: друїд, слідопит</content>
   <content contentuid="h35519665ge949g4374ga365g7bda4404fe86" version="1">Сувій "Ганебна кара"</content>
   <content contentuid="h51ea462dg7af4g46c6g98ddga2de23fe1459" version="1">Доступні класи: паладин</content>
-  <content contentuid="hc0e72a85g7d23g4c2dgb4f1gbe82eaa88e00" version="1">Сувій "Утихомирення емоцій"</content>
+  <content contentuid="hc0e72a85g7d23g4c2dgb4f1gbe82eaa88e00" version="1">Сувій «Гамування емоцій»</content>
   <content contentuid="hc298c1d3g5b1fg4a35gb89bga87a125fb109" version="1">Доступні класи: бард, клірик</content>
-  <content contentuid="heca566f5g65fcg4803g8dd1g682cc5887e4b" version="1">Сувій "Посилення характеристики"</content>
+  <content contentuid="heca566f5g65fcg4803g8dd1g682cc5887e4b" version="1">Сувій «Поліпшення здібності»</content>
   <content contentuid="hbdd71080g88bag48b8gbbe9g6e98deccccfd" version="1">Доступні класи: винахідник, бард, клірик, друїд, слідопит, чародій, чарівник</content>
-  <content contentuid="h728428ccg46b4g4d4fga3e5gbf83f178944e" version="1">Сувій "Завороження"</content>
+  <content contentuid="h728428ccg46b4g4d4fga3e5gbf83f178944e" version="1">Сувій «Полонення»</content>
   <content contentuid="hb7b57624g2a86g4643gabd8g3c71b0683ff1" version="1">Доступні класи: бард</content>
-  <content contentuid="h804ae2f1g0930g4491g8763g4b06563c2821" version="1">Сувій "Розжарити метал"</content>
+  <content contentuid="h804ae2f1g0930g4491g8763g4b06563c2821" version="1">Сувій «Гарячий метал»</content>
   <content contentuid="hc7c754fag911ag47a7ga5beg7f98f8c469f8" version="1">Доступні класи: винахідник, бард, друїд</content>
   <content contentuid="he504d141gc259g45f8gb80dg3c310b21a85b" version="1">Сувій "Мале відновлення"</content>
   <content contentuid="h6f2f1343gd3ecg4b9eg85e2g2ef6cc31d097" version="1">Доступні класи: винахідник, бард, клірик, друїд, паладин, слідопит</content>
   <content contentuid="he10d9305g8cf6g4ccbgad7bgd2746ea46ca4" version="1">Сувій "Місячний промінь"</content>
   <content contentuid="h250348d7ge71dg40a2ga944g6f665b8e18c0" version="1">Доступні класи: друїд</content>
-  <content contentuid="h45d0b5d3ga398g445cga7f9gd75da7a8aae3" version="1">Сувій "Безслідний крок"</content>
+  <content contentuid="h45d0b5d3ga398g445cga7f9gd75da7a8aae3" version="1">Сувій «Безслідна хода»</content>
   <content contentuid="hfeb4fe3ag8905g4d2bgb6a9g7ee7674d54b6" version="1">Доступні класи: друїд, слідопит</content>
-  <content contentuid="hc6d61f66ga59cg4754gac48ge00fb1fb5ddd" version="1">Сувій "Молитва зцілення"</content>
+  <content contentuid="hc6d61f66ga59cg4754gac48ge00fb1fb5ddd" version="1">Сувій «Цілюща молитва»</content>
   <content contentuid="h65a54d96gda00g48f3gb956gbf5821b6ed10" version="1">Доступні класи: клірик, паладин</content>
   <content contentuid="h4df0a731g189eg4843gb14fg950fd7625872" version="1">Сувій "Захист від отрути"</content>
   <content contentuid="h5427b5b7g9e41g4bbeg8e31g82d493a9b617" version="1">Доступні класи: винахідник, клірик, друїд, паладин, слідопит</content>
@@ -5821,7 +5819,7 @@
   <content contentuid="h87e57107g3fd4g43dcga492g90ec809f3f7a" version="1">Доступні класи: чародій, чаклун, чарівник</content>
   <content contentuid="h07d70d75gb311g4b65gaf4eg8807c20ff75d" version="1">Сувій "Тиша"</content>
   <content contentuid="h72e6f048g2dbag460egbdbcg13df38c3298c" version="1">Доступні класи: бард, клірик, слідопит</content>
-  <content contentuid="h2fd14680g25deg43cdg9566gbe966a172cd8" version="1">Сувій "Шипасте поле"</content>
+  <content contentuid="h2fd14680g25deg43cdg9566gbe966a172cd8" version="1">Сувій «Приріст шипів»</content>
   <content contentuid="hd0519165g9dffg4e5fg82eegf51c3855776a" version="1">Доступні класи: друїд, слідопит</content>
   <content contentuid="h63eb55ccgfb97g429agbc6dg76a3f91ba6dc" version="1">Сувій "Духовна зброя"</content>
   <content contentuid="hd9f0d1begbcf0g4bf7g854ageeacf34955bf" version="1">Доступні класи: клірик</content>
@@ -5831,7 +5829,7 @@
   <content contentuid="he9f6e2b1g23dfg41e9g9a07gbc2cec13be20" version="1">Доступні класи: клірик</content>
   <content contentuid="h55a35097g5dd8g4e9fg877ag564708edc728" version="1">Сувій "Сліпуча кара"</content>
   <content contentuid="h9bf76849g3018g4f96gbac5gcd39839b2394" version="1">Доступні класи: паладин</content>
-  <content contentuid="hca7ebb00g47b4g4574g953bgdb15df0bca67" version="1">Сувій "Викликати блискавку"</content>
+  <content contentuid="hca7ebb00g47b4g4574g953bgdb15df0bca67" version="1">Сувій «Заклик блискавки»</content>
   <content contentuid="h9c7aa655g6161g4dedg9ffbg92220abe2475" version="1">Доступні класи: друїд</content>
   <content contentuid="hbaf05e9cg8b9ag48dagb7eag7903cf5bc3c3" version="1">Сувій "Прикликаний обстріл"</content>
   <content contentuid="he94292e5gd3a9g44eegaaf6gdfc66d5bd1e2" version="1">Доступні класи: слідопит</content>
@@ -5841,31 +5839,31 @@
   <content contentuid="h73580f96ga9bag489aga276gaa2200b19c22" version="1">Доступні класи: клірик, друїд, паладин, слідопит, чародій</content>
   <content contentuid="haf04e176g4abeg4764gb773gf6644ec21fac" version="1">Сувій "Стихійна зброя"</content>
   <content contentuid="hd2abd846g45b3g427dgb7a8g08a2cd62544a" version="1">Доступні класи: винахідник, друїд, паладин, слідопит</content>
-  <content contentuid="hf37a3668g5485g462dgb8bfg24f366499655" version="1">Сувій "Голод Хадара"</content>
+  <content contentuid="hf37a3668g5485g462dgb8bfg24f366499655" version="1">Сувій «Голод Гадара»</content>
   <content contentuid="hdcedefeeg8769g45e9ga84bgac21bffb520f" version="1">Доступні класи: чаклун</content>
-  <content contentuid="h2d37feacg6e1dg4330ga540gcd5096a455e8" version="1">Сувій "Блискавична стріла"</content>
+  <content contentuid="h2d37feacg6e1dg4330ga540gcd5096a455e8" version="1">Сувій «Блискавкова стріла»</content>
   <content contentuid="ha40f0509gf80eg4b7agb932gee31a11de074" version="1">Доступні класи: слідопит</content>
   <content contentuid="h21fd31cfg39c3g427egbc9egf048a4cf21a5" version="1">Сувій "Масове цілюще слово"</content>
   <content contentuid="h665b1f14gbe43g44f5g9a56ga2e7cb2fa287" version="1">Доступні класи: бард, клірик</content>
-  <content contentuid="hbdf82ee0g0a92g43e1g8697gbaa2fd5aecf7" version="1">Сувій "Ріст рослин"</content>
+  <content contentuid="hbdf82ee0g0a92g43e1g8697gbaa2fd5aecf7" version="1">Сувій «Приріст рослин»</content>
   <content contentuid="habb3d245gf146g4a01g8fd5g6d0eaf22fede" version="1">Доступні класи: бард, друїд, слідопит</content>
-  <content contentuid="h50778009g9d87g418bg87b5g2254454260ed" version="1">Сувій "Духовні охоронці"</content>
+  <content contentuid="h50778009g9d87g418bg87b5g2254454260ed" version="1">Сувій «Духовна сторожа»</content>
   <content contentuid="h8fe1d517gfd0dg43f7gb1b5ge42cd5ffc705" version="1">Доступні класи: клірик</content>
   <content contentuid="h55d62a6fge1a3g4d2fg93cfg89f4f3459f11" version="1">Сувій "Прикликання лісових істот"</content>
   <content contentuid="h5e1c76d8g5917g4dcfgaf4bg102510402809" version="1">Доступні класи: друїд, слідопит</content>
   <content contentuid="h6610ee0eg1eb2g4ce7g9ca1gcf3d85a89aee" version="1">Сувій "Оберіг від смерті"</content>
   <content contentuid="h8b1f4993ga883g4f66g9bb9g24d8dd30700d" version="1">Доступні класи: клірик, паладин</content>
-  <content contentuid="hfa5194fdga498g4753g845eg38616d41d105" version="1">Сувій "Панування над звіром"</content>
+  <content contentuid="hfa5194fdga498g4753g845eg38616d41d105" version="1">Сувій «Підкорення звіра»</content>
   <content contentuid="ha49988b7g0aaag4c53gb135g16e4a7d028ca" version="1">Доступні класи: друїд, слідопит, чародій</content>
   <content contentuid="h8587bf57g8e23g47eeg855ag694f1815cca7" version="1">Сувій "Свобода руху"</content>
   <content contentuid="h924ee79agb241g4343g9a17g84d939186d74" version="1">Доступні класи: винахідник, бард, клірик, друїд, слідопит</content>
-  <content contentuid="h0ae3a512ga30bg4e55gaacfg84dc3f72dda1" version="1">Сувій "Хапка лоза"</content>
+  <content contentuid="h0ae3a512ga30bg4e55gaacfg84dc3f72dda1" version="1">Сувій «Чіпка лоза»</content>
   <content contentuid="hea395c9ag018fg4009g9180g6a41e317a1e4" version="1">Доступні класи: друїд, слідопит</content>
-  <content contentuid="hfd260509g0e4bg4d5fgb5d2gd0e37328a597" version="1">Сувій "Охоронець віри"</content>
+  <content contentuid="hfd260509g0e4bg4d5fgb5d2gd0e37328a597" version="1">Сувій «Страж віри»</content>
   <content contentuid="hab2b3ccagbed1g40b3gb1bbg58fd80b5531e" version="1">Доступні класи: клірик</content>
   <content contentuid="he70e6205gdf4fg4d5cg9dc6gdc22475bfbf4" version="1">Сувій "Танок смерті"</content>
   <content contentuid="hb9d9d80cg39e7g43cagabd7g4b093f1e2863" version="1">Доступні класи: чаклун, чарівник</content>
-  <content contentuid="hca48287cg09ddg475eg984dgb74dd7555661" version="1">Сувій "Розсіювання зла й добра"</content>
+  <content contentuid="hca48287cg09ddg475eg984dgb74dd7555661" version="1">Сувій «Розвіяння зла й добра»</content>
   <content contentuid="ha59d7b3cg42aeg4b10gae24g03767f5b5588" version="1">Доступні класи: клірик</content>
   <content contentuid="hb48ea529ga046g4da2ga1d7g7a6603bceb12" version="1">Сувій "Вогняний стовп"</content>
   <content contentuid="h34eac281g5918g45fbg9d4egdf30d279379c" version="1">Доступні класи: клірик</content>
@@ -5873,7 +5871,7 @@
   <content contentuid="h29c82c0eg24ccg4d14ga127g3278b7b2fa8b" version="1">Доступні класи: бард, клірик, друїд</content>
   <content contentuid="hf901b922g373ag4bf3gb6bbg47b4699ed0fb" version="2">Сувій "Свята зброя"</content>
   <content contentuid="h8a08067fg3f76g4e1dg8e02gad5095c8eeb9" version="2">Доступні класи: клірик</content>
-  <content contentuid="h93979a42gdc26g4964ga7f7gc4974506e66a" version="1">Сувій "Нашестя комах"</content>
+  <content contentuid="h93979a42gdc26g4964ga7f7gc4974506e66a" version="1">Сувій «Комашина чума»</content>
   <content contentuid="hab57462agb792g494bg9462g32ca3e45469e" version="1">Доступні класи: клірик, друїд, чародій</content>
   <content contentuid="hf954e01dg9e5fg497fga5d3g2cef68a76aec" version="1">Сувій "Масове зцілення ран"</content>
   <content contentuid="h2a19ce2dg5763g4613g9861g7c187ef6cb3e" version="1">Доступні класи: бард, клірик, друїд</content>
@@ -5881,19 +5879,19 @@
   <content contentuid="hdb0e30bbgc764g4d02gb2d8g7ec827bccb17" version="1">Доступні класи: чародій, чарівник</content>
   <content contentuid="hfd5fe6cbg9e79g4506gbd98g47f8fa71ae2c" version="1">Сувій "Стіна клинків"</content>
   <content contentuid="hb91babffg2098g4a95g8d11g80cbabdbd5f4" version="1">Доступні класи: клірик</content>
-  <content contentuid="h70a619eeg6ec3g4740g9447gdafb23e4c3bd" version="1">Сувій "Створити невмерлого"</content>
+  <content contentuid="h70a619eeg6ec3g4740g9447gdafb23e4c3bd" version="1">Сувій «Створення невмерлих»</content>
   <content contentuid="h8288432dge8adg48dcgb39ag463d70eae5e5" version="1">Доступні класи: клірик, чарівник</content>
-  <content contentuid="he1063367gd781g4567g8184gcff119cfbc4d" version="1">Сувій "Ушкодження"</content>
+  <content contentuid="he1063367gd781g4567g8184gcff119cfbc4d" version="1">Сувій «Лихо»</content>
   <content contentuid="hc7337917gc650g450egb66cg48f29d82ed25" version="1">Доступні класи: клірик</content>
-  <content contentuid="hd2cff643g1314g451dg8b52g3c72ab9cc277" version="1">Сувій "Зцілення"</content>
+  <content contentuid="hd2cff643g1314g451dg8b52g3c72ab9cc277" version="1">Сувій «Благо»</content>
   <content contentuid="h5a3b8f8dg1fa6g4882g9145g812f10a1971d" version="1">Доступні класи: клірик, друїд</content>
   <content contentuid="h8dce5792g2335g4226gb661gca3e4cf933f9" version="1">Сувій "Героїчний бенкет"</content>
   <content contentuid="hda55ee17gdadfg4de3g9bf8g049e90d394f8" version="1">Доступні класи: бард, клірик, друїд</content>
-  <content contentuid="hf577238eg5e24g45b6gb0a2g141a090436e0" version="1">Сувій "Планарний союзник"</content>
+  <content contentuid="hf577238eg5e24g45b6gb0a2g141a090436e0" version="1">Сувій «Іншовимірний союзник»</content>
   <content contentuid="hc4d67b9ag8485g41a4gaf7ag052379dbe08f" version="1">Доступні класи: клірик</content>
-  <content contentuid="h2ecfc655g0140g46e2gb3a1g79eb47deb506" version="1">Сувій "Тернова стіна"</content>
+  <content contentuid="h2ecfc655g0140g46e2gb3a1g79eb47deb506" version="1">Сувій «Стіна терну»</content>
   <content contentuid="h2f0b64a4geb48g4c40g9076g26cb973d6c00" version="1">Доступні класи: друїд</content>
-  <content contentuid="hc2613126g1447g4fd3g9ecdg5f633dce7f75" version="1">Сувій "Ходіння вітром"</content>
+  <content contentuid="hc2613126g1447g4fd3g9ecdg5f633dce7f75" version="1">Сувій «Вітроступ»</content>
   <content contentuid="h6c3bff41ge93bg4284g9158gfe616f679bae" version="1">Доступні класи: бард, друїд</content>
   <content contentuid="hbdab1650g7fcegb743g3bf5gb818b5acb043" version="2">Перемінник</content>
   <content contentuid="hb280ba69g6538g2683g4a87gc4ce53e3c3c6" version="1">Перемінник</content>
@@ -6120,7 +6118,7 @@
 
 Вроджена майстерність клинка. Поки діє ваша особливість «Вроджене чаклунство», атакуючи зброєю, якою володієте, ви можете використовувати свій модифікатор харизми замість сили чи спритності для кидків атаки й шкоди.
 
-Бойова підготовка. Ви отримуєте володіння бойовою зброєю та вміння носити легкі й середні обладунки і користуватися щитами.</content>
+Бойова підготовка. Ви отримуєте володіння бойовою зброєю та вміння носити легкі й середні обладунки й користуватися щитами.</content>
   <content contentuid="h24a47f20g3ac1g6d84g3d56g0ed1cb4e72a0" version="1">Вроджена майстерність клинка</content>
   <content contentuid="h11d402ccg5d0ag742bgf457g44dda07625c7" version="1">Поки діє ваша особливість «Вроджене чаклунство», атакуючи зброєю, якою володієте, ви можете використовувати свій модифікатор харизми замість сили чи спритності для кидків атаки й шкоди.</content>
   <content contentuid="h53a12d9egc7c5gf706ga7b8g2d29d648745c" version="1">Героїчна душа</content>
@@ -6150,7 +6148,7 @@
   <content contentuid="he7ab672fgb558g9a55g2482gc3f14b08385f" version="1">Благословення кузні: магічні обладунки</content>
   <content contentuid="h5087f168gc945g5fb3g83d6g3f3a84dd61d9" version="1">Благословення ремісника</content>
   <content contentuid="hf4556a98g94c2g16ddg4fe9g5fa3c35a3652" version="1">Коли ви вражаєте істоту атакою ближнього бою, ви можете використовувати свій &lt;LSTag Type="ActionResource" Tooltip="ChannelDivinity"&gt;Боже наснаження&lt;/LSTag&gt;, щоб завдати додаткової шкоди від вогню.</content>
-  <content contentuid="he9a93975g783agd634g2f29gb040a65e4d4f" version="1">Коли ви досягаєте певних рівнів клірика, у вас завжди є готові наступні закляття: жир, спалюючий удар, гарячий метал і магічна зброя на рівні 3; Елементарна зброя та захист від енергії на рівні 5; Вогняний щит і Вогняна стіна на рівні 7; і Вогняний стовп і Стіна каменю на рівні 9. Ці закляття не зараховуються до кількості заклять, які ви можете підготувати.</content>
+  <content contentuid="he9a93975g783agd634g2f29gb040a65e4d4f" version="1">На певних рівнях клірика ви отримуєте закляття, які надалі завжди вважаються підготовленими: на 3-му рівні — «Жир», «Палюча кара», «Гарячий метал» і «Магічна зброя»; на 5-му — «Стихійна зброя» та «Захист від енергії»; на 7-му — «Вогняний щит» і «Стіна вогню»; на 9-му — «Вогняний стовп» і «Стіна каменю». Ці закляття не враховуються до кількості заклять, які ви можете підготувати.</content>
   <content contentuid="heabce0ebge4c8g32e1gec9dgfa7d3983180d" version="4">Небесний дух</content>
   <content contentuid="ha1f46ec6g425egaef3g8a83g4a20db310dd5" version="1">Прикликати небесника</content>
   <content contentuid="h102e9b14g2c12gd739gf2fegff7c28ae9efe" version="1">Ви прикликаєте духа небесника. Він з’являється в ангельській подобі у видимому вільному просторі в межах досяжності й використовує блок характеристик Небесного духа.</content>
@@ -6209,31 +6207,31 @@
   <content contentuid="hab14da86g7b16g490fgb2d6gc1562b7be680" version="1">Сувій "Сковувальний лід Райма"</content>
   <content contentuid="he8952d9fg34d0g4b96ga9d2gcb83f53d70bf" version="1">Доступні класи: чародій, чарівник</content>
   <content contentuid="h30d1d690gdf53g656bgcf28g9576cd55a3ca" version="1">Обіт дозорців</content>
-  <content contentuid="h5bc272c5gfa88g8410g5e75gdfb68e7e142b" version="1">Клятва спостерігачів зобов’язує паладинів захищати царства смертних від хижаків позапланових істот, багато з яких можуть спустошити смертних солдатів. Таким чином, Спостерігачі відточують свій розум, дух і тіло, щоб стати найкращою зброєю проти таких загроз.
+  <content contentuid="h5bc272c5gfa88g8410g5e75gdfb68e7e142b" version="1">Обіт дозорців зобов’язує паладинів захищати світи смертних від зазіхань позапланових істот, багато з яких здатні нищити цілі війська. Тому дозорці гартують розум, дух і тіло, щоб стати найкращою зброєю проти таких загроз.
 
-Паладини, які дотримуються присяги Спостерігачів, завжди пильно виявляють вплив позапланових сил, часто створюючи мережу шпигунів та інформаторів для збору інформації про підозрювані культи. Для спостерігача зберігати здорову підозру та обізнаність про оточення так само природно, як носити броню в бою.</content>
+Паладини цього обіту невсипуще вишукують ознаки впливу позапланових сил і часто створюють мережі шпигунів та інформаторів, щоб збирати відомості про підозрілі культи. Для дозорця пильна недовіра й уважність до оточення такі ж природні, як обладунок у бою.</content>
   <content contentuid="hffe71531ga373g6aebg5c04g34c95b77fed1" version="1">Воля дозорця</content>
   <content contentuid="hcade1749gdcc0g1f97g1533gca440242cfde" version="1">Ви можете скористатися Обітним наснаженням, щоб сповнити свою присутність захисною силою віри. Виберіть видимих істот у межах 30 футів у кількості, що не перевищує ваш модифікатор харизми (щонайменше одну). Протягом 1 хвилини ви й вибрані істоти маєте перевагу для кидків протидії інтелектом, мудрістю та харизмою.</content>
-  <content contentuid="h54a6679dg10f0g981egf460g55ffbc1cfcaf" version="1">Вигнання екстрапланарних істот</content>
-  <content contentuid="h8f70346agdae6g92b8gc487gb1bbc53e7cbd" version="1">&lt;LSTag Type="Status" Tooltip="TURNED"&gt;Вигнати&lt;/LSTag&gt; поблизьких покручів, небожителів, стихійників, фейських істот або нечисть. Вони змушені тікати й не можуть наблизитися до вас.</content>
-  <content contentuid="h19f6ac0dg82e0g24f3g61f4ge443d1f54e72" version="1">Принципи спостерігачів</content>
-  <content contentuid="h33e17780g9ca6g87f9g62b0gdbc3715ada11" version="1">Паладин, який приймає Клятву Спостерігачів, клянеться захищати царства смертних від потойбічних загроз.
+  <content contentuid="h54a6679dg10f0g981egf460g55ffbc1cfcaf" version="1">Вигнання позапланових істот</content>
+  <content contentuid="h8f70346agdae6g92b8gc487gb1bbc53e7cbd" version="1">&lt;LSTag Type="Status" Tooltip="TURNED"&gt;Прогнати&lt;/LSTag&gt; поблизьких покручів, небесників, елементалів, фей або нечисть. Вони змушені тікати й не можуть наближатися до вас.</content>
+  <content contentuid="h19f6ac0dg82e0g24f3g61f4ge443d1f54e72" version="1">Засади дозорців</content>
+  <content contentuid="h33e17780g9ca6g87f9g62b0gdbc3715ada11" version="1">Паладин, який складає обіт дозорців, присягається захищати світи смертних від потойбічних загроз.
 
-Пильність. Загрози, з якими ви стикаєтеся, хитрі, потужні та підривні. Будьте завжди напоготові щодо їхньої корупції.
+Пильність. Загрози, яким ви протистоїте, підступні, могутні й руйнівні. Завжди будьте готові помітити їхній згубний вплив.
 
-Лояльність. Ніколи не приймайте подарунки чи послуги від недоброзичливців або тих, хто їх перевозить. Залишайтеся вірними своєму наказу, своїм товаришам і своєму обов’язку.
+Вірність. Ніколи не приймайте дарів чи послуг від нечисті або тих, хто має з нею справу. Залишайтеся вірними своєму ордену, товаришам та обов’язку.
 
-Дисциплінованість. Ви — щит від нескінченних жахів, які ховаються за зірками. Ваше лезо повинно бути вічно гострим, а ваш розум — гострим, щоб пережити те, що лежить за ним.</content>
+Дисципліна. Ви — щит проти нескінченних жахіть, що причаїлися за зорями. Щоб вижити перед невідомим, ваш клинок має завжди бути гострим, а розум — проникливим.</content>
   <content contentuid="hf005b6eegd9edg12b5g2847g6cb308887662" version="1">Аура Вартового</content>
-  <content contentuid="ha8e6db56ge4ddgc57dgdfdbg53d7f82bba08" version="1">Ви випромінюєте ауру пильності, поки ви не втрачені. Коли ви та будь-яка істота на ваш вибір у радіусі 10 футів від вас кидаєте ініціативу, ви всі отримуєте бонус до ініціативи, рівний бонусу вашої майстерності.</content>
+  <content contentuid="ha8e6db56ge4ddgc57dgdfdbg53d7f82bba08" version="1">Ви випромінюєте ауру пильності, доки не набули стану недієздатності. Коли ви або вибрана вами істота в межах 10 футів кидаєте ініціативу, кожен із вас отримує бонус до ініціативи, що дорівнює вашому бонусу спеціалізації.</content>
   <content contentuid="he8ec9e49g1ed3g994egd537g4bff52ad40e5" version="1">Рівень 3: Закляття Обіту дозорців</content>
-  <content contentuid="h7731d2eag11ffg44e4g8569ga5e35e0e6de9" version="1">Паладини, які принесли Клятву Спостерігачів, отримують доступ до Захисту від Зла і Добра та Щита на 3-му рівні, Місячного променя та Бачення Невидимості на 5-му рівні, а також Чароспин і Духовна сторожа на 9-му рівні.</content>
+  <content contentuid="h7731d2eag11ffg44e4g8569ga5e35e0e6de9" version="1">Паладини, які склали обіт дозорців, отримують такі закляття: на 3-му рівні — «Захист від зла й добра» та «Щит»; на 5-му — «Місячний промінь» і «Бачення невидимого»; на 9-му — «Чароспин» і «Духовна сторожа».</content>
   <content contentuid="h53bf4744g8817g4dc1g9f65g4ca743366100" version="1">Рівень 3: Воля дозорця</content>
   <content contentuid="h55809fbag7bd0g427fgaea4gcc7103f95f2c" version="1">Ви можете скористатися Обітним наснаженням, щоб сповнити свою присутність захисною силою віри. Виберіть видимих істот у межах 30 футів у кількості, що не перевищує ваш модифікатор харизми (щонайменше одну). Протягом 1 хвилини ви й вибрані істоти маєте перевагу для кидків протидії інтелектом, мудрістю та харизмою.</content>
-  <content contentuid="h1c396853g089ag4cf6gaac4g3a465614eb89" version="1">Рівень 3: Вигнання екстрапланарних істот</content>
-  <content contentuid="h9aa052ddgf617g4344ga11dg4ad49e29159e" version="1">Ви можете використати Обітне наснаження, щоб спробувати &lt;LSTag Type="Status" Tooltip="TURNED"&gt;прогнати&lt;/LSTag&gt; позапланарну істоту. Кожна аберація, небесник, елементаль, фея чи біс у межах 30 футів від вас має успішно виконати кидок протидії мудрістю, інакше зазнає Прогнання на 1 хвилину. Прогнана істота мусить тікати й не може наближатися до вас.</content>
+  <content contentuid="h1c396853g089ag4cf6gaac4g3a465614eb89" version="1">Рівень 3: Вигнання позапланових істот</content>
+  <content contentuid="h9aa052ddgf617g4344ga11dg4ad49e29159e" version="1">Скористайтеся Обітним наснаженням, щоб спробувати &lt;LSTag Type="Status" Tooltip="TURNED"&gt;прогнати&lt;/LSTag&gt; позапланових істот. Кожен покруч, небесник, елементаль, фея чи нечисть у межах 30 футів повинен успішно виконати кидок протидії мудрістю, інакше буде прогнаний на 1 хвилину. Прогнана істота мусить тікати й не може наближатися до вас.</content>
   <content contentuid="h7d68e487g894dg47f1g8cdcg0ca8573c0e57" version="1">Рівень 7: Аура Вартового</content>
-  <content contentuid="h41b477e4g3e5cg4162gb3dbga2e44d7f9e08" version="1">Ви випромінюєте ауру пильності, поки ви не втрачені. Коли ви та будь-яка істота на ваш вибір у радіусі 10 футів від вас кидаєте ініціативу, ви всі отримуєте бонус до ініціативи, рівний бонусу вашої майстерності.</content>
+  <content contentuid="h41b477e4g3e5cg4162gb3dbga2e44d7f9e08" version="1">Ви випромінюєте ауру пильності, доки не набули стану недієздатності. Коли ви або вибрана вами істота в межах 10 футів кидаєте ініціативу, кожен із вас отримує бонус до ініціативи, що дорівнює вашому бонусу спеціалізації.</content>
   <content contentuid="hfe23251ag4606g4bd5gb621g1bf49c9afed5" version="1">Воля дозорця</content>
   <content contentuid="h162f8511gf43fg4a20g92acg66806eb1c643" version="1">Перевага на &lt;LSTag Tooltip="SavingThrow"&gt;кидки протидії&lt;/LSTag&gt; інтелектом, мудрістю та харизмою.</content>
   <content contentuid="h2e981e1agea92gf303gbd58g40778c39d1a0" version="1">Наказ</content>
@@ -6256,15 +6254,15 @@
   <content contentuid="h3383897fg0d52g3610ga0acg1e6c8127185a" version="1">Наказ: стояти</content>
   <content contentuid="h008339d0g409egb1d7gdd3dg2127e870cf45" version="1">Сутінковий домен</content>
   <content contentuid="h928d315dg5edfg7525gef8agea8c6f1f21dc" version="1">Сутінки</content>
-  <content contentuid="h8785e885g203ag3328g4efcge9f1b68f7063" version="1">Сутінковий перехід від світла до темряви часто приносить спокій і навіть радість, оскільки денні праці закінчуються і починаються години відпочинку. Темрява також може принести жахи, але боги сутінків оберігають від жахів ночі.
+  <content contentuid="h8785e885g203ag3328g4efcge9f1b68f7063" version="1">Сутінковий перехід від світла до темряви часто приносить спокій і навіть радість: денні турботи завершуються й настають години відпочинку. Темрява може нести й жахіття, але боги сутінків оберігають від небезпек ночі.
 
-клірики, які служать цим божествам (приклади яких представлені в таблиці Сутінкових Божеств), приносять розраду тим, хто шукає відпочинку, і захищають їх, вирушаючи в темряву, яка вторгається, щоб переконатися, що темрява є розрадою, а не жахом.</content>
+Клірики, які служать цим божествам — їхні приклади наведено в таблиці «Сутінкові божества», — дарують розраду тим, хто прагне спочинку, і захищають їх, вирушаючи назустріч пітьмі, що насувається, аби темрява залишалася джерелом спокою, а не жаху.</content>
   <content contentuid="had547f10gf9b5gc30cg6122g99ef0b90d2ad" version="1">Рівень 3: Закляття сутінкового домену</content>
   <content contentuid="h434df1f3gdadag1149g4c36g6bfc2c7a1bec" version="1">На певних рівнях клірика ви отримуєте закляття, які надалі завжди вважаються підготовленими: на 3-му рівні — «Чарівний посвіт», «Сон», «Місячний промінь» і «Бачення невидимого»; на 5-му — «Аура життєвості» та «Удар порожнечі»; на 7-му — «Свобода руху» й &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;«Велика невидимість»&lt;/LSTag&gt;; на 9-му — «Коло сили» та «Світанок». Ці закляття не враховуються до кількості заклять, які ви можете підготувати.</content>
   <content contentuid="h0060ddb2gfe04g6d96g6e94g9496e7fff0e0" version="2">Рівень 3: Очі ночі</content>
-  <content contentuid="h73451af6g0c9dge1e4g112ag73be890335ef" version="2">Ви можете бачити крізь найглибшу темряву. У вас чудовий темнозір, ви можете бачити в тьмяному світлі, ніби це яскраве світло, і в темряві, як ніби це тьмяне світло.
+  <content contentuid="h73451af6g0c9dge1e4g112ag73be890335ef" version="2">Ви бачите крізь найгустіший морок. Завдяки покращеному темнозору ви бачите за тьмяного освітлення, наче за яскравого, а в темряві — наче за тьмяного.
 
-Як дію, ви можете чарівним чином поділитися темним баченням з охочими істотами, яких ви бачите в радіусі 30 футів від вас.</content>
+Дією ви можете магічно поділитися своїм темнозором зі згодними істотами, яких бачите в межах 30 футів.</content>
   <content contentuid="ha2cbe761g2aeagb911g1788g0866a2b29338" version="2">Рівень 3: Сутінкове святилище</content>
   <content contentuid="h532c41a2g898dg391bgea84g9bed3cd65e57" version="2">Ви можете застосувати Боже наснаження, щоб огорнути союзників заспокійливими сутінками.
 
@@ -6280,7 +6278,7 @@
   <content contentuid="hebfbed86g90fbg2febg9b40gf962dcb2a657" version="1">Благословення пильності</content>
   <content contentuid="hf3e7519ag2e32g1737g0368g20c23dbd7c78" version="1">Ви отримуєте бонус +5 до наступного кидка ініціативи.</content>
   <content contentuid="h93835ab2gd32dgb000g6d71gaf792488673b" version="1">Сутінкове святилище</content>
-  <content contentuid="h7e9705fdg8018gea33g08e7g9a5b338d7d6a" version="1">Дією ви здіймаєте священний символ, і від вас поширюється сфера присмерку радіусом 30 футів, наповнена тьмяним світлом. Вона рухається разом із вами й існує 1 хвилину, доки ви не станете недієздатними або не помрете. Щоразу, коли істота завершує хід у сфері, вона отримує тимчасові очки здоров’я в кількості 1d6 + ваш рівень клірика й припиняє один ефект, через який вона зачарована або налякана.</content>
+  <content contentuid="h7e9705fdg8018gea33g08e7g9a5b338d7d6a" version="1">Дією ви здіймаєте священний символ, і від вас поширюється сфера сутінків радіусом 30 футів, наповнена тьмяним світлом. Вона рухається разом із вами й існує 1 хвилину або доки ви не станете недієздатним чи не помрете. Щоразу, коли істота завершує хід у сфері, вона отримує тимчасові очки здоров’я в кількості 1d6 + ваш рівень клірика й припиняє один ефект, що спричиняє її причарування або переляк.</content>
   <content contentuid="h1680e4e3g7e97g83f6g8211gb82d21865136" version="1">Сутінкове святилище</content>
   <content contentuid="h252a159fg1973g1128g723dgcc172f2c22d4" version="1">Щоразу, коли істота завершує свій хід у сфері, вона отримує 1d6 + рівень клірика тимчасових очок здоров’я та припиняє один ефект, що спричиняє її причарування або переляк.</content>
   <content contentuid="hbed305dbgd604g3016gc95fg85178f47c414" version="1">Сутінкове святилище</content>
@@ -6312,11 +6310,11 @@
   <content contentuid="h3f64848bg052dg43f2g810eg7be150061cc4" version="1">Магічний хист: Злісне глузування</content>
   <content contentuid="h37588848gdc10g2334gdf51ga179befdb18d" version="1">Завершуючи короткий або довгий відпочинок, ви можете зіграти пісню на музичному інструменті, яким володієте, і надати &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Героїчне натхнення&lt;/LSTag&gt; союзникам, які її чують. У такий спосіб можна вплинути на стількох союзників, скільки становить ваш бонус спеціалізації.</content>
   <content contentuid="hdb7f26d7gc116gec10g33c4g5d76f22454ca" version="1">Божественна душа</content>
-  <content contentuid="h490ad4f0gd12fg2b06g615bg7c7d9ecf0520" version="1">Іноді іскра магії, яка підживлює чаклуна, походить із божественного джерела, яке мерехтить у душі. Наявність такої благословенної душі є ознакою того, що ваша вроджена магія може походити від далекого, але потужного сімейного зв’язку з божественною істотою. Можливо, ваш предок був ангелом, перетвореним на смертного і посланим воювати в ім’я бога. Або ваше народження може узгоджуватися з стародавнім пророцтвом, позначаючи вас як слугу богів або обрану посудину божественної магії.
+  <content contentuid="h490ad4f0gd12fg2b06g615bg7c7d9ecf0520" version="1">Іноді іскра, що живить магію чародія, походить із божественного джерела, яке мерехтить у самій душі. Така благословенна душа може свідчити, що ваша вроджена магія бере початок від далекого, але могутнього родинного зв’язку з божественною істотою. Можливо, вашим предком був ангел, обернений на смертного й посланий битися в ім’я бога. Або ваше народження збіглося зі стародавнім пророцтвом, що проголосило вас слугою богів чи обраною посудиною божественної магії.
 
-Божественна душа з природним магнетизмом розглядається деякими релігійними ієрархіями як загроза. Як аутсайдер, який керує священною владою, Божественна Душа може підірвати існуючий порядок, заявляючи про прямий зв’язок із божественним.
+Природна харизма Божественної душі змушує деякі релігійні ієрархії вбачати в ній загрозу. Як стороння особа, що володіє священною силою, Божественна душа може підважити усталений лад, заявивши про прямий зв’язок із божественним.
 
-У деяких культурах лише ті, хто може претендувати на силу Божественної Душі, можуть керувати релігійною владою. На цих землях церковні посади домінують за кількома кровними лініями і зберігаються протягом поколінь.</content>
+У деяких культурах релігійну владу дозволено мати лише носіям сили Божественної душі. У таких землях церковні посади поколіннями залишаються в руках кількох родів.</content>
   <content contentuid="h15f0ee5fga398ga6a4g198cgef588b8b978b" version="1">Рівень 3: Божественна магія</content>
   <content contentuid="h7388ec5cg457dg1ca4ge8c5g3185c4df0a9b" version="1">Ваш зв’язок із божественним дає змогу вивчати закляття клірика. На 3-му, 5-му, 7-му та 9-му рівнях чародія ви вивчаєте додаткові закляття зі списку клірика. Для вас вони вважаються закляттями чародія, але не враховуються до кількості відомих вам заклять чародія.
 
@@ -6555,17 +6553,17 @@
   <content contentuid="h4931b661gf594g391eg284egf77199038e8c" version="1">Гостре чуття</content>
   <content contentuid="h282b4762g8c1dgbed2ga8d4g5feabffdd2b7" version="1">Ви володієте однією з таких навичок: «Проникливість», «Відчуття» або «Виживання».</content>
   <content contentuid="hea2fd3f2g7379ga387g20eeg1c9c6a1516f9" version="1">Орк</content>
-  <content contentuid="h1536d1d3ge2e9ge28dg516eg94798f8d7ebe" version="1">Орки відносять своє створення до Ґруумша, могутнього бога, який бродив широкими просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, щоб допомогти їм блукати великими рівнинами, величезними печерами та бурхливими морями та протистояти чудовиськам, які там ховаються. Навіть коли вони звертаються до інших богів, орки зберігають дари Груумша: витривалість, рішучість і здатність бачити в темряві.
+  <content contentuid="h1536d1d3ge2e9ge28dg516eg94798f8d7ebe" version="1">Орки ведуть свій рід від Ґруумша — могутнього бога, що мандрував безкраїми просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, які допомагають їм мандрувати великими рівнинами, просторими печерами та бурхливими морями й протистояти чудовиськам, що там причаїлися. Навіть присвячуючи себе іншим богам, орки зберігають дари Ґруумша: витривалість, рішучість і здатність бачити в темряві.
 
-Орки в середньому високі та широкі. Вони мають сіру шкіру, гостро загострені вуха та видатні нижні ікла, схожі на маленькі бивні. Юнакам орків у деяких світах розповідають про великі мандри та муки їхніх предків. Натхненні цими оповіданнями, багато з цих орків цікавляться, коли Ґруумш покличе їх, щоб вони зрівнялися з героїчними вчинками давнини, і чи виявляться вони гідними його прихильності. Інші орки із задоволенням залишають старі казки в минулому і знаходять свій власний шлях.</content>
+Зазвичай орки високі й кремезні. Вони мають сіру шкіру, гострі вуха й помітні нижні ікла, схожі на невеликі бивні. У деяких світах юним оркам розповідають про великі мандри й випробування предків. Натхненні цими оповідями, багато хто з них замислюється, коли Ґруумш покличе їх повторити героїчні діяння давнини й чи виявляться вони гідними його прихильності. Інші орки радо лишають старі оповіді в минулому й торують власний шлях.</content>
   <content contentuid="h1536c082g3218g6c89gaa12g6f75fce49800" version="1">Орк</content>
-  <content contentuid="h449084fbgb69ag0519ge52dg161d6d97eae4" version="1">Орки відносять своє створення до Ґруумша, могутнього бога, який бродив широкими просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, щоб допомогти їм блукати великими рівнинами, величезними печерами та бурхливими морями та протистояти чудовиськам, які там ховаються. Навіть коли вони звертаються до інших богів, орки зберігають дари Груумша: витривалість, рішучість і здатність бачити в темряві.</content>
+  <content contentuid="h449084fbgb69ag0519ge52dg161d6d97eae4" version="1">Орки ведуть свій рід від Ґруумша — могутнього бога, що мандрував безкраїми просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, які допомагають їм мандрувати великими рівнинами, просторими печерами та бурхливими морями й протистояти чудовиськам, що там причаїлися. Навіть присвячуючи себе іншим богам, орки зберігають дари Ґруумша: витривалість, рішучість і здатність бачити в темряві.</content>
   <content contentuid="h534d8977g610cgaa09gb6eeg1889a251dd1d" version="1">Орк</content>
-  <content contentuid="h498af51ag51c8geb62g0208g43489e7a4c7c" version="1">Орки відносять своє створення до Ґруумша, могутнього бога, який бродив широкими просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, щоб допомогти їм блукати великими рівнинами, величезними печерами та бурхливими морями та протистояти чудовиськам, які там ховаються. Навіть коли вони звертаються до інших богів, орки зберігають дари Груумша: витривалість, рішучість і здатність бачити в темряві.
+  <content contentuid="h498af51ag51c8geb62g0208g43489e7a4c7c" version="1">Орки ведуть свій рід від Ґруумша — могутнього бога, що мандрував безкраїми просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, які допомагають їм мандрувати великими рівнинами, просторими печерами та бурхливими морями й протистояти чудовиськам, що там причаїлися. Навіть присвячуючи себе іншим богам, орки зберігають дари Ґруумша: витривалість, рішучість і здатність бачити в темряві.
 
-Орки в середньому високі та широкі. Вони мають сіру шкіру, гостро загострені вуха та видатні нижні ікла, схожі на маленькі бивні. Юнакам орків у деяких світах розповідають про великі мандри та муки їхніх предків. Натхненні цими оповіданнями, багато з цих орків цікавляться, коли Ґруумш покличе їх, щоб вони зрівнялися з героїчними вчинками давнини, і чи виявляться вони гідними його прихильності. Інші орки із задоволенням залишають старі казки в минулому і знаходять свій власний шлях.</content>
+Зазвичай орки високі й кремезні. Вони мають сіру шкіру, гострі вуха й помітні нижні ікла, схожі на невеликі бивні. У деяких світах юним оркам розповідають про великі мандри й випробування предків. Натхненні цими оповідями, багато хто з них замислюється, коли Ґруумш покличе їх повторити героїчні діяння давнини й чи виявляться вони гідними його прихильності. Інші орки радо лишають старі оповіді в минулому й торують власний шлях.</content>
   <content contentuid="hd17f3cfegc77cg62eagf508ga2afbb8b3651" version="1">Орк</content>
-  <content contentuid="hefd844a2gf6d5g1299g89e1ge8acaed81bb9" version="1">Орки відносять своє створення до Ґруумша, могутнього бога, який бродив широкими просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, щоб допомогти їм блукати великими рівнинами, величезними печерами та бурхливими морями та протистояти чудовиськам, які там ховаються. Навіть коли вони звертаються до інших богів, орки зберігають дари Груумша: витривалість, рішучість і здатність бачити в темряві.</content>
+  <content contentuid="hefd844a2gf6d5g1299g89e1ge8acaed81bb9" version="1">Орки ведуть свій рід від Ґруумша — могутнього бога, що мандрував безкраїми просторами Матеріального плану. Ґруумш наділив своїх дітей дарами, які допомагають їм мандрувати великими рівнинами, просторими печерами та бурхливими морями й протистояти чудовиськам, що там причаїлися. Навіть присвячуючи себе іншим богам, орки зберігають дари Ґруумша: витривалість, рішучість і здатність бачити в темряві.</content>
   <content contentuid="he31c01dfg72adg4db2g94c1gbc12a3a0e8c6" version="1">Дампір</content>
   <content contentuid="h35285b67g36d4g40a2gb3cdg7f02716f722d" version="1">Дампіри — живі люди, які володіють вампірською доблестю, але прокляті жахливим голодом. Більшість дампірів жадають крові, але деякі харчуються снами, життєвою енергією чи іншими життєво важливими джерелами. Дампірам доводиться вибирати, чи боротися, щоб контролювати свій голод, чи піддатися хижацьким бажанням.</content>
   <content contentuid="h79606373g3860g4fcag9d5cg6a9759d91e00" version="2">Дампір</content>
@@ -6587,9 +6585,9 @@
   <content contentuid="h3b3b4882g56f7g12dag4b9fgcf25e36c625d" version="1">Ривок</content>
   <content contentuid="h6d9021a0gb82bgbcb8ge41bgbb23b222a400" version="1">Кинутися вперед, маючи шанс &lt;LSTag Type="Status" Tooltip="PRONE"&gt;повалити&lt;/LSTag&gt; ціль.</content>
   <content contentuid="hbd1c29f3g9d49g7f6bgd0f5g7628a41aeced" version="1">Прикличте лютоворона, який літає й атакує ворогів &lt;LSTag Type="Spell" Tooltip="Target_Beak_Raven_Summon_BeastMaster"&gt;дзьобом&lt;/LSTag&gt;. Вилітаючи з досяжності ворога, він не провокує &lt;LSTag Tooltip="OpportunityAttack"&gt;принагідних атак&lt;/LSTag&gt;.</content>
-  <content contentuid="h1944ab59g9198g6ac4gba4ag5a0efe856cbb" version="2">Прикличте чорного ведмедя, який шматує ворогів &lt;LSTag Type="Spell" Tooltip="Target_Claws_Bear_Black_Summon"&gt;кігтями&lt;/LSTag&gt; і збиває їх з ніг &lt;LSTag Type="Spell" Tooltip="Rush_Rush_Boar_Summon"&gt;натиском&lt;/LSTag&gt;.</content>
+  <content contentuid="h1944ab59g9198g6ac4gba4ag5a0efe856cbb" version="2">Прикличте чорного ведмедя, який шматує ворогів &lt;LSTag Type="Spell" Tooltip="Target_Claws_Bear_Black_Summon"&gt;кігтями&lt;/LSTag&gt; й збиває їх з ніг &lt;LSTag Type="Spell" Tooltip="Rush_Rush_Boar_Summon"&gt;натиском&lt;/LSTag&gt;.</content>
   <content contentuid="hd5b90e52gc2cagaf46gca4cg4997c18e17fb" version="1">Прикличте кабана, який проштрикує ворогів &lt;LSTag Type="Spell" Tooltip="Target_Tusk_Boar_Summon"&gt;іклом&lt;/LSTag&gt; і збиває їх з ніг &lt;LSTag Type="Spell" Tooltip="Rush_Rush_Boar_Summon"&gt;натиском&lt;/LSTag&gt;.</content>
-  <content contentuid="hafbed588gb94eg788agb035g22cf2f434eb4" version="1">Прикличте вовчого павука, який кидається на ворогів із &lt;LSTag Type="Spell" Tooltip="Target_Bite_GiantSpider_Summon"&gt;укусом&lt;/LSTag&gt; і збиває їх з ніг &lt;LSTag Type="Spell" Tooltip="Rush_Rush_Boar_Summon"&gt;натиском&lt;/LSTag&gt;.</content>
+  <content contentuid="hafbed588gb94eg788agb035g22cf2f434eb4" version="1">Прикличте вовчого павука, який атакує ворогів &lt;LSTag Type="Spell" Tooltip="Target_Bite_GiantSpider_Summon"&gt;укусом&lt;/LSTag&gt; і збиває їх з ніг &lt;LSTag Type="Spell" Tooltip="Rush_Rush_Boar_Summon"&gt;натиском&lt;/LSTag&gt;.</content>
   <content contentuid="h67d9ca78g7e48g27e7g2e6bg3fd979f583a5" version="1">Прикличте вовка, який шматує ворогів &lt;LSTag Type="Spell" Tooltip="Target_Bite_Wolf_Summon"&gt;укусом&lt;/LSTag&gt; і збиває їх з ніг &lt;LSTag Type="Spell" Tooltip="Rush_Rush_Boar_Summon"&gt;натиском&lt;/LSTag&gt;.</content>
   <content contentuid="h119be29dg24e8gbccbg6e70ge67fbf2b1f17" version="1">Бивень</content>
   <content contentuid="h9b257208g4458gc4b6g1ebbg7a1d4529bb88" version="1">Укус</content>


### PR DESCRIPTION
## Summary

This is a follow-up proofreading pass for the Ukrainian localization already merged in #1305.

- updates 144 localization entries
- aligns spell names in scrolls, feats, and spell lists with the official Ukrainian Baldur's Gate 3 localization
- rewrites several machine-like class, subclass, race, and feature descriptions into natural Ukrainian
- standardizes Illrigger terminology (Згубна заборона, печатка, заборонена істота)
- fixes grammar, spelling, euphony, quotation marks, and terminology consistency

## Validation

- all 5,355 English handles are present exactly once
- no missing or extra handles
- no version or ordering mismatches
- no empty or visibly English entries
- no tag, placeholder, or dice-expression mismatches
- all directly comparable spell titles match the official BG3 Ukrainian localization

Only Localization/Ukrainian/ukrainian.xml is changed.

## Credit note

As with the original contribution, please mention the Ukrainian **TableTop BRAMA** community in the translation credit. Their established Ukrainian D&D terminology is used where Baldur's Gate 3 has no official equivalent.