### PR TITLE
Align Polish D&D 2024 feature names

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -2768,7 +2768,7 @@ Ponadto istota oznaczona twoim Znakiem łowcy nie może wykonywać akcji Odstąp
   <content contentuid="hbeb4351eged06g5aa8g19cag2270bd60a6eb" version="1">Doświadczenie zdobyte podczas przetrwania w śmiertelnie niebezpiecznych miejscach pozwala ci wzmacniać nie tylko siebie, lecz także sojuszników. W ramach akcji Magii wybierz tyle widocznych istot, ile wynosi twój modyfikator Mądrości (co najmniej jedną). Każda wybrana istota odzyskuje punkty wytrzymałości w liczbie równej 1k10 plus twój poziom Łowcy i przez 1 godzinę ma ułatwienie w rzutach obronnych wykonywanych, aby uniknąć stanu Przerażenia lub go zakończyć.
 
 Po użyciu tej zdolności musisz ukończyć długi odpoczynek, zanim użyjesz jej ponownie.</content>
-  <content contentuid="hd373a822gfb21g38dfge5a8g77c001185e3a" version="1">Poziom 11: Mroźna odpłata</content>
+  <content contentuid="hd373a822gfb21g38dfge5a8g77c001185e3a" version="1">Poziom 11: Przeszywająca odpłata</content>
   <content contentuid="hb6e753d8g25f2gee18g87d6gdda8a5857b4c" version="3">Gdy istota trafi cię atakiem, możesz w ramach reakcji zmusić ją do rzutu obronnego na Mądrość przeciwko twojemu ST obrony przed czarami. Przy niepowodzeniu cel otrzymuje &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;stan Ogłuszenia&lt;/LSTag&gt; na 2 tury.
 
 Możesz użyć tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości (co najmniej raz), a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
@@ -2780,10 +2780,10 @@ Możesz użyć tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości
   <content contentuid="h3b19ec2fg1828gff82g805cg351bdc1b191b" version="1">W ramach akcji Magii wybierz maksymalnie tyle widocznych istot, ile wynosi twój modyfikator Mądrości (co najmniej jedną). Każda wybrana istota odzyskuje punkty wytrzymałości w liczbie równej sumie 1k10 i twojego poziomu łowcy, a przez 1 godzinę wykonuje z ułatwieniem rzuty obronne pozwalające uniknąć stanu Przerażenia albo go zakończyć.</content>
   <content contentuid="haf330cbag9da5g81b9gc9c4g13038dc4bc59" version="1">Krzepiąca dusza</content>
   <content contentuid="h1b6a7023gadf1g5468g1b86gda2cac4d8e2b" version="1">Masz ułatwienie w rzutach obronnych wykonywanych, aby uniknąć albo zakończyć stan Przerażenia.</content>
-  <content contentuid="hcf64a967g8805ge99bg1ff7ga0cb9cd0764c" version="1">Mroźna odpłata</content>
+  <content contentuid="hcf64a967g8805ge99bg1ff7ga0cb9cd0764c" version="1">Przeszywająca odpłata</content>
   <content contentuid="hae8770acg873fg844dgedd5g825cc772d72c" version="1">Gdy istota trafi cię atakiem, możesz w ramach reakcji zmusić ją do rzutu obronnego na Mądrość przeciwko twojemu ST obrony przed czarami. Przy niepowodzeniu cel otrzymuje &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;stan Ogłuszenia&lt;/LSTag&gt; do końca twojej następnej tury.</content>
