### PR TITLE
Use Polish D&D 2024 Artificer terminology

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -3703,8 +3703,8 @@ Choć druidzi ci noszą w sobie chaos natury, trening i dyscyplina pozwalają im
   <content contentuid="hbbc19e32g5427g3585gaaabg3a72c966a807" version="1">Zadaj dodatkowe obrażenia od trucizny w liczbie równej &lt;LSTag Tooltip="ProficiencyBonus"&gt;premii z biegłości&lt;/LSTag&gt;. Po trafieniu otocz cel trującą chmurą, która może &lt;LSTag Type="Status" Tooltip="POISONED"&gt;zatruć&lt;/LSTag&gt; znajdujące się w niej istoty.</content>
   <content contentuid="hed352d94g7b9dg3b87g2d2bgb0b679111113" version="1">Przy trafieniu istnieje szansa na nałożenie stanu Płonięcia. Płonącym celom zadaje dodatkowe [1].</content>
   <content contentuid="hfc73e10fg17e9g9f07gc85fg541d0d54d67b" version="1">Raz na turę, gdy chybisz atakiem przeciwko celowi, możesz na [1] tur otoczyć go &lt;LSTag Type="Status" Tooltip="FAERIE_FIRE"&gt;Blaskiem faerie&lt;/LSTag&gt;.</content>
-  <content contentuid="h420e8530gf543gee3dg23ebg5105a14fcc37" version="1">Rzemieślnik</content>
-  <content contentuid="h2fdc2689g1529ge2b4gd969g4df570df4ae6" version="1">Rzemieślnicy są mistrzami wynalazczości. Za pomocą pomysłowości i magii wydobywają z przedmiotów niezwykłe możliwości. Postrzegają magię jako złożony system, który można rozszyfrować, a następnie wykorzystać w czarach i wynalazkach.</content>
+  <content contentuid="h420e8530gf543gee3dg23ebg5105a14fcc37" version="1">Wynalazca</content>
+  <content contentuid="h2fdc2689g1529ge2b4gd969g4df570df4ae6" version="1">Wynalazcy są mistrzami wynalazczości. Za pomocą pomysłowości i magii wydobywają z przedmiotów niezwykłe możliwości. Postrzegają magię jako złożony system, który można rozszyfrować, a następnie wykorzystać w czarach i wynalazkach.</content>
   <content contentuid="h3ff79f84g7162g193bg5ea1g2e4078a61d7e" version="1">Poziom 2: Replikuj magiczny przedmiot</content>
   <content contentuid="h45df701cg39aag071cg66aag602b1d91c8a1" version="1">Znasz tajemne schematy służące do tworzenia magicznych przedmiotów.
 
@@ -3736,7 +3736,7 @@ Z tej reakcji możesz skorzystać tyle razy, ile wynosi twój modyfikator Inteli
 
 Po zakończeniu długiego odpoczynku możesz utworzyć tylko jedną instancję każdego zreplikowanego przedmiotu. Istota może korzystać tylko z jednego replikowanego przedmiotu na raz.
 
-Tworzenie każdego replikowanego magicznego przedmiotu wymaga osiągnięcia określonego poziomu Rzemieślnika.</content>
+Tworzenie każdego replikowanego magicznego przedmiotu wymaga osiągnięcia określonego poziomu Wynalazcy.</content>
   <content contentuid="hb0fdd4d9g503ege786g4e88g495448e216a3" version="1">Jeśli posiadacz zda test &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medycyny&lt;/LSTag&gt; o ST 15, może wytworzyć dwa ekstrakty alchemiczne.</content>
   <content contentuid="hd8a61fbeg966eg2925g4b33g06cdd667a7db" version="1">Nośność nośnika zwiększa się dziesięciokrotnie.</content>
   <content contentuid="h0389208ag20a5gb33cgd6d4g1a76d494f34c" version="1">Nosiciel może widzieć przez ciemność, w tym ciemność magiczną.</content>
@@ -3791,13 +3791,13 @@ Z tej reakcji możesz skorzystać tyle razy, ile wynosi twój modyfikator Inteli
   <content contentuid="h7616ad89g71cag4308g0298ge537bbd04ae3" version="1">Alchemik</content>
   <content contentuid="hb0914d9fg1cd5gf675g447bg8f8c7b23a8bc" version="1">Alchemik jest ekspertem w łączeniu odczynników, aby wywoływać magiczne efekty. Alchemicy używają swoich tworów, by dawać życie i je wysysać.</content>
   <content contentuid="h6c2794d4g3126g3b3dg2ae1g7f34dee9cdc6" version="1">Poziom 3: Czary Alchemika</content>
-  <content contentuid="h99061a90g09cagcb07g6afegd32298d72981" version="1">Po osiągnięciu określonych poziomów Rzemieślnika zawsze masz przygotowane czary wskazane w tabeli Czarów Alchemika: na 3. poziomie — Kojące słowo i Promień zatrucia; na 5. poziomie — Płomienna kula i Kwasowa strzała Melfa; a na 9. poziomie — Forma gazowa i Masowe kojące słowo.</content>
+  <content contentuid="h99061a90g09cagcb07g6afegd32298d72981" version="1">Po osiągnięciu określonych poziomów Wynalazcy zawsze masz przygotowane czary wskazane w tabeli Czarów Alchemika: na 3. poziomie — Kojące słowo i Promień zatrucia; na 5. poziomie — Płomienna kula i Kwasowa strzała Melfa; a na 9. poziomie — Forma gazowa i Masowe kojące słowo.</content>
   <content contentuid="he9d21042g0c4ag847eg705agae859cb223ec" version="1">Poziom 3: Eksperymentalny eliksir</content>
   <content contentuid="h64879c2eg307fgbb40gef3egfe67041bc0cf" version="2">Po każdym długim odpoczynku, jeśli masz przy sobie przybory alchemika, możesz za ich pomocą magicznie stworzyć dwa eliksiry.
 
 Tworzenie dodatkowych eliksirów. Możesz zużyć jedną komórkę czaru, aby stworzyć kolejny eliksir.
 
-Po osiągnięciu określonych poziomów rzemieślnika tworzysz po każdym długim odpoczynku dodatkowy eliksir: łącznie trzy na 5. poziomie i cztery na 9. poziomie.</content>
+Po osiągnięciu określonych poziomów wynalazcy tworzysz po każdym długim odpoczynku dodatkowy eliksir: łącznie trzy na 5. poziomie i cztery na 9. poziomie.</content>
   <content contentuid="h9cb34817gce50g22afg8b5bgdd5576b387bd" version="1">Poziom 5: Alchemiczny erudyta</content>
   <content contentuid="h18867071gc581g6029g538cg5893e7b59e95" version="1">Za każdym razem, gdy rzucasz czar, używając Materiałów alchemicznych jako Magicznego Fokusa, dodajesz premię do jednego rzutu wykonywanego w ramach tego czaru. Musi to być rzut przywracający punkty wytrzymałości albo rzut na obrażenia od kwasu, ognia lub trucizny. Premia jest równa twojemu modyfikatorowi Inteligencji (co najmniej +1).</content>
   <content contentuid="h19ac5e59g8da4gab1egdd1ag819d6284a636" version="1">Poziom 9: Odczynniki regenerujące</content>
@@ -3876,7 +3876,7 @@ Jeden z paladynów zasłynął z wypowiedzi, w której jego święty mściciel b
   <content contentuid="ha0ef5bd2gf3e7g689cgef0egd528c73742ba" version="1">Paladyn i wszyscy sojusznicy w pobliżu zyskują &lt;LSTag Tooltip="Resistant"&gt;odporność&lt;/LSTag&gt; na obrażenia od czarów.</content>
   <content contentuid="hae58b170g1a86g562dg9c15gc5a91fb03fe1" version="1">&lt;LSTag Tooltip="Resistant"&gt;Odporność&lt;/LSTag&gt; na obrażenia od czarów rzucanych w promieniu [1] od paladyna.</content>
   <content contentuid="hda8b38bag9499g847bgcf99g9febaba0926a" version="1">Poziom 3: Czary płatnerza</content>
