### PR TITLE
Fix Polish formula spacing

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -5012,7 +5012,7 @@ Zasięg twoich ataków bez broni zwiększa się o 1,5 m.</content>
   <content contentuid="h64ffc9d5ga96fg168bg296eg9642cbd7f4b0" version="1">Ścieżka Dzikiej Magii</content>
   <content contentuid="h08c08b52g956bgcf55gaba1gfea165770305" version="2">Wiele miejsc w wieloświecie obfituje w piękno, intensywne emocje i szalejącą magię; Feywild, Wyższe Plany i inne sfery nadprzyrodzonej mocy promieniują takimi siłami i mogą głęboko wpływać na ludzi. Jako ludzie o głębokich uczuciach barbarzyńcy są szczególnie podatni na te dzikie wpływy, a niektórzy barbarzyńcy ulegają przemianie pod wpływem magii. Ci przesiąknięci magią barbarzyńcy kroczą Ścieżką Dzikiej Magii. Barbarzyńcy elfowie, diabelstwa, aasimarowie i genasi często szukają tej ścieżki, pragnąc zamanifestować nieziemską magię swoich przodków.</content>
   <content contentuid="h9c95882dg83f6g1bbdg05f2geae221b89b7a" version="1">Fałszywe życie</content>
-  <content contentuid="h22179fdag3286gcd27g7facg8e73f5c76e01" version="3">Zyskujesz 2k4 +[1] &lt;LSTag Tooltip="TemporaryHitPoints"&gt;tymczasowe punkty wytrzymałości&lt;/LSTag&gt;.</content>
+  <content contentuid="h22179fdag3286gcd27g7facg8e73f5c76e01" version="3">Zyskujesz 2k4 + [1] &lt;LSTag Tooltip="TemporaryHitPoints"&gt;tymczasowe punkty wytrzymałości&lt;/LSTag&gt;.</content>
   <content contentuid="hd981160eg2361g96c5g14b2g6faa8b2cc888" version="1">Inwokacja: Fałszywe życie</content>
   <content contentuid="h7706db7cg7c7dgf09bg4d14gc9faed17fc8b" version="1">Fałszywe życie</content>
   <content contentuid="h64a85505gb9ccg347eg37efg4472a54e2380" version="1">Zdobyto 2k4+[1] &lt;LSTag Tooltip="TemporaryHitPoints"&gt;tymczasowe punkty wytrzymałości&lt;/LSTag&gt;.</content>


### PR DESCRIPTION
## Summary

- Restores the missing space in one temporary-hit-point formula: `2k4 +[1]` becomes `2k4 + [1]`.
- This matches the spacing in the English source and renders correctly as `2k4 + 1` after placeholder substitution.
- Changes only `Localization/Polish/polish.xml`.

## Validation

- 5,355/5,355 handles remain present, with all `contentuid` and `version` attributes unchanged.
- Localization, coverage, and spell audits report zero errors.
- The LanguageTool finding for this formula is resolved, with no new findings introduced.