-  <content contentuid="h2dc72da7geb6fg6757g65b9g28c64f77f068" version="1">Mroźna odpłata</content>
-  <content contentuid="h4ff1d8aeg3628g34f5gd2e0gf05e758e89f6" version="1">Mroźna odpłata</content>
+  <content contentuid="h2dc72da7geb6fg6757g65b9g28c64f77f068" version="1">Przeszywająca odpłata</content>
+  <content contentuid="h4ff1d8aeg3628g34f5gd2e0gf05e758e89f6" version="1">Przeszywająca odpłata</content>
   <content contentuid="h7683213dgcd67g8a04g76bdg263469054d80" version="1">Gdy istota trafi cię atakiem, możesz w ramach reakcji zmusić ją do rzutu obronnego na Mądrość przeciwko twojemu ST obrony przed czarami. Przy niepowodzeniu cel otrzymuje &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;stan Ogłuszenia&lt;/LSTag&gt; na 2 tury.</content>
   <content contentuid="h6c8f835eg0910g6b96ga78bg651c0ba6cd54" version="1">Zimowy wędrowiec</content>
   <content contentuid="h11ed03f2g16a9g0ee9g4b45g6c8ca4ac593d" version="1">Zimowi wędrowcy doskonalą swój kunszt w ponurej, skutej lodem dziczy miejsc takich jak Dolina Lodowego Wichru. Ci bezwzględni, oszronieni łowcy polują na potwory nawiedzające arktyczne pustkowia, aż w końcu sami stają się lodowatymi postrachami. Doskonale znają zjawiska charakterystyczne dla Doliny Lodowego Wichru, w tym utajoną magię upadłych miast Netheru, endemiczne potwory, takie jak yeti i koty skalne, oraz rosnące zagrożenie ze strony najeźdźców z Podmroku. Z powodu chłodnego pragmatyzmu, przerażającej magii i opanowania regionu budzą w równym stopniu szacunek i strach. Mieszkańcy Dziesięciu Miast mówią, że częste zetknięcie ze złowrogimi bytami daje zimowym wędrowcom ich budzące grozę moce. Wielu nomadów Reghed z kolei wierzy, że duchy natury obdarzają zimowych wędrowców wyjątkową klątwą.</content>
@@ -4009,20 +4009,20 @@ Do następnego długiego odpoczynku ty i twoi sojusznicy zyskujecie premię +5 d
   <content contentuid="h318e3ac4g7a18ga5edgf912g65c014f1354e" version="2">Wampiryczne Ukąszenie</content>
   <content contentuid="h64543ab1gec40g4962g092eg85f690ed7102" version="2">Możesz wyssać krew z żywej istoty, aby odzyskać punkty wytrzymałości.</content>
   <content contentuid="h9936bfdfgad15g113bged99g9778bc8cba86" version="1">Wampiryczny głód został chwilowo zaspokojony. +1 do wszystkich &lt;LSTag Tooltip="AttackRoll"&gt;testów ataku&lt;/LSTag&gt;, &lt;LSTag Tooltip="SavingThrow"&gt;rzutów obronnych&lt;/LSTag&gt; i większości &lt;LSTag Tooltip="AbilityCheck"&gt;testach cechy&lt;/LSTag&gt;.</content>
-  <content contentuid="ha48ff32fg388ag1220g80cbgc8e2ec3cd1c7" version="2">Odcięcie od snów</content>
+  <content contentuid="ha48ff32fg388ag1220g80cbgc8e2ec3cd1c7" version="2">Odcięty od snów</content>
   <content contentuid="h9105e090ga08cg9a3fgb40ag60da6cec8ae0" version="2">Po zakończeniu długiego odpoczynku zyskujesz biegłość w jednej wybranej umiejętności. Biegłość ta trwa do momentu ukończenia kolejnego długiego odpoczynku.</content>