-  <content contentuid="hee79b7c5g14dagd8ecg3444ge2c7d3d25745" version="1">Po osiągnięciu określonych poziomów Rzemieślnika zawsze masz przygotowane czary wskazane w tabeli Czarów Płatnerza: na 3. poziomie — Magiczny pocisk i Fala gromu; na 5. poziomie — Lustrzane odbicia i Trzask; a na 9. poziomie — Hipnotyczny wzór i Błyskawica.</content>
+  <content contentuid="hee79b7c5g14dagd8ecg3444ge2c7d3d25745" version="1">Po osiągnięciu określonych poziomów Wynalazcy zawsze masz przygotowane czary wskazane w tabeli Czarów Płatnerza: na 3. poziomie — Magiczny pocisk i Fala gromu; na 5. poziomie — Lustrzane odbicia i Trzask; a na 9. poziomie — Hipnotyczny wzór i Błyskawica.</content>
   <content contentuid="h5e04a4b5g175bgdd37g3e7dgce0dab6d5f40" version="1">Poziom 3: Tajemna Zbroja</content>
   <content contentuid="h2d1fac5ag5486g7185gac07g348c2ae033ff" version="1">Jeśli zbroja zwykle wymaga siły, tajemna zbroja nie spełnia tego wymagania.</content>
   <content contentuid="hca9785d1g9483g710egfc60ga2d4f1dfeef6" version="1">Poziom 3: Model zbroi</content>
@@ -3897,7 +3897,7 @@ Olbrzymia postura. W ramach akcji dodatkowej przekształcasz i powiększasz swoj
   <content contentuid="h59b9ca7dgb3a7g13d9gaca8g5cb0cc11512f" version="1">Projektujesz zbroję z myślą o walce na pierwszej linii. Zapewnia następujące zdolności:
 
 Gromowy impuls. Uderzeniami zbroi możesz wyzwalać ogłuszające fale. Impuls jest prostą bronią do walki wręcz i przy trafieniu zadaje 1k8 obrażeń od dźwięku. Trafiona nim istota ma utrudnienie w testach ataku przeciwko celom innym niż ty do początku twojej następnej tury.
-Pole obronne. Gdy masz stan Zakrwawienia, możesz w ramach akcji dodatkowej zyskać tymczasowe punkty wytrzymałości w liczbie równej twojemu poziomowi Rzemieślnika. Tracisz je, jeśli zdejmiesz zbroję.</content>
+Pole obronne. Gdy masz stan Zakrwawienia, możesz w ramach akcji dodatkowej zyskać tymczasowe punkty wytrzymałości w liczbie równej twojemu poziomowi Wynalazcy. Tracisz je, jeśli zdejmiesz zbroję.</content>
   <content contentuid="h9d97ea6eg0369g70aag3edegb0ac7465f9b3" version="3">Dostosowujesz zbroję do bardziej dyskretnych przedsięwzięć. Zapewnia następujące zdolności:
 
 Wyrzutnia błyskawic. Na zbroi pojawia się węzeł przypominający klejnot, z którego możesz strzelać błyskawicami. Wyrzutnia jest prostą bronią dystansową i przy trafieniu zadaje 1k6 obrażeń od elektryczności. Raz w każdej swojej turze, gdy trafisz nią istotę, możesz zadać mu dodatkowe 1k6 obrażeń od elektryczności.
@@ -3940,18 +3940,18 @@ Infiltrator. Kość obrażeń Wyrzutni błyskawic zwiększa się do 2k6 obraże�
   <content contentuid="h0ca5e8d6gb9fdgdf73g977bgf17f49b479f7" version="1">Raz podczas każdej swojej tury, gdy trafisz istotę Wyrzutnią błyskawic, możesz zadać mu dodatkowe 1k6 obrażeń od elektryczności.</content>
   <content contentuid="hf5b8251dg37fag23degfd61gb647962089e3" version="1">Olbrzymia postura</content>
   <content contentuid="ha072f922ge3c6g116bgc7feg773bb825e8e2" version="1">Pole obronne</content>
-  <content contentuid="ha243be2aged30g4c6dg9dedge3df9a10db81" version="1">Będąc Zakrwawionym, możesz wykonać akcję dodatkową, aby zyskać tymczasowe punkty wytrzymałości równe twojemu poziomowi Rzemieślnika. Tracisz tymczasowe punkty wytrzymałości, jeśli zdejmiesz zbroję.</content>
+  <content contentuid="ha243be2aged30g4c6dg9dedge3df9a10db81" version="1">Będąc Zakrwawionym, możesz wykonać akcję dodatkową, aby zyskać tymczasowe punkty wytrzymałości równe twojemu poziomowi Wynalazcy. Tracisz tymczasowe punkty wytrzymałości, jeśli zdejmiesz zbroję.</content>
   <content contentuid="h1986e89ag8ebfg5144gcfc6g4888865326e5" version="1">Pole obronne</content>
   <content contentuid="h7564a2a6g104bg423egf734g715e17a86450" version="1">Przyznano [1].</content>
   <content contentuid="h90cf192bga720g4832g6e4dg0c99af7066d2" version="1">Przypływ adrenaliny</content>
   <content contentuid="heb8b42dfgf791g5695g2d5bg94d944d01b24" version="1">Artylerzysta</content>
   <content contentuid="he4ee4e0eg19a4gb02cgb58agdfdbd170d103" version="1">Artylerzysta specjalizuje się w używaniu magii do miotania energii, pocisków i eksplozji na polu walki.</content>
   <content contentuid="hb2e1a5b6gf536gee48g07d0g84251df2a247" version="1">Poziom 3: Czary artylerzysty</content>
-  <content contentuid="hb830b235g9469g7dd2ga75agc175eb448a0b" version="3">Po osiągnięciu określonych poziomów Rzemieślnika zawsze masz przygotowane następujące czary: na 3. poziomie — Tarcza i Fala gromu; na 5. poziomie — Wypalający promień i Trzask; a na 9. poziomie — Kula ognia i Przywołanie ognia zaporowego.</content>
+  <content contentuid="hb830b235g9469g7dd2ga75agc175eb448a0b" version="3">Po osiągnięciu określonych poziomów Wynalazcy zawsze masz przygotowane następujące czary: na 3. poziomie — Tarcza i Fala gromu; na 5. poziomie — Wypalający promień i Trzask; a na 9. poziomie — Kula ognia i Przywołanie ognia zaporowego.</content>
   <content contentuid="h8972d6f1gb973gb24eg4f39ga448bf22f9f4" version="1">Poziom 3: Mistyczne działo</content>
   <content contentuid="hee38cff0g9a4fg5a8dgfbf6g69eae04525e5" version="1">Możesz stworzyć na swojej dłoni Malutkie Mistyczne działo. Ty decydujesz o jego wyglądzie i o tym, czy je nosisz; może na przykład mieć nogi albo koła.</content>
   <content contentuid="hc7dd7a10g7e44gb9a6gc6bfgcc7a3d89e928" version="1">Poziom 5: Tajemna broń palna</content>
-  <content contentuid="hd05b9c65g79acgf13egbf4ag94ac102d1cb3" version="1">Możesz używać swojej Tajemnej broni palnej jako Magicznego Fokusa dla czarów Rzemieślnika. Gdy rzucasz przez nią czar Rzemieślnika, rzuć 1k8. Do jednego rzutu na obrażenia tego czaru dodajesz premię równą uzyskanemu wynikowi.</content>
+  <content contentuid="hd05b9c65g79acgf13egbf4ag94ac102d1cb3" version="1">Możesz używać swojej Tajemnej broni palnej jako Magicznego Fokusa dla czarów Wynalazcy. Gdy rzucasz przez nią czar Wynalazcy, rzuć 1k8. Do jednego rzutu na obrażenia tego czaru dodajesz premię równą uzyskanemu wynikowi.</content>
   <content contentuid="h3b11a6dfg7408ga680gbdf9g27b20bb02003" version="1">Poziom 9: Działo wybuchowe</content>
   <content contentuid="hb63bc4e3g2375g28c1gc6f9g87176ffa864b" version="2">Tworzone przez ciebie Mistyczne działo staje się bardziej niszczycielskie i zapewnia następujące korzyści.
 
