### PR TITLE
Standardize Polish Kalashtar terminology

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -4607,19 +4607,19 @@ Dampiry często powstają w wyniku spotkań z wampirami; niektórzy są potomkam
   <content contentuid="h4cdf86a0g7d76g2e84gd83dg6220d5a5ca95" version="1">Dampiry to żywi ludzie, którzy mają wampiryczne zdolności, ale są przeklęci makabrycznym głodem. Większość dampirów pragnie krwi, ale niektóre czerpią pożywienie ze snów, energii życiowej lub innych ważnych źródeł. Dampiry muszą wybrać, czy walczyć, aby kontrolować swój głód, czy poddać się drapieżnym pragnieniom.
 
 Dampiry często powstają w wyniku spotkań z wampirami; niektórzy są potomkami potężnego wampira, podczas gdy inni zostają częściowo przemienieni przez ukąszenie wampira. Wszelkiego rodzaju makabryczne targi i wpływy nekromantyczne mogą również dać początek dampirowi. Bez względu na pochodzenie, dampiry wykazują swoją wampirzą naturę na różne sposoby, w tym zwiększoną szybkość i wysysające życie ugryzienie.</content>
-  <content contentuid="h877ab541g5ce7g7a78g2577g02cab9025520" version="1">Kałasztar</content>
+  <content contentuid="h877ab541g5ce7g7a78g2577g02cab9025520" version="1">Kalashtar</content>
   <content contentuid="h0bb6e377geac3g99bdg6ae0gdd2ba3ffc657" version="1">Kalashtar (wymawiane kal-ASZ-tar) powstali z połączenia ludzi i zbuntowanych duchów zwanych quori ze sfery snów. Kalashtar wyglądają jak ludzie, ale ich duchowa więź wpływa na nich na różne sposoby. Mają symetryczne, lekko kanciaste rysy, a ich oczy często jaśnieją, gdy się koncentrują albo przeżywają silne emocje.</content>
-  <content contentuid="h0a563e02g95f0gd9e3g039ag98f3b4346158" version="1">Kałasztar</content>
+  <content contentuid="h0a563e02g95f0gd9e3g039ag98f3b4346158" version="1">Kalashtar</content>
   <content contentuid="hbccdb504gf83fgad58g2d25g913047122f49" version="1">Kalashtar (wymawiane kal-ASZ-tar) powstali z połączenia ludzi i zbuntowanych duchów zwanych quori ze sfery snów. Kalashtar wyglądają jak ludzie, ale ich duchowa więź wpływa na nich na różne sposoby. Mają symetryczne, lekko kanciaste rysy, a ich oczy często jaśnieją, gdy się koncentrują albo przeżywają silne emocje.</content>
   <content contentuid="hd5d6a1b0g7f08g3a12g364agc72eb40de46b" version="1">Dwoisty umysł</content>
   <content contentuid="ha8516a36g6307g1d10g28acge1491664cc54" version="1">Masz ułatwienie w rzutach obronnych na Mądrość i Charyzmę.</content>
   <content contentuid="hb34d9e37g9dacgc539ga29dgfa6196ae1daa" version="1">Dyscyplina umysłu</content>
   <content contentuid="hb138c39cgbb30gf571ga733gc5887d878bd0" version="1">Masz Odporność na obrażenia psychiczne.</content>
-  <content contentuid="ha860cb95g7c9ag10c1g85f5gc9e5b708f2a5" version="1">Kałasztar</content>
+  <content contentuid="ha860cb95g7c9ag10c1g85f5gc9e5b708f2a5" version="1">Kalashtar</content>
   <content contentuid="hd180b5fege06agd03ag32b2g4030476ac579" version="1">Kalashtar (wymawiane kal-ASZ-tar) powstali z połączenia ludzi i zbuntowanych duchów zwanych quori ze sfery snów. Kalashtar wyglądają jak ludzie, ale ich duchowa więź wpływa na nich na różne sposoby. Mają symetryczne, lekko kanciaste rysy, a ich oczy często jaśnieją, gdy się koncentrują albo przeżywają silne emocje.
 
 Kalashtar nie mogą komunikować się bezpośrednio ze swoimi duchami quori. Zamiast tego mogą doświadczać ich jako źródła instynktu i natchnienia, czerpiąc ze wspomnień duchów, gdy śpią. To połączenie daje Kalashtar drobne zdolności psioniczne, a także ochronę przed atakami psionicznymi.</content>
-  <content contentuid="hfa61106eg95adg47fbg8362gcbea543e7ea6" version="1">Kałasztar</content>
+  <content contentuid="hfa61106eg95adg47fbg8362gcbea543e7ea6" version="1">Kalashtar</content>
   <content contentuid="h7272c6b6gd59fg3f4dg8d02g45a02e4928d6" version="1">Kalashtar (wymawiane kal-ASZ-tar) powstali z połączenia ludzi i zbuntowanych duchów zwanych quori ze sfery snów. Kalashtar wyglądają jak ludzie, ale ich duchowa więź wpływa na nich na różne sposoby. Mają symetryczne, lekko kanciaste rysy, a ich oczy często jaśnieją, gdy się koncentrują albo przeżywają silne emocje.
 
 Kalashtar nie mogą komunikować się bezpośrednio ze swoimi duchami quori. Zamiast tego mogą doświadczać ich jako źródła instynktu i natchnienia, czerpiąc ze wspomnień duchów, gdy śpią. To połączenie daje Kalashtar drobne zdolności psioniczne, a także ochronę przed atakami psionicznymi.</content>


### PR DESCRIPTION
## Summary

- Standardizes four duplicated species title handles from `Kałasztar` to `Kalashtar`.
- `Kalashtar` is the form used throughout the corresponding Polish descriptions and in the established Polish community localization corpus, so this removes an internal terminology inconsistency.
- Changes only `Localization/Polish/polish.xml`.

## Validation

- 5,355/5,355 handles remain present, with all `contentuid` and `version` attributes unchanged.
- Localization, coverage, and spell audits report zero errors.
- All four title handles now match the terminology already used by their descriptions.