-  <content contentuid="hb3e89e41gbe95gff0dgb116gf17d00181a3d" version="1">Odcięcie od snów</content>
-  <content contentuid="h76b975b4g225dg6d93g8391g805c6fe94d75" version="1">Odcięcie od snów: Charyzma</content>
-  <content contentuid="he10fa554g1d22g52e8ga07ag4d67ea3adba9" version="1">Odcięcie od snów: Zręczność</content>
-  <content contentuid="h5aaa6305g5e92gf0bbge44cg808c6bfe53e3" version="1">Odcięcie od snów: Inteligencja</content>
-  <content contentuid="hfa38bd13g00b7g251ag5dcfg7b778b90f0fa" version="1">Odcięcie od snów: Siła</content>
-  <content contentuid="h1bcd11adgf59dg2940g9970gc535b6f03671" version="1">Odcięcie od snów: Mądrość</content>
-  <content contentuid="h349db2d2g6007g8ab3g7a65gc8a49bb91090" version="1">Odcięcie od snów</content>
-  <content contentuid="hf8e05d10g02faga33fg2d55ge9f15c67f8f2" version="1">Odcięcie od snów: Siła</content>
-  <content contentuid="h22d73c13gc15eg0eacg8774ge49e882c482d" version="1">Odcięcie od snów: Zręczność</content>
-  <content contentuid="h80c38745g80eag0668gc029g08825f3ec1ef" version="1">Odcięcie od snów: Inteligencja</content>
-  <content contentuid="h0152f209g939bg4575g22f7g26ad677352b5" version="1">Odcięcie od snów: Mądrość</content>
-  <content contentuid="hb641ddd6g0950g5b50gf483g681c68224f61" version="1">Odcięcie od snów: Charyzma</content>
+  <content contentuid="hb3e89e41gbe95gff0dgb116gf17d00181a3d" version="1">Odcięty od snów</content>
+  <content contentuid="h76b975b4g225dg6d93g8391g805c6fe94d75" version="1">Odcięty od snów: Charyzma</content>
+  <content contentuid="he10fa554g1d22g52e8ga07ag4d67ea3adba9" version="1">Odcięty od snów: Zręczność</content>
+  <content contentuid="h5aaa6305g5e92gf0bbge44cg808c6bfe53e3" version="1">Odcięty od snów: Inteligencja</content>
+  <content contentuid="hfa38bd13g00b7g251ag5dcfg7b778b90f0fa" version="1">Odcięty od snów: Siła</content>
+  <content contentuid="h1bcd11adgf59dg2940g9970gc535b6f03671" version="1">Odcięty od snów: Mądrość</content>
+  <content contentuid="h349db2d2g6007g8ab3g7a65gc8a49bb91090" version="1">Odcięty od snów</content>
+  <content contentuid="hf8e05d10g02faga33fg2d55ge9f15c67f8f2" version="1">Odcięty od snów: Siła</content>
+  <content contentuid="h22d73c13gc15eg0eacg8774ge49e882c482d" version="1">Odcięty od snów: Zręczność</content>
+  <content contentuid="h80c38745g80eag0668gc029g08825f3ec1ef" version="1">Odcięty od snów: Inteligencja</content>
+  <content contentuid="h0152f209g939bg4575g22f7g26ad677352b5" version="1">Odcięty od snów: Mądrość</content>
+  <content contentuid="hb641ddd6g0950g5b50gf483g681c68224f61" version="1">Odcięty od snów: Charyzma</content>
   <content contentuid="h387fbbd8g1993g3f29gb171ge2f1a3b1e7cd" version="1">Wszechstronny</content>
   <content contentuid="h0f6ded08gcd3bgf273gc080g6c03b3f1633b" version="1">Otrzymujesz wybrany przez siebie atut Pochodzenia lub możesz wybrać cechę gatunku innego niż człowiek.</content>
   <content contentuid="h325e735fg2b3bg04e3g4111g0c40750b7fbe" version="1">Umiejętny</content>


### PR DESCRIPTION
## Summary

- align Chilling Retribution with the current Polish D&D 2024 Heroes of Faerûn terminology: Przeszywająca odpłata
- align Severed from Dreams with the current Polish D&D 2024 Forge of the Artificer terminology: Odcięty od snów
- update all duplicate title, level-header, and ability-specific handles consistently

The first change also avoids implying cold damage: the feature inflicts Stunned and does not deal cold damage.

## Validation

- 5,355 English source entries and 5,355 Polish entries
- no missing, added, renamed, or duplicate content handles
- no contentuid or version changes
- no untranslated non-whitelisted entries
- no spell structure, language, title, description, or spell-list coverage errors
- only the Polish localization file is changed

## Credit note

Please use the following Discord-linked credit wherever TableTop BRAMA is mentioned:

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