@@ -4063,13 +4063,13 @@ Kensei postrzega broń w podobny sposób, w jaki kaligraf lub malarz postrzega p
   <content contentuid="h7e5c8452ge0d5g2610g45eagca1b87277e92" version="1">Naostrz ostrze</content>
   <content contentuid="hb071d3c2g373ag7bc8gf0d5g10bf8a344624" version="1">Potrafisz dodatkowo wzmacniać swoją broń za pomocą ki. W ramach akcji dodatkowej możesz wydać 1 punkt ki, aby dotknięta przez ciebie broń kensei zyskała premię do testów ataku i rzutów na obrażenia. Premia utrzymuje się przez 1 minutę albo do ponownego użycia tej zdolności.</content>
   <content contentuid="hed8eb390g17b2g994bg8cfdg02107c263310" version="1">Poziom 3: Czary kowala bitewnego</content>
-  <content contentuid="hd22a1ff8gaca7gd01cg610fgbe3a8ed48875" version="1">Od 3. poziomu zawsze masz przygotowane określone czary po osiągnięciu wskazanych poziomów tej klasy. Są dla ciebie czarami Rzemieślnika, ale nie wliczają się do liczby czarów Rzemieślnika, które możesz przygotować. Na 3. poziomie są to Heroizm i Tarcza; na 5. poziomie — Piętnujące ugodzenie i Ochronna więź; a na 9. poziomie — Aura witalności i Przywołanie ognia zaporowego.</content>
+  <content contentuid="hd22a1ff8gaca7gd01cg610fgbe3a8ed48875" version="1">Od 3. poziomu zawsze masz przygotowane określone czary po osiągnięciu wskazanych poziomów tej klasy. Są dla ciebie czarami Wynalazcy, ale nie wliczają się do liczby czarów Wynalazcy, które możesz przygotować. Na 3. poziomie są to Heroizm i Tarcza; na 5. poziomie — Piętnujące ugodzenie i Ochronna więź; a na 9. poziomie — Aura witalności i Przywołanie ognia zaporowego.</content>
   <content contentuid="h1276ad5dgc82ag3397g6f0bgb0f6dfda70ed" version="1">Poziom 3: Gotowy do bitwy</content>
   <content contentuid="h203da993gc56cg398cg8dc3g00fec0e594ca" version="2">Twoje wyszkolenie bojowe i eksperymenty z magią przyniosły efekty na dwa sposoby.
 
 Magiczne wzmocnienie. Gdy atakujesz magiczną bronią, możesz użyć swojego modyfikatora Inteligencji zamiast modyfikatora Siły lub Zręczności do testów ataku i rzutów na obrażenia.
 
-Obeznanie z bronią. Zyskujesz biegłość w broniach żołnierskich. Możesz używać broni, w której masz biegłość, jako Magicznego Fokusu dla swoich czarów Rzemieślnika.</content>
+Obeznanie z bronią. Zyskujesz biegłość w broniach żołnierskich. Możesz używać broni, w której masz biegłość, jako Magicznego Fokusu dla swoich czarów Wynalazcy.</content>
   <content contentuid="hd5cef72fg7633gfff7g44f5g7c4e863fdc13" version="1">Gotowość bojowa</content>
   <content contentuid="h9e3e17e5gec22g340bgdae4g359fcaa6dc68" version="1">Kiedy atakujesz magiczną bronią, możesz użyć swojego modyfikatora Inteligencji zamiast modyfikatora Siły lub Zręczności, do testów ataku i rzutów na obrażenia.</content>
   <content contentuid="h41d2ff5cgefb3g4750gfbbfg9ce76cd22456" version="1">Poziom 3: Stalowy Obrońca</content>
@@ -4402,7 +4402,7 @@ Przy powodzeniu cel otrzymuje tylko połowę obrażeń.</content>
   <content contentuid="h7b203ccagf3bbgbc50ge697g2f7d6dd55d71" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="h5cc2b487g9e1cg67f3gff45gb8bebf140d50" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="h81b6ff86g5390gac9bg1d77ga53e64111601" version="1">Dostępne klasy: Zaklinacz, Mag</content>
-  <content contentuid="hab99ff93g3f23gd11egb0f9gbffa91781c6a" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Mag</content>
+  <content contentuid="hab99ff93g3f23gd11egb0f9gbffa91781c6a" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Mag</content>
   <content contentuid="hc5d990c5g4bc9g584ag42c3g14e89f46c133" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
   <content contentuid="hea71fda5ge282g59e5g6655g9ddd810de96b" version="1">Dostępne klasy: Druid, Zaklinacz</content>
   <content contentuid="h9a00c633g9e59gdb51g8d17g33a090a4b718" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
@@ -4416,12 +4416,12 @@ Przy powodzeniu cel otrzymuje tylko połowę obrażeń.</content>
   <content contentuid="h5b9af6b6g0fb9g76bfge6acg31f03b6be9ab" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h081d2ca7g938fg7b8cgabc2g3ebfd3f20918" version="2">Dostępne klasy: Bard, Kleryk, Druid, Mag</content>
   <content contentuid="h9ce29b2fg9512g42fcg0bb3g0130eac87437" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
-  <content contentuid="hb5449aaeg0cdag7016g618ag5818eb654495" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="hb5449aaeg0cdag7016g618ag5818eb654495" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h8ce9a23egb8a0gb9d7gd45fga0d286bbc402" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="hc21389d1g0818gfd8cg1028g98e4b6dfab5f" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h99da7e22g12afgd783gdbf2gc858ed098a7c" version="1">Dostępne klasy: Zaklinacz, Mag</content>
-  <content contentuid="ha12ea06dg5003g6e60gc979g1f90ad6c1484" version="1">Dostępne klasy: Rzemieślnik, Bard, Kleryk, Mag</content>
-  <content contentuid="h53ebe725g777bg732bgd58fg65c4f7d7f4a5" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Mag</content>
+  <content contentuid="ha12ea06dg5003g6e60gc979g1f90ad6c1484" version="1">Dostępne klasy: Wynalazca, Bard, Kleryk, Mag</content>
+  <content contentuid="h53ebe725g777bg732bgd58fg65c4f7d7f4a5" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Mag</content>
   <content contentuid="hb1711043gacb3g9782g2cf8g32a2ec0ff2ea" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hdd2cf90fg0261g02b3gae25gfb176a817222" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h62899232g86b6gcbbag7509g512371a04a09" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
@@ -4430,19 +4430,19 @@ Przy powodzeniu cel otrzymuje tylko połowę obrażeń.</content>
   <content contentuid="he09832a9g1034gf61eg906bg73be5b1aa940" version="1">Dostępne klasy: Bard, Mag</content>
   <content contentuid="h871fa494g4b4eg1958g9389g7d0935b4ff7b" version="1">Dostępne klasy: Bard, Kleryk, Druid, Czarownik, Mag</content>
   <content contentuid="h631b429cg3757gfc36gdba0ga51c780084b6" version="1">Dostępne klasy: Bard, Druid, Zaklinacz, Mag</content>
-  <content contentuid="hf991584cg399dge2a2g8552gf07ff0b4b8d3" version="1">Dostępne klasy: Rzemieślnik, Kleryk, Druid, Łowca, Zaklinacz, Mag</content>
-  <content contentuid="h8b5be3bcge99dg7031gbde6g1d904a4e7ab7" version="1">Dostępne klasy: Rzemieślnik, Mag</content>
+  <content contentuid="hf991584cg399dge2a2g8552gf07ff0b4b8d3" version="1">Dostępne klasy: Wynalazca, Kleryk, Druid, Łowca, Zaklinacz, Mag</content>
+  <content contentuid="h8b5be3bcge99dg7031gbde6g1d904a4e7ab7" version="1">Dostępne klasy: Wynalazca, Mag</content>
   <content contentuid="h068c31d3g6f3aga38cg1f1bgb356fb37a648" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
   <content contentuid="h89e4c126g6369g3dfegb0bdg2f6aceb008b9" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
   <content contentuid="h094ae749g82a5g27f5g5963g3c4b4de8ae2a" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
   <content contentuid="h96da94d7gf3f8g932bgd0d2g8c8fecea83ea" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
-  <content contentuid="hcb7bb507ge7f5g0a9egc740gd2e42ec643dd" version="1">Dostępne klasy: Rzemieślnik, Druid, Łowca, Zaklinacz, Mag</content>
+  <content contentuid="hcb7bb507ge7f5g0a9egc740gd2e42ec643dd" version="1">Dostępne klasy: Wynalazca, Druid, Łowca, Zaklinacz, Mag</content>
   <content contentuid="h490fc0dege26fg9f86gebe5ge9fe1504744d" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h405a2a4dgacbdgeb6bg4dcfg074c58afd9b7" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h498bbe50g966fg2071g8171gfed451e31514" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="h265185b6gb7e4gbe1dgf258g5b026be55064" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
   <content contentuid="hfd8df497g28c9g3b75gc242gfa87f646de28" version="1">Dostępne klasy: Mag</content>
-  <content contentuid="h76da8d92g272dgb35ag7f49g0604c8aceb3f" version="1">Dostępne klasy: Rzemieślnik, Druid, Zaklinacz, Mag</content>
+  <content contentuid="h76da8d92g272dgb35ag7f49g0604c8aceb3f" version="1">Dostępne klasy: Wynalazca, Druid, Zaklinacz, Mag</content>
   <content contentuid="h43586658g7269g4ac9g84f4g92239e7e5113" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
   <content contentuid="h82fcd113g91bcg7a32g7db2g7a9bb77bc1a9" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h0d09994cgb932g4c8bg28b6g6a5d21972441" version="1">Dostępne klasy: Zaklinacz, Mag</content>
@@ -5316,11 +5316,11 @@ Zasięg twoich ataków bez broni zwiększa się o 1,5 m.</content>
   <content contentuid="h73c88544g3627g41a6gbe73g7f725f7093ce" version="1">Dostępne klasy: Mag</content>
   <content contentuid="h9036825bg9a32g4e70g8c69gf202e0ae6384" version="1">Dostępne klasy: Paladyn</content>
   <content contentuid="h5f032521g0f3bg457agaca7g37bad35cd378" version="1">Dostępne klasy: Kleryk, Druid, Paladyn, Czarownik, Mag</content>
-  <content contentuid="h0c4ae731g86b7g4cddg9448g2ec70d8c41e3" version="1">Dostępne klasy: Mag, Rzemieślnik</content>
+  <content contentuid="h0c4ae731g86b7g4cddg9448g2ec70d8c41e3" version="1">Dostępne klasy: Mag, Wynalazca</content>
   <content contentuid="h3caacbafgd256g4d2bga846g1e0e85d5bfd9" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="ha43d0c84g7029g4bb4g91b9g40464ff2451d" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
-  <content contentuid="h0f476bcdg9eefg4e31ga725g8d2b8048b540" version="1">Dostępne klasy: Mag, Rzemieślnik</content>
-  <content contentuid="he3ed5607gfd3bg4037g8cedg98e1474da744" version="1">Dostępne klasy: Druid, Łowca, Zaklinacz, Mag, Rzemieślnik</content>
+  <content contentuid="h0f476bcdg9eefg4e31ga725g8d2b8048b540" version="1">Dostępne klasy: Mag, Wynalazca</content>
+  <content contentuid="he3ed5607gfd3bg4037g8cedg98e1474da744" version="1">Dostępne klasy: Druid, Łowca, Zaklinacz, Mag, Wynalazca</content>
   <content contentuid="h850611abg9fa9g4ef3ga920g342e381d85db" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h157bc8b6g7bd3g42b6gb126g8844ae4e6897" version="1">Dostępne klasy: Mag</content>
   <content contentuid="hf517cb38gb91fg4b74g9651g9d26b04c4a4f" version="1">Dostępne klasy: Zaklinacz, Mag</content>
@@ -5328,7 +5328,7 @@ Zasięg twoich ataków bez broni zwiększa się o 1,5 m.</content>
   <content contentuid="h07c5d370g49d6g4466ga8deg9b86e982e5dd" version="1">Dostępne klasy: Bard, Druid, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h5545fdeegaf71g4a87gb389g8b033c437233" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
   <content contentuid="h09f480c3g2968g4108g955cg52ea764a99e8" version="1">Dostępne klasy: Zaklinacz, Mag</content>
-  <content contentuid="ha6524e13ga393g46c6g81ccg8c0505a61fa6" version="1">Dostępne klasy: Bard, Zaklinacz, Mag, Rzemieślnik</content>
+  <content contentuid="ha6524e13ga393g46c6g81ccg8c0505a61fa6" version="1">Dostępne klasy: Bard, Zaklinacz, Mag, Wynalazca</content>
   <content contentuid="hfdc5321bg8e80g4295gab40g23fc855ca270" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
   <content contentuid="h989195e0gd334g4d2fga48cg60ac72b1b1d9" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="h5198c509gbadfg4c26g8450g1fc86eb31633" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
@@ -5340,38 +5340,38 @@ Zasięg twoich ataków bez broni zwiększa się o 1,5 m.</content>
   <content contentuid="he9329f83ga933g46dfgabd0g37d583feacd1" version="1">Dostępne klasy: Kleryk, Paladyn</content>
   <content contentuid="h61e1a792g9f16g4e16ga50dg0ee6c9c7ccb1" version="1">Dostępne klasy: Bard, Kleryk, Druid, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h552f275cgee76g4947ga777g927bce86aa21" version="1">Dostępne klasy: Druid, Łowca, Zaklinacz, Mag</content>
-  <content contentuid="h54e64aa9g3189g44e2gbf65g0425fd20f75f" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag, Rzemieślnik</content>
+  <content contentuid="h54e64aa9g3189g44e2gbf65g0425fd20f75f" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag, Wynalazca</content>
   <content contentuid="hc98b225eg8da0g4e31g8bc5g876e89935b90" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hf769e1e7g4972g4edbg966dgd4372642ed9d" version="1">Dostępne klasy: Druid, Łowca</content>
-  <content contentuid="h701629dfgc58dg4887g8faeg08469d671d32" version="1">Dostępne klasy: Bard, Druid, Zaklinacz, Mag, Rzemieślnik</content>
-  <content contentuid="haedcf633gdecdg416aga1c4gacc76d9402eb" version="1">Dostępne klasy: Zaklinacz, Mag, Rzemieślnik</content>
-  <content contentuid="h6b900209g8da2g4792gaf6dge1c9ef17c58a" version="1">Dostępne klasy: Bard, Druid, Łowca, Mag, Rzemieślnik</content>
+  <content contentuid="h701629dfgc58dg4887g8faeg08469d671d32" version="1">Dostępne klasy: Bard, Druid, Zaklinacz, Mag, Wynalazca</content>
+  <content contentuid="haedcf633gdecdg416aga1c4gacc76d9402eb" version="1">Dostępne klasy: Zaklinacz, Mag, Wynalazca</content>
+  <content contentuid="h6b900209g8da2g4792gaf6dge1c9ef17c58a" version="1">Dostępne klasy: Bard, Druid, Łowca, Mag, Wynalazca</content>
   <content contentuid="h57f41308g4badg4fe3gaac6gcc36d4dc3d8b" version="1">Dostępne klasy: Zaklinacz, Mag</content>
-  <content contentuid="h65bcba2fg62dfg4712gaae5g9ffa44f4a2b8" version="1">Dostępne klasy: Bard, Zaklinacz, Mag, Rzemieślnik</content>
+  <content contentuid="h65bcba2fg62dfg4712gaae5g9ffa44f4a2b8" version="1">Dostępne klasy: Bard, Zaklinacz, Mag, Wynalazca</content>
   <content contentuid="hd0f8bef5g3744g473bgb6f7g416cd1b21776" version="1">Dostępne klasy: Bard, Czarownik, Mag</content>
   <content contentuid="h9f107cbeg704cg4efdg80f3gae22cf746ff8" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="h4e563d34g5893g4564g93d3gbe30f8798c6d" version="1">Dostępne klasy: Bard, Druid, Zaklinacz, Mag</content>
   <content contentuid="h45afcc46g07e8g413ega467g1230c256bb27" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hd6dbd33fg0848g46bdg93d0ga604e88b0045" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h29717b0bgc570g4958gae52g7e29bf101fb7" version="1">Dostępne klasy: Mag</content>
-  <content contentuid="h57a34188gbe1dg4aecg9436g26c503c38ca5" version="1">Dostępne klasy: Zaklinacz, Mag, Rzemieślnik</content>
+  <content contentuid="h57a34188gbe1dg4aecg9436g26c503c38ca5" version="1">Dostępne klasy: Zaklinacz, Mag, Wynalazca</content>
   <content contentuid="ha55948cag17d3g4aa3gae23ga952030cb26c" version="1">Dostępne klasy: Mag</content>
-  <content contentuid="ha069636bg3b39g4b50gae6fg37e461b68a60" version="1">Dostępne klasy: Bard, Zaklinacz, Mag, Rzemieślnik</content>
+  <content contentuid="ha069636bg3b39g4b50gae6fg37e461b68a60" version="1">Dostępne klasy: Bard, Zaklinacz, Mag, Wynalazca</content>
   <content contentuid="hc7c2f070g087bg4664ga8d0gf731f76c0a06" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="hda5eeb36gf99bg4cc8gb43egb740c1c24b98" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hea2bda2fgbe08g4ab1g8a22g7f50ccea400e" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
   <content contentuid="h0936d3bbg9d40g4b82g991bg63f298cdd927" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
-  <content contentuid="h25ea32bcgf38dg464dg8a09g608fa6283272" version="1">Dostępne klasy: Paladyn, Łowca, Zaklinacz, Mag, Rzemieślnik</content>
+  <content contentuid="h25ea32bcgf38dg464dg8a09g608fa6283272" version="1">Dostępne klasy: Paladyn, Łowca, Zaklinacz, Mag, Wynalazca</content>
   <content contentuid="h99cdb013gd519g46c8g8ee7g88ce569e971b" version="1">Dostępne klasy: Czarownik, Mag</content>
   <content contentuid="he7c90888g22e0g4d75g85f4g768f561d6f30" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="had587edfg3e1eg46a6g88e9gba4983e47b20" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="hbbbaa8ebg9199g46ffgbeafg104d39c86b43" version="1">Dostępne klasy: Druid, Łowca</content>
   <content contentuid="h2223a50agc511g4d44gb143g94f0113311a5" version="1">Dostępne klasy: Mag</content>
-  <content contentuid="h0991a1dfgb4b0g45eagbbb3ga5ae65a31f0e" version="1">Dostępne klasy: Druid, Łowca, Zaklinacz, Mag, Rzemieślnik</content>
+  <content contentuid="h0991a1dfgb4b0g45eagbbb3ga5ae65a31f0e" version="1">Dostępne klasy: Druid, Łowca, Zaklinacz, Mag, Wynalazca</content>
   <content contentuid="hca88c584g8a5bg4e69g9eb7g5af56d234776" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h37934098g756eg4431gaed9g88557c60ee6e" version="1">Dostępne klasy: Zaklinacz, Mag</content>
   <content contentuid="h482dd2dbg9946g4f59g93baga4c4928fd097" version="1">Dostępne klasy: Bard, Kleryk, Paladyn, Mag</content>
-  <content contentuid="h2c2386e2g0722g480egaa8ag57417fd707f9" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag, Rzemieślnik</content>
+  <content contentuid="h2c2386e2g0722g480egaa8ag57417fd707f9" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag, Wynalazca</content>
   <content contentuid="h6d713dd0gf384g4e20g81f0g0a61b2b73a86" version="1">Dostępne klasy: Druid, Zaklinacz, Mag</content>
   <content contentuid="h102dd2b4gf963g41a5g8094g52a0af052bf9" version="1">Dostępne klasy: Mag</content>
   <content contentuid="hed54d08eg254egab54g634egc5696f632258" version="1">Mistyczne ugodzenie (dystansowe)</content>
@@ -5630,11 +5630,11 @@ Następnie możesz wydać swoją akcję, aby poruszyć się na odległość do 6
 Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzymałości w liczbie równej połowie otrzymanych przez niego obrażeń nekrotycznych.</content>
   <content contentuid="h6f070cfeg02fbgebecga6d1gb5a5d6ee555e" version="1">Cel Wyczerpania</content>
   <content contentuid="hf4df8f40g734eg4a1cgb8fagea08b40b8073" version="5">Zwój balistycznego ugodzenia</content>
-  <content contentuid="hb8962a55g8344g4835ga773g610c4b802669" version="5">Dostępne klasy: Rzemieślnik, Paladyn</content>
+  <content contentuid="hb8962a55g8344g4835ga773g610c4b802669" version="5">Dostępne klasy: Wynalazca, Paladyn</content>
   <content contentuid="h3ef06543gb18dg44b9gb236g44997392d5a6" version="1">Zwój wypaczenia ciała Gorgorotha</content>
   <content contentuid="h048e9757gf877g4790g9da6ga7ed07014d56" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h21f28158g6fd4g4f13gaeb5g46ebd693793f" version="1">Zwój katapulty</content>
-  <content contentuid="h36ab8ce6g4ba6g476ag8f30ga885fc028382" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Mag</content>
+  <content contentuid="h36ab8ce6g4ba6g476ag8f30ga885fc028382" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Mag</content>
   <content contentuid="hb76f98a1gdaddg4951gb182gc6db746c906f" version="1">Zwój głodnego ostrza</content>
   <content contentuid="h865d57bag46d3g4e6egb4b9g4b2be8c9fa2e" version="1">Dostępne klasy: Paladyn, Łowca, Czarownik</content>
   <content contentuid="h96f8024cg9940g41e2g8738g75f648f13e41" version="1">Zwój widmowego cięcia</content>
@@ -5648,7 +5648,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="h365e83bfgbaa3g4ed5g8b43gf8e3cb6b0f1b" version="1">Zwój gniewnego ugodzenia</content>
   <content contentuid="h2d010845g555bg4d03g8d82gd5d53c0a75e7" version="1">Dostępne klasy: Paladyn</content>
   <content contentuid="h29012509g9a1ag4f12gb771g80fea8b18f27" version="1">Zwój kroku Ashardalona</content>
-  <content contentuid="ha87130cag43b6g43aagb72eg9039f36dbbf5" version="1">Dostępne klasy: Rzemieślnik, Łowca, Zaklinacz, Mag</content>
+  <content contentuid="ha87130cag43b6g43aagb72eg9039f36dbbf5" version="1">Dostępne klasy: Wynalazca, Łowca, Zaklinacz, Mag</content>
   <content contentuid="h1e76b51fg30f1g4826gbff9g56fb7ca775d4" version="1">Zwój kakofonicznej tarczy</content>
   <content contentuid="hd129c79fg4974g4468gbeccgb1048964db88" version="1">Dostępne klasy: Bard, Zaklinacz, Mag</content>
   <content contentuid="h6fd871efg483cg46a3g84e7g5145abb4d358" version="1">Zwój zionięcia żywiołu</content>
@@ -5664,17 +5664,17 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="h713b476fg66a5g4653ga065gd0eabad305c9" version="1">Zwój wyczerpania</content>
   <content contentuid="h4b7db2ffg085fg4b20g8ed8g4d26a4634f00" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h1fb28cd1g312fg4a30g9c6fg88c9d787974a" version="1">Zwój smoczego zionięcia</content>
-  <content contentuid="h43c7ed41g0c76g4c1cg8555g3622987390d2" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Mag</content>
+  <content contentuid="h43c7ed41g0c76g4c1cg8555g3622987390d2" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Mag</content>
   <content contentuid="h68f18197gef59g4d42g89d4g359f077b2f65" version="1">Zwój kręgu mocy</content>
   <content contentuid="h45bfef77gc136g4fcdga0c9g905ed940113b" version="1">Dostępne klasy: Kleryk, Mag</content>
   <content contentuid="h7a6dd032g8505g4c5agb68cgdd27768b296f" version="1">Zwój nieziemskiego uderzenia</content>
   <content contentuid="hb8333042ga43bg4fb8g9ebegc1dc00106cdc" version="1">Dostępne klasy: Czarownik</content>
   <content contentuid="h01124f5bg5522g461dgb0aeg4f68be71b1c3" version="1">Zwój pistoletów z palców</content>
-  <content contentuid="hefcb8274gb96dg453agbff3g26f6c5ec90ae" version="1">Dostępne klasy: Rzemieślnik, Bard, Zaklinacz, Mag</content>
+  <content contentuid="hefcb8274gb96dg453agbff3g26f6c5ec90ae" version="1">Dostępne klasy: Wynalazca, Bard, Zaklinacz, Mag</content>
   <content contentuid="h32cb692bgdd16g43c9g892dg3c4da0676c57" version="1">Zwój przerażającego początku</content>
   <content contentuid="h7f53e712g4b92g496egad03gd289e5e44822" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h177e18f7g6dc3g474bg9532g74fcb3c4f440" version="1">Zwój ostrza zielonego płomienia</content>
-  <content contentuid="h2b6b0081g8d02g432fga25fg5cea43d6ad1d" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="h2b6b0081g8d02g432fga25fg5cea43d6ad1d" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hbde1c1b9g49b7g4bf5gb05bgb6e611fc395a" version="1">Zwój ognia piekielnego</content>
   <content contentuid="h19ef7182g0461g4729g9bd7gb3a83834d046" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h807cf0e0gb4e2g4ca7g8b0agbe30dda8c3ee" version="1">Zwój świętego słowa</content>
@@ -5682,13 +5682,13 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="h3eefa19dg5779g4ec2gab7bg0b4ec8deb583" version="1">Zwój myślowego odłamka</content>
   <content contentuid="h36b9bd7cgd3ffg4451gab20g2407d989d8c1" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h1e4e1990g501dg4f11g8b2egf4a3766ee6ad" version="1">Zwój powstrzymania śmierci</content>
-  <content contentuid="h65a17f23g538bg4660g8ddcgf15764bb8f9c" version="1">Dostępne klasy: Rzemieślnik, Kleryk, Druid</content>
+  <content contentuid="h65a17f23g538bg4660g8ddcgf15764bb8f9c" version="1">Dostępne klasy: Wynalazca, Kleryk, Druid</content>
   <content contentuid="haddbee20g6f91g4707gb100g19e0d1c9979d" version="1">Zwój gwiezdnego ognika</content>
   <content contentuid="h7923fe7dg7483g4e09gb200g403b36ab0c43" version="1">Dostępne klasy: Bard, Druid</content>
   <content contentuid="h398e6d03gc7e5g4d33g9722gbd9206f05133" version="1">Zwój wybuchu miecza</content>
-  <content contentuid="he6a9e927g508eg48ebgbe13g101b2c1e7adb" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="he6a9e927g508eg48ebgbe13g101b2c1e7adb" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hfbe03474g4d63g47c6ga736gb204c33c193f" version="1">Zwój grzmotu</content>
-  <content contentuid="h7e719dddg56a4g4792g9d5fgebc975efc849" version="1">Dostępne klasy: Rzemieślnik, Bard, Druid, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="h7e719dddg56a4g4792g9d5fgebc975efc849" version="1">Dostępne klasy: Wynalazca, Bard, Druid, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h303255c0g1aceg4f8fg8a84gd85c4d39af19" version="1">Zwój mściwego ostrza</content>
   <content contentuid="hc805ebbcg7821g44d9g89b8g04dbf30e50fe" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h934a6c93ge8fbg41e6g9e9dg8ff631afa06e" version="1">Zwój słowa blasku</content>
@@ -5698,7 +5698,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="hcb30eea5g0d75g45adgb302g4835f16ea7af" version="1">Zwój widmowego wierzchowca</content>
   <content contentuid="h54acce3ag0998g4f67g829eg1a3af0043508" version="1">Dostępne klasy: Mag</content>
   <content contentuid="h98058138gc85fg4eeagb856g0f31a491a570" version="1">Zwój grzmiącego ostrza</content>
-  <content contentuid="h2c792efagc3c7g448eg8c6ag52bf02b25d32" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="h2c792efagc3c7g448eg8c6ag52bf02b25d32" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h4c544d69g6d1fg46fegb8a2g30a5726c36e2" version="1">Zwój wybuchu mocy</content>
   <content contentuid="h4a5affa6g47b3g4704gb66dg389fd6211b47" version="1">Dostępne klasy: Zaklinacz</content>
   <content contentuid="h483976a4g540ag445dgb277gb00b31441f0c" version="1">Zwój uroku</content>
@@ -5708,29 +5708,29 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="ha0cd15ddg0aabg4626gb9e7g4247772148ba" version="3">Pantera</content>
   <content contentuid="hf7fc2047ga596g401dg9482gcb6cc2037cf9" version="3">Tygrys szablozębny</content>
   <content contentuid="h7b45a178g006bg4210gb636g69e7b0272a40" version="1">Zwój kwasowego rozprysku</content>
-  <content contentuid="h42e7c0a6g17efg428dg8696g5e39b360bf45" version="1">Dostępne klasy: Rzemieślnik, Zaklinacz, Mag</content>
+  <content contentuid="h42e7c0a6g17efg428dg8696g5e39b360bf45" version="1">Dostępne klasy: Wynalazca, Zaklinacz, Mag</content>
   <content contentuid="hf156bfc1gdd2eg4f41gad34g1c9eb6624388" version="1">Zwój osłony przed orężem</content>
   <content contentuid="h442b48b7g5fd1g45bfgb68bgc8dc56f80471" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h9e4e7db2g8e7bg46eega5f1gdb891d8cf6e0" version="1">Zwój pękającego ścięgna</content>
   <content contentuid="hf86775abg3ed7g414cga752g2779876b3c2b" version="1">Dostępne klasy: Kleryk, Zaklinacz, Mag</content>
   <content contentuid="h78290588g0282g4151g95cag5baef69c1634" version="1">Zwój tańczących świateł</content>
-  <content contentuid="ha1e89b4eg8d92g4aecg97e6g412ea9b904ac" version="1">Dostępne klasy: Rzemieślnik, Bard, Zaklinacz, Mag</content>
+  <content contentuid="ha1e89b4eg8d92g4aecg97e6g412ea9b904ac" version="1">Dostępne klasy: Wynalazca, Bard, Zaklinacz, Mag</content>
   <content contentuid="h2104ae25g8fedg4919gb897gadbc9e42ee72" version="1">Zwój przyjaźni</content>
   <content contentuid="h8b7b0898gbdedg4063g9934gc756b66c18e9" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hd6c2558bgc523g47bcgb14ag057c67c1c3a8" version="1">Zwój wskazówek</content>
-  <content contentuid="h81ca2d82g0058g40b9g822eg48d00fa390f1" version="1">Dostępne klasy: Rzemieślnik, Kleryk, Druid</content>
+  <content contentuid="h81ca2d82g0058g40b9g822eg48d00fa390f1" version="1">Dostępne klasy: Wynalazca, Kleryk, Druid</content>
   <content contentuid="hb579f1c3gfd84g4b25ga4eagc3746dba60c9" version="1">Zwój światła</content>
-  <content contentuid="hbbfea48fg9939g4a68g9f77g75b827833bb9" version="1">Dostępne klasy: Rzemieślnik, Bard, Kleryk, Zaklinacz, Mag</content>
+  <content contentuid="hbbfea48fg9939g4a68g9f77g75b827833bb9" version="1">Dostępne klasy: Wynalazca, Bard, Kleryk, Zaklinacz, Mag</content>
   <content contentuid="h72cfddcagd9adg46e5g9370g300ae4624cf3" version="1">Zwój magicznej dłoni</content>
-  <content contentuid="h64daa63ag9736g4405gbd0fgb7a1a6818a53" version="1">Dostępne klasy: Rzemieślnik, Bard, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="h64daa63ag9736g4405gbd0fgb7a1a6818a53" version="1">Dostępne klasy: Wynalazca, Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h06c20aa3ga24ag4712g8d65gef0c57b09d88" version="1">Zwój pomniejszej iluzji</content>
   <content contentuid="h51f7caaeg9372g4e86gaf59g32f47c7ca3fd" version="1">Dostępne klasy: Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h80896363g0d60g4d9aga98dg6683f010415d" version="1">Zwój trującego rozprysku</content>
-  <content contentuid="h47e76386g3be1g40b1g97deg21f1ba49349a" version="1">Dostępne klasy: Rzemieślnik, Druid, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="h47e76386g3be1g40b1g97deg21f1ba49349a" version="1">Dostępne klasy: Wynalazca, Druid, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h4d344a13g13e1g4670g9671g6a65e9c8db6b" version="1">Zwój wywołania płomienia</content>
   <content contentuid="heb1c0ea3geae1g43b3g9275g4eb4542e750c" version="1">Dostępne klasy: Druid</content>
   <content contentuid="h7e24e8c4gd619g4b7bgbb8fgf6e69df662bd" version="1">Zwój odporności</content>
-  <content contentuid="h2684b3a8g5785g4b36g91aag1a15e2d6235a" version="1">Dostępne klasy: Rzemieślnik, Kleryk, Druid</content>
+  <content contentuid="h2684b3a8g5785g4b36g91aag1a15e2d6235a" version="1">Dostępne klasy: Wynalazca, Kleryk, Druid</content>
   <content contentuid="hd6b957e7gf997g46f7gb34cgd07ed973fb49" version="1">Zwój świętego płomienia</content>
   <content contentuid="hc5261503g7ffeg44f4g9adeg4a453b390776" version="1">Dostępne klasy: Kleryk</content>
   <content contentuid="h969e79f8ga241g4f3eg904ag8f4858d7c146" version="1">Zwój Shillelagh</content>
@@ -5738,11 +5738,11 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="h4e359edbgd14fg48e3gaaa8gec2f6f104eff" version="1">Zwój taumaturgii</content>
   <content contentuid="h68e674cegfb0eg4833g9161g16eb4a4a0ae6" version="1">Dostępne klasy: Kleryk</content>
   <content contentuid="hd8acfaf2gdc2fg4a8bg85d8g786e61843d71" version="1">Zwój cierniowego bicza</content>
-  <content contentuid="h2cec4524g94f3g406cg949bgabc8f7ab61a8" version="1">Dostępne klasy: Rzemieślnik, Druid</content>
+  <content contentuid="h2cec4524g94f3g406cg949bgabc8f7ab61a8" version="1">Dostępne klasy: Wynalazca, Druid</content>
   <content contentuid="hd794ebceg972cg429aga2fbg3d9a7db47812" version="1">Zwój żałobnego dzwonu</content>
   <content contentuid="h9776cce3ga97cg44bag8675g5a02e511c687" version="1">Dostępne klasy: Kleryk, Czarownik, Mag</content>
   <content contentuid="h096ebfe5g0cb5g4dfeg934cg08534e139de2" version="1">Zwój prawdziwego uderzenia</content>
-  <content contentuid="hd82e1bf6g1c8dg4df4g85e8ge5cc7b209599" version="1">Dostępne klasy: Rzemieślnik, Bard, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="hd82e1bf6g1c8dg4df4g85e8ge5cc7b209599" version="1">Dostępne klasy: Wynalazca, Bard, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="hd6dc4fb0ga5fag40e4g94a8gf532a76634c0" version="1">Zwój zjadliwego szyderstwa</content>
   <content contentuid="h5b8d54d1ga5f7g44ebgb131g294190f528a8" version="1">Dostępne klasy: Bard</content>
   <content contentuid="h13714915ge8a8g4f94g810egd8c9ba002446" version="1">Zwój zbroi Agathys</content>
@@ -5760,7 +5760,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="h652294ddg8ca4g4600gb068g4c65f5fc27f9" version="1">Zwój stworzenia lub zniszczenia wody</content>
   <content contentuid="hf064b5feg4877g4e8bg8a64g84ce7bbef50a" version="1">Dostępne klasy: Kleryk, Druid</content>
   <content contentuid="h6c69e211gc0fdg446dgb4a6gc5f6f6b1df24" version="1">Zwój leczenia ran</content>
-  <content contentuid="h7f314a75g180ag4b5fgb292g79d9ab6b5e9d" version="1">Dostępne klasy: Rzemieślnik, Bard, Kleryk, Druid, Paladyn, Łowca</content>
+  <content contentuid="h7f314a75g180ag4b5fgb292g79d9ab6b5e9d" version="1">Dostępne klasy: Wynalazca, Bard, Kleryk, Druid, Paladyn, Łowca</content>
   <content contentuid="ha240a28bgac40g47f6g81c8g9397f5b7151f" version="1">Zwój fałszywych podszeptów</content>
   <content contentuid="h882af9a4gb72dg433fg81bfg913a9ca05fb3" version="1">Dostępne klasy: Bard</content>
   <content contentuid="hc05fd5f0gabeag4800gad2eg36539cdcef6e" version="1">Zwój boskiej łaski</content>
@@ -5770,7 +5770,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="h4d2440a7g773eg4df5ga298ge47b7cb7545d" version="1">Zwój oplątania</content>
   <content contentuid="heb239ae8gb512g4a22gb543g9b98c9f2df9d" version="1">Dostępne klasy: Druid, Łowca</content>
   <content contentuid="h74437106g3801g4e49gb67bge87de1f118c5" version="1">Zwój blasku faerie</content>
-  <content contentuid="h53a09d3agfa14g4382ga82bga385c31825d6" version="1">Dostępne klasy: Rzemieślnik, Bard, Druid</content>
+  <content contentuid="h53a09d3agfa14g4382ga82bga385c31825d6" version="1">Dostępne klasy: Wynalazca, Bard, Druid</content>
   <content contentuid="h7ef4ab92ge90ag48bdgb4deg1e7f771f5319" version="1">Zwój pocisku wiodącego</content>
   <content contentuid="hef54eecfgdce9g4473gb994g4113b91775fb" version="1">Dostępne klasy: Kleryk</content>
   <content contentuid="h5271ce83g7c0fg4956gb2afg0a429f41a26e" version="1">Zwój gradu cierni</content>
@@ -5784,7 +5784,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="hf42b7ddfg2028g4ec4gb854g9528bb39b818" version="1">Zwój zadawania ran</content>
   <content contentuid="h17266dddg8a8bg426bgb096g6b9bf2eca717" version="1">Dostępne klasy: Kleryk</content>
   <content contentuid="he05c72e9g0761g4a5cgbe1bgfe115ce91c95" version="1">Zwój sanktuarium</content>
-  <content contentuid="h6dab634bg7fcdg455bg97fag943f3d768fb1" version="1">Dostępne klasy: Rzemieślnik, Kleryk</content>
+  <content contentuid="h6dab634bg7fcdg455bg97fag943f3d768fb1" version="1">Dostępne klasy: Wynalazca, Kleryk</content>
   <content contentuid="hf58661b8gab76g47ebg8450g07dbcd2e223e" version="1">Zwój palącego ugodzenia</content>
   <content contentuid="hb5ca2a00g713ag4654g8663g5f27ac95a237" version="1">Dostępne klasy: Paladyn</content>
   <content contentuid="h68efba27gab0dg43f4ga260gea1789a83134" version="1">Zwój tarczy wiary</content>
@@ -5800,13 +5800,13 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="hc0e72a85g7d23g4c2dgb4f1gbe82eaa88e00" version="1">Zwój wyciszenia emocji</content>
   <content contentuid="hc298c1d3g5b1fg4a35gb89bga87a125fb109" version="1">Dostępne klasy: Bard, Kleryk</content>
   <content contentuid="heca566f5g65fcg4803g8dd1g682cc5887e4b" version="1">Zwój wzmocnienia cechy</content>
-  <content contentuid="hbdd71080g88bag48b8gbbe9g6e98deccccfd" version="1">Dostępne klasy: Rzemieślnik, Bard, Kleryk, Druid, Łowca, Zaklinacz, Mag</content>
+  <content contentuid="hbdd71080g88bag48b8gbbe9g6e98deccccfd" version="1">Dostępne klasy: Wynalazca, Bard, Kleryk, Druid, Łowca, Zaklinacz, Mag</content>
   <content contentuid="h728428ccg46b4g4d4fga3e5gbf83f178944e" version="1">Zwój fascynacji</content>
   <content contentuid="hb7b57624g2a86g4643gabd8g3c71b0683ff1" version="1">Dostępne klasy: Bard</content>
   <content contentuid="h804ae2f1g0930g4491g8763g4b06563c2821" version="1">Zwój rozgrzania metalu</content>
-  <content contentuid="hc7c754fag911ag47a7ga5beg7f98f8c469f8" version="1">Dostępne klasy: Rzemieślnik, Bard, Druid</content>
+  <content contentuid="hc7c754fag911ag47a7ga5beg7f98f8c469f8" version="1">Dostępne klasy: Wynalazca, Bard, Druid</content>
   <content contentuid="he504d141gc259g45f8gb80dg3c310b21a85b" version="1">Zwój mniejszego przywrócenia</content>
-  <content contentuid="h6f2f1343gd3ecg4b9eg85e2g2ef6cc31d097" version="1">Dostępne klasy: Rzemieślnik, Bard, Kleryk, Druid, Paladyn, Łowca</content>
+  <content contentuid="h6f2f1343gd3ecg4b9eg85e2g2ef6cc31d097" version="1">Dostępne klasy: Wynalazca, Bard, Kleryk, Druid, Paladyn, Łowca</content>
   <content contentuid="he10d9305g8cf6g4ccbgad7bgd2746ea46ca4" version="1">Zwój księżycowego promienia</content>
   <content contentuid="h250348d7ge71dg40a2ga944g6f665b8e18c0" version="1">Dostępne klasy: Druid</content>
   <content contentuid="h45d0b5d3ga398g445cga7f9gd75da7a8aae3" version="1">Zwój przejścia bez śladu</content>
@@ -5814,7 +5814,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="hc6d61f66ga59cg4754gac48ge00fb1fb5ddd" version="1">Zwój uzdrawiającej modlitwy</content>
   <content contentuid="h65a54d96gda00g48f3gb956gbf5821b6ed10" version="1">Dostępne klasy: Kleryk, Paladyn</content>
   <content contentuid="h4df0a731g189eg4843gb14fg950fd7625872" version="1">Zwój ochrony przed trucizną</content>
-  <content contentuid="h5427b5b7g9e41g4bbeg8e31g82d493a9b617" version="1">Dostępne klasy: Rzemieślnik, Kleryk, Druid, Paladyn, Łowca</content>
+  <content contentuid="h5427b5b7g9e41g4bbeg8e31g82d493a9b617" version="1">Dostępne klasy: Wynalazca, Kleryk, Druid, Paladyn, Łowca</content>
   <content contentuid="hb45b2deeg7891g4ef5g9247g6271029e08c6" version="1">Zwój ostrza cienia</content>
   <content contentuid="h87e57107g3fd4g43dcga492g90ec809f3f7a" version="1">Dostępne klasy: Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h07d70d75gb311g4b65gaf4eg8807c20ff75d" version="1">Zwój ciszy</content>
@@ -5838,7 +5838,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="h5b3aa645gc718g46fcgb3b1g48cced477759" version="1">Zwój światła dnia</content>
   <content contentuid="h73580f96ga9bag489aga276gaa2200b19c22" version="1">Dostępne klasy: Kleryk, Druid, Paladyn, Łowca, Zaklinacz</content>
   <content contentuid="haf04e176g4abeg4764gb773gf6644ec21fac" version="1">Zwój broni żywiołu</content>
-  <content contentuid="hd2abd846g45b3g427dgb7a8g08a2cd62544a" version="1">Dostępne klasy: Rzemieślnik, Druid, Paladyn, Łowca</content>
+  <content contentuid="hd2abd846g45b3g427dgb7a8g08a2cd62544a" version="1">Dostępne klasy: Wynalazca, Druid, Paladyn, Łowca</content>
   <content contentuid="hf37a3668g5485g462dgb8bfg24f366499655" version="1">Zwój głodu Hadara</content>
   <content contentuid="hdcedefeeg8769g45e9ga84bgac21bffb520f" version="1">Dostępne klasy: Czarownik</content>
   <content contentuid="h2d37feacg6e1dg4330ga540gcd5096a455e8" version="1">Zwój piorunostrzału</content>
@@ -5856,7 +5856,7 @@ Za każdym razem, gdy czar zadaje celowi obrażenia, odzyskujesz punkty wytrzyma
   <content contentuid="hfa5194fdga498g4753g845eg38616d41d105" version="1">Zwój dominacji nad bestią</content>
   <content contentuid="ha49988b7g0aaag4c53gb135g16e4a7d028ca" version="1">Dostępne klasy: Druid, Łowca, Zaklinacz</content>
   <content contentuid="h8587bf57g8e23g47eeg855ag694f1815cca7" version="1">Zwój swobody ruchu</content>
-  <content contentuid="h924ee79agb241g4343g9a17g84d939186d74" version="1">Dostępne klasy: Rzemieślnik, Bard, Kleryk, Druid, Łowca</content>
+  <content contentuid="h924ee79agb241g4343g9a17g84d939186d74" version="1">Dostępne klasy: Wynalazca, Bard, Kleryk, Druid, Łowca</content>
   <content contentuid="h0ae3a512ga30bg4e55gaacfg84dc3f72dda1" version="1">Zwój chwytnego pnącza</content>
   <content contentuid="hea395c9ag018fg4009g9180g6a41e317a1e4" version="1">Dostępne klasy: Druid, Łowca</content>
   <content contentuid="hfd260509g0e4bg4d5fgb5d2gd0e37328a597" version="1">Zwój strażnika wiary</content>
@@ -6336,7 +6336,7 @@ Poziom 9: dwa czary 5. poziomu.</content>
   <content contentuid="h48ecfce6g6053gb38agfd4dg1a591402a8b0" version="1">Ma utrudnienie w następnym teście ataku bronią, który wykona przed końcem swojej następnej tury.</content>
   <content contentuid="h6b3f21c4ge58ag7d19gb04cg3ea75f81d0c6" version="1">Wtajemniczony: Odmrożenie</content>
   <content contentuid="h4c9e7f21gb306g5d84ga17fg2e60c9d8b435" version="1">Zwój odmrożenia</content>
-  <content contentuid="h8d15b6e3gc472g49a0g83bdg5f71e2a04c69" version="1">Dostępne klasy: Rzemieślnik, Druid, Zaklinacz, Czarownik, Mag</content>
+  <content contentuid="h8d15b6e3gc472g49a0g83bdg5f71e2a04c69" version="1">Dostępne klasy: Wynalazca, Druid, Zaklinacz, Czarownik, Mag</content>
   <content contentuid="h9d7a0c3eg115bg4ae2gad78gc3e65c3e40bc" version="1">Nie dokonuj wyboru</content>
   <content contentuid="hbfc3c711gf795g4750g93f7ga4084ef4f25d" version="1">Nic nie zyskujesz. Wybierz tę opcję, jeśli jesteś już biegły we wszystkich umiejętnościach z tej listy, dzięki czemu możesz ukończyć zdobywanie kolejnych poziomów.</content>
   <content contentuid="h3bdf72d8gd593g05f4g1758g5a0b980320ce" version="1">Prześladowca pajęczynówek</content>


### PR DESCRIPTION
## Summary
- standardize the Artificer class as Wynalazca, following the Polish D&D 2024 Eberron: Forge of the Artificer community localization
- update all class references and usable-class lists with the correct Polish inflection
- preserve ordinary uses of rzemieślnik that mean an artisan rather than the Artificer class

## Validation
- 63 changed handles; every corresponding English source contains Artificer
- 5,355/5,355 localization entries present
- no added, removed, renamed, or version-changed handles
- XML, placeholders, tags, spell titles, and spell descriptions validated
- only Localization/Polish/polish.xml is changed

## Credit note
Please link the community credit to Discord:

**Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)

The existing Ukrainian Translation credit should use the same community name and Discord URL.