### PR TITLE
Fix Polish D&D 2024 UI terminology and grammar

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -14,19 +14,19 @@ Ograniczenie ruchu. Aby wstać i zakończyć ten stan, musisz zużyć ruch równ
 Ataki. Test ataku przeciwko tobie ma ułatwienie, jeśli napastnik znajduje się w promieniu [1] od ciebie. W przeciwnym razie test ma utrudnienie.</content>
   <content contentuid="h4d9f934eg7721gfb63gcff8gb411e659dc78" version="1">Zasada: Jeden czar z komórki na turę</content>
   <content contentuid="hd3ffb028g9755g52adgf223g4bb289eebf93" version="1">W jednej turze możesz zużyć tylko jedną komórkę czaru. Oznacza to na przykład, że nie możesz w tej samej turze rzucić jednego czaru z komórki w ramach akcji Magii, a drugiego w ramach akcji dodatkowej.</content>
-  <content contentuid="hb60d9b3bg491bg7056g1bd9gc752b67bfd56" version="2">Rąbnięcie</content>
+  <content contentuid="hb60d9b3bg491bg7056g1bd9gc752b67bfd56" version="2">Szerokie cięcie</content>
   <content contentuid="h57100728g823cg76f4g4795g878063b680ae" version="2">Gdy trafisz istotę atakiem wręcz tą bronią, możesz wykonać nią atak wręcz przeciwko drugiej istocie, która znajduje się w promieniu [1] od pierwszego celu i w zasięgu twojej broni. Przy trafieniu druga istota otrzymuje obrażenia broni, ale nie dodajesz do nich modyfikatora cechy, chyba że jest ujemny. Ten dodatkowy atak możesz wykonać tylko raz na turę.</content>
   <content contentuid="h240aa2f4g6571ge23eg8142g83ee7b985b8d" version="2">Draśnięcie</content>
   <content contentuid="h0fbee9aag6abeg6294g3fd8gbeb26ffd19f6" version="1">Gdy chybisz istotę atakiem tą bronią, możesz zadać jej obrażenia równe modyfikatorowi cechy użytemu w teście ataku. Obrażenia są tego samego typu co obrażenia broni i można je zwiększyć wyłącznie przez zwiększenie tego modyfikatora.</content>
   <content contentuid="hdbe460a9gf800gdb75g15bbg2b81a80fe8ab" version="2">Nacięcie</content>
   <content contentuid="h84f8977cg06ecg1e31gebd6g21e4b7346121" version="2">Dodatkowy atak wynikający z właściwości Lekka możesz wykonać w ramach akcji Ataku zamiast akcji dodatkowej. Ten dodatkowy atak możesz wykonać tylko raz na turę.</content>
-  <content contentuid="h64e7021cg8b69g3f60gde38gd59f3cdc5846" version="2">Naciśnij</content>
+  <content contentuid="h64e7021cg8b69g3f60gde38gd59f3cdc5846" version="2">Popchnięcie</content>
   <content contentuid="h694f6a66g0531g98f0ga23eg525e146eb4d7" version="1">Gdy trafisz tą bronią istotę rozmiaru dużego lub mniejszego, możesz odepchnąć ją od siebie na odległość do [1].</content>
   <content contentuid="haf74199bg92cbg93dega0fbgebb535603f83" version="2">Osłabienie</content>
   <content contentuid="h6846e460g6aecg1e76g52c0g8c751abe8744" version="1">Gdy trafisz istotę tą bronią, ma ona utrudnienie w następnym teście ataku wykonanym przed początkiem twojej następnej tury.</content>
   <content contentuid="hb839de91gb995ge42eg62b9g1dd41fe4da4b" version="2">Spowolnienie</content>
   <content contentuid="h7773a857g54d9g0e61gc338g5671eef1378d" version="1">Gdy trafisz istotę tą bronią i zadasz jej obrażenia, możesz zmniejszyć jej szybkość o [1] do początku swojej następnej tury. Jeśli istota zostanie trafiona więcej niż raz bronią z tą właściwością, łączne zmniejszenie szybkości nie może przekroczyć [1].</content>
-  <content contentuid="ha395ebeag3995g70fage1d7g718229b74f9b" version="2">Przewrócenie</content>
+  <content contentuid="ha395ebeag3995g70fage1d7g718229b74f9b" version="2">Obalenie</content>
   <content contentuid="h5af643b9gd1b7g259cg51cegf17292ec2f43" version="1">Gdy trafisz istotę tą bronią, możesz zmusić ją do rzutu obronnego na Kondycję (ST 8 plus modyfikator cechy użyty w teście ataku i twoja premia z biegłości). Przy niepowodzeniu istota otrzymuje stan Powalenia.</content>
   <content contentuid="hdfca5f76g305cgff0cg0532gbc6b23ff9367" version="2">Nękanie</content>
   <content contentuid="hf0019ff2g27f5g13abg7a86g646b2f8a1f55" version="1">Gdy trafisz istotę tą bronią i zadasz jej obrażenia, masz ułatwienie w następnym teście ataku przeciwko niej wykonanym przed końcem swojej następnej tury.</content>
@@ -168,19 +168,19 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="h28bdf1edg1a62gc8a2gc601gdedb4f01f3b6" version="1">Punkty Wytrzymałości tej istoty spadły poniżej 50%.</content>
   <content contentuid="h12e63398gc863ged08g09d8g9e2fffc91af3" version="1">Akt wiary</content>
   <content contentuid="h62870381g3b8dgbb2cgfc78gf6ba26bd778f" version="1">Określa, ile razy możesz użyć boskich mocy.</content>
-  <content contentuid="h39b48f39g9a41g2ba3g3567g7ab1cb265f82" version="1">Poziom 3: Flara Strażnicza</content>
+  <content contentuid="h39b48f39g9a41g2ba3g3567g7ab1cb265f82" version="1">Poziom 3: Ochronny rozbłysk</content>
   <content contentuid="ha7d55e66g6f97ga4b7g45b4g5829f0c36910" version="2">Gdy widoczna istota w promieniu [1] od ciebie wykonuje test ataku, możesz w ramach reakcji zapewnić temu testowi utrudnienie, wywołując rozbłysk światła, zanim atak trafi albo chybi.
 
 Możesz użyć tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości (co najmniej raz), a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
-  <content contentuid="h67f1e6b2g8adcge989g555ag3cbae9d62375" version="1">Poziom 6: Ulepszona Flara Strażnicza</content>
+  <content contentuid="h67f1e6b2g8adcge989g555ag3cbae9d62375" version="1">Poziom 6: Ulepszony ochronny rozbłysk</content>
   <content contentuid="hcac62cb2g678dgbdc4g4a80g875b53ed7a48" version="1">Po zakończeniu krótkiego lub długiego odpoczynku odzyskujesz wszystkie użycia Ochronnego rozbłysku.
 
 Ponadto za każdym razem, gdy używasz Ochronnego rozbłysku, możesz przyznać celowi ataku, który go wywołał, tymczasowe punkty wytrzymałości w liczbie równej sumie 2k6 i twojego modyfikatora Mądrości.</content>
   <content contentuid="h772e3772g49fdg8cf4g0f02g893153584b30" version="1">Ochronny rozbłysk</content>
   <content contentuid="h6c1ab5a0g8a40g1755g2eacg01f53db2903f" version="1">Gdy widoczna istota w promieniu 9 m od ciebie wykonuje test ataku, możesz w ramach reakcji zapewnić temu testowi utrudnienie, wywołując rozbłysk światła, zanim atak trafi albo chybi.</content>
-  <content contentuid="h03dc1992g1d8agc3e0ga6bbg22607e81d966" version="1">Ochronna Flara (Sojusznik)</content>
-  <content contentuid="hcb0f1d4dg6ea8gf1eag5e72g32b56f306af2" version="1">Ochronna Flara (Ja)</content>
-  <content contentuid="hdc4e30afg0702g20ddgf4a5g1751c8b46770" version="1">Poziom 3: Przywołaj dwulicowość</content>
+  <content contentuid="h03dc1992g1d8agc3e0ga6bbg22607e81d966" version="1">Ochronny rozbłysk (sojusznik)</content>
+  <content contentuid="hcb0f1d4dg6ea8gf1eag5e72g32b56f306af2" version="1">Ochronny rozbłysk (własna postać)</content>
+  <content contentuid="hdc4e30afg0702g20ddgf4a5g1751c8b46770" version="1">Poziom 3: Przywołanie sobowtóra</content>
   <content contentuid="h31748432g34ebg740cgf353g2071d6cae486" version="1">W ramach akcji dodatkowej możesz zużyć jedno użycie Aktu wiary, aby stworzyć doskonałą wizualną iluzję siebie na widocznym, niezajętym miejscu w promieniu [1]. Iluzja trwa 1 minutę. W ramach akcji dodatkowej możesz przenieść ją o maksymalnie [1] na inne widoczne, niezajęte miejsce.</content>
   <content contentuid="h002b7ed0g2d07g9ecbg0301g13b767a04c7e" version="1">Poziom 6: Transpozycja oszusta</content>
   <content contentuid="h9d5766b9g0e51g3888g5633gd570f3096a0f" version="1">Za każdym razem, gdy wykonujesz akcję dodatkową, aby stworzyć lub przesunąć iluzję swojego Przywołania sobowtóra, możesz teleportować się, zamieniając się miejscami z iluzją.</content>
@@ -1421,17 +1421,17 @@ W późniejszych turach możesz wykonać akcję Magii, aby przesunąć Cylinder 
   <content contentuid="h61fc3e75g1ec0gc89ag9436g4e8ddfbca849" version="1">Dotknięciem nakładasz na wybraną istotę klątwę. Otrzymuje ona &lt;LSTag Tooltip="Disadvantage"&gt;utrudnienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; i &lt;LSTag Tooltip="SavingThrow"&gt;rzutach obronnych&lt;/LSTag&gt; dotyczących Siły.</content>
   <content contentuid="hd7230d6bg2475g7ee0gd19eg41d41b35912b" version="1">Nałożenie klątwy</content>
   <content contentuid="h92b0717fg3876gf392gd6bege29b23736c7c" version="1">Rzuć klątwę na istotę dotykiem. Klątwa nakłada &lt;LSTag Tooltip="Disadvantage"&gt;utrudnienie&lt;/LSTag&gt; do &lt;LSTag Tooltip="AbilityCheck"&gt;testów&lt;/LSTag&gt; i &lt;LSTag Tooltip="SavingThrow"&gt;rzutów obronnych&lt;/LSTag&gt; lub &lt;LSTag Tooltip="AttackRoll"&gt;ataków&lt;/LSTag&gt;. Pozwala również zadawać dodatkowe obrażenia celowi lub pozbawić go akcji.  </content>
-  <content contentuid="ha3fdc893gcf78gc804gf587gdbeacfc06c65" version="1">Przeróbka Ciemności</content>
+  <content contentuid="ha3fdc893gcf78gc804gf587gdbeacfc06c65" version="1">Powtórz Ciemność</content>
   <content contentuid="h165ff057g66b4g488dg8815gdc5f1e533378" version="1">Możesz ponownie rzucić czar bez wydawania komórki czaru lub korzystania z akcji.</content>
-  <content contentuid="hc846b26dgef48g7d56g1bb9g632994732104" version="1">Przeróbka Podmuchu Wiatru</content>
+  <content contentuid="hc846b26dgef48g7d56g1bb9g632994732104" version="1">Powtórz Poryw wiatru</content>
   <content contentuid="h95994da7g0cf6g8834gdb14g989056e28ce2" version="2">Możesz ponownie rzucić czar bez wydawania komórki czaru.</content>
-  <content contentuid="hadf8e795g3f57g1ec6g0288gfd8ec498c690" version="1">Przeróbka Ciemności</content>
+  <content contentuid="hadf8e795g3f57g1ec6g0288gfd8ec498c690" version="1">Powtórz Ciemność</content>
   <content contentuid="h69cd9ae0gfac9gb6a0g0a63g844853dd03d6" version="1">Możesz ponownie rzucić czar bez wydawania komórki czaru lub korzystania z akcji.</content>
-  <content contentuid="h99ed2837g02ccg455dg2e23gad3d13fc9b06" version="1">Przeróbka Ciemności</content>
+  <content contentuid="h99ed2837g02ccg455dg2e23gad3d13fc9b06" version="1">Powtórz Ciemność</content>
   <content contentuid="h17de1a92g5cc6g1a92gfd13ga062e9e031f2" version="1">Możesz ponownie rzucić czar bez wydawania komórki czaru lub korzystania z akcji.</content>
-  <content contentuid="h48d3643fg9150g4323g6a3bg15e71e622720" version="1">Przeróbka Ciemności</content>
+  <content contentuid="h48d3643fg9150g4323g6a3bg15e71e622720" version="1">Powtórz Ciemność</content>
   <content contentuid="hc704bd0ag2056geb75gf781g2a3b1ef159c5" version="1">Możesz ponownie rzucić czar bez wydawania komórki czaru lub korzystania z akcji.</content>
-  <content contentuid="h272e8b3fg32bcg9272g86a0g32a43e6b7889" version="1">Przeróbka Ciemności</content>
+  <content contentuid="h272e8b3fg32bcg9272g86a0g32a43e6b7889" version="1">Powtórz Ciemność</content>
   <content contentuid="h191d3b3cg589agc29bg69e9g143e19f63834" version="1">Możesz ponownie rzucić czar bez wydawania komórki czaru lub korzystania z akcji.</content>
   <content contentuid="hb302549egc54bg5a4dgbcedg1c098cc541f2" version="1">Urok</content>
   <content contentuid="h15d4347egf4adg1955g7c5agb0611504409c" version="1">Cel odnosi dodatkowo [1] obr. za każdym razem, gdy go atakujesz. Ma również &lt;LSTag Tooltip="Disadvantage"&gt;utrudnienie&lt;/LSTag&gt; dla wybranej przez ciebie &lt;LSTag Tooltip="Abilities"&gt;cechy&lt;/LSTag&gt;.</content>
@@ -1756,14 +1756,14 @@ Jeśli wybierzesz tropikalną krainę, przygotowujesz następujące czary: na 3.
   <content contentuid="hf78b7f33g6aa9g43f9g5859ga51f9e7facde" version="1">Jeśli wybierzesz tropikalną krainę, przygotowujesz następujące czary: na 3. poziomie — Kwasowy rozprysk, Promień zatrucia i Pajęczyna; na 5. poziomie — Śmierdząca chmura; na 7. poziomie — Polimorfia; a na 9. poziomie — Plaga owadów.</content>
   <content contentuid="h59bddf9bg3094g2868gce0dgb0fbfbb3fdd4" version="1">Furia żywiołów</content>
   <content contentuid="h22eae394ga5fbg653egff67gee9e5b542914" version="1">Potęga żywiołów przepływa przez ciebie. Zyskujesz jedną z następujących opcji według własnego wyboru.</content>
-  <content contentuid="h2b54832cgd102gec1dg521dgc5239b16c5b9" version="1">Pomoc Landu</content>
+  <content contentuid="h2b54832cgd102gec1dg521dgc5239b16c5b9" version="1">Pomoc natury</content>
   <content contentuid="h7d366d57g2abcg334egec99gd574e5abbc31" version="1">W ramach akcji Magii możesz zużyć jedno użycie Dzikiej Postaci i wybrać punkt w promieniu 18 m od siebie. W sferze o promieniu 3 m, której środkiem jest ten punkt, pojawiają się na chwilę życiodajne kwiaty i ciernie wysysające życie. Wrogie istoty w sferze otrzymują 2k6 obrażeń nekrotycznych. Pozostałe istoty na tym obszarze odzyskują 2k6 punktów wytrzymałości.
 
 Obrażenia i leczenie zwiększają się o 1k6 na 5. poziomie druida (3k6) i ponownie na 10. poziomie (4k6).</content>
   <content contentuid="h971b2780g3870g87c7g5557ge1126bfcc79b" version="1">Poziom 10: Strażnik Natury</content>
   <content contentuid="h08f86230g6e53ga6e6g6abfg870e7ec18f88" version="1">Masz niewrażliwość na stan Zatrucia oraz odporność na typ obrażeń powiązany z krainą wybraną obecnie dla zdolności Czary Kręgu: ogień (jałowa), zimno (polarna), elektryczność (umiarkowana) albo trucizna (tropikalna).</content>
   <content contentuid="h993714a3gef7eg3fa3g8208g34aa994bdb90" version="1">Krąg Morza</content>
-  <content contentuid="h620c69f6g5443g20cdg6ba6g742691ee6c08" version="1">Druidzi z Kręgu Morza czerpią z burzliwych sił oceanów i burz. Niektórzy uważają się za ucieleśnienia gniewu natury i szukają zemsty na tych, którzy ją rabują. Inni poszukują mistycznej jedności z naturą, dostrajając się do przypływów i odpływów przypływów, podążając za pędem prądów i fal oraz słuchając nieprzeniknionych szeptów i ryków wiatrów.</content>
+  <content contentuid="h620c69f6g5443g20cdg6ba6g742691ee6c08" version="1">Druidzi z Kręgu Morza czerpią z burzliwych sił oceanów i burz. Niektórzy uważają się za ucieleśnienia gniewu natury i szukają zemsty na tych, którzy ją rabują. Inni poszukują mistycznej jedności z naturą, dostrajając się do rytmu przypływów i odpływów, podążając za pędem prądów i fal oraz słuchając nieprzeniknionych szeptów i ryków wiatrów.</content>
   <content contentuid="h098af219gb42agf6c9gb202g7d21b599c435" version="1">Poziom 3: Gniew Morza</content>
   <content contentuid="he83b406cg6857g3e88gd60dg2ef8a8d31d88" version="2">W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby przejawić otaczającą cię emanację morskiej bryzy o promieniu 1,5 m. Emanacja kończy się wcześniej, jeśli ją zakończysz (bez użycia akcji), przejawisz ponownie albo otrzymasz stan Obezwładnienia.
 
@@ -2461,7 +2461,7 @@ W Szmaragdowej Enklawie troszczysz się o tych, którzy dbają o świat. Wraz z 
 Rozmawianie ze zwierzętami. Zawsze masz przygotowany czar Rozmawianie ze zwierzętami i możesz rzucać go, zużywając dowolną posiadaną komórkę czaru.
 
 Zgrany zespół. Gdy wykonujesz akcję Pomocy, możesz w ramach tej samej akcji zamienić się miejscami z chętnym sojusznikiem w promieniu 1,5 m od siebie. Ten ruch nie prowokuje ataków okazyjnych.</content>
-  <content contentuid="hdca03596gcde4g4b29g8a36g81f8496c69a4" version="1">Najemnik z Pięści</content>
+  <content contentuid="hdca03596gcde4g4b29g8a36g81f8496c69a4" version="1">Najemnik Płonącej Pięści</content>
   <content contentuid="he09a0c77g31aeg7362g892bg7bdd827aa73e" version="2">Atut: Twardziel
 
 Główną formacją strzegącą prawa we Wrotach Baldura jest Płonąca Pięść — potężna gildia najemników dowodzona przez wielkiego księcia miasta. Masz za sobą służbę w jej szeregach, która uczy cię uprzedzać kłopoty groźnym spojrzeniem, a w razie potrzeby przyjmować śmiertelne ciosy. Czynni i emerytowani najemnicy Płonącej Pięści uchodzą za jednych z najtwardszych i najbardziej wytrzymałych wojowników Wybrzeża Mieczy, a ty zamierzasz podtrzymać tę reputację.</content>
@@ -4852,7 +4852,7 @@ Podczas rzucania tego czaru możesz wskazać istoty, na które nie będzie on dz
   <content contentuid="h7eca827eg60a1g2e15ga615g5750ad9f5621" version="1">Zniknie do czerni</content>
   <content contentuid="h075cad75ge0b8g8089g7a0bge757b2193df5" version="1">Poziom 10: Boska Interwencja</content>
   <content contentuid="h8dfac8b3gdd9aga779ga229g8159a97e610e" version="2">Kiedy wzywasz swoje bóstwo do Boskiej Interwencji, twój bóg odpowiada, przywracając część twojej boskiej mocy. Natychmiast odzyskujesz jedną komórkę czaru 5. poziomu.</content>
-  <content contentuid="hb220d543g0de9ga76cg8f82gc0f939ce0a89" version="1">Ulepszony Ochronny rozbłysk</content>
+  <content contentuid="hb220d543g0de9ga76cg8f82gc0f939ce0a89" version="1">Ulepszony ochronny rozbłysk</content>
   <content contentuid="he222d284gfebfg2d88g1574g14e9d5ea7c35" version="1">Zyskaj tymczasowe punkty wytrzymałości równe 2k6 + modyfikator Mądrości Kleryka.</content>
   <content contentuid="h717d6a55gf9a8g7d5eg5430gc31fbe95ad80" version="1">Kolegium Duchów</content>
   <content contentuid="h6923d229ga101g2539g1a0fg9771146b44a4" version="1">Bardowie z Kolegium Duchów przywołują legendarne duchy, aby zmienić świat. Jednak takie istoty są kapryśne i to, co przywołuje Bard, nie zawsze jest pod ich całkowitą kontrolą.</content>
@@ -6405,17 +6405,17 @@ Podobnie jak inne elfy, eladriny mogą żyć ponad 750 lat.</content>
   <content contentuid="hccff7485gca62gd284gdabagfbef3ee11653" version="1">Krok Fey: Zima</content>
   <content contentuid="h9cda9df5g341bg90cag16e9gfc25dc9df498" version="1">Gdy używasz Kroku Fey, możesz dotknąć chętnej istoty w promieniu 1,5 m od siebie. Teleportuje się ona zamiast ciebie i pojawia na wybranym przez ciebie widocznym, niezajętym miejscu w promieniu 9 m od ciebie.</content>
   <content contentuid="h4a8a3d05ged7ag55e3g1276g814259823391" version="1">Natychmiast po użyciu Kroku Fey każda wybrana przez ciebie widoczna istota w promieniu 1,5 m od ciebie otrzymuje obrażenia od ognia równe twojej premii z biegłości.</content>
-  <content contentuid="h5c1e93a7g2f48g4d6bg8e13ga7f4c2b60d95" version="1">Dwulicowe czarowanie</content>
-  <content contentuid="h9a4f2b81gd37eg46c2gb058ge1d93f7a2c46" version="1">Wydaj akcję i komórkę czaru, aby skierować swoją magię przez swój duplikat. W swojej turze może rzucić jedno z przygotowanych przez ciebie czarów w tym miejscu, korzystając ze ST obronnego czarów i premii do ataku czarami – pozwalając ci rzucać tak, jakbyś znajdował się w przestrzeni iluzji.</content>
-  <content contentuid="h3f8a1c72g5e94g4b21ga7c3gd8e51f0b9a46" version="1">Dwulicowe czarowanie</content>
-  <content contentuid="h7b2e4d19gc63fg41a8gb95egf2c8a3d716b0" version="1">W swojej turze może rzucić jeden z przygotowanych przez kleryka czarów, zużywając jego komórkę czaru oraz korzystając z jego ST obrony przed czarami i premii do ataku czarami.</content>
-  <content contentuid="h4e92a1c7g63bdg48f0g9c25ga07f1b53de86" version="1">Dwulicowy sztuczka</content>
-  <content contentuid="hb1c6082fg95a4g4e37g8d16gf3ae92c04751" version="1">Wydaj akcję, aby skierować swoją magię przez swój duplikat. W swojej turze może rzucić jedną z twoich sztuczek, wykorzystując ST obronny czarów i premię do ataku czarów – pozwalając ci rzucać tak, jakbyś znajdował się w przestrzeni iluzji.</content>
-  <content contentuid="h2d47b9e1g8c35g4a70gb61fg5e8d0c34a927" version="1">Dwulicowy sztuczka</content>
-  <content contentuid="h6f81c3a5g47deg4b92g8a03gd15f92c7be48" version="1">W swojej turze może rzucić jedną ze sztuczek kleryka, korzystając z jego ST obrony przed czarami i premii do ataku czarami.</content>
+  <content contentuid="h5c1e93a7g2f48g4d6bg8e13ga7f4c2b60d95" version="1">Czarowanie przez sobowtóra</content>
+  <content contentuid="h9a4f2b81gd37eg46c2gb058ge1d93f7a2c46" version="1">Zużyj akcję i komórkę czaru, aby skierować magię przez swojego sobowtóra. W swojej turze sobowtór może rzucić jeden z przygotowanych przez ciebie czarów, zużywając tę komórkę i korzystając z twojego ST obrony przed czarami oraz premii do ataku czarami. Dzięki temu rzucasz czar tak, jakbyś znajdował się na miejscu iluzji.</content>
+  <content contentuid="h3f8a1c72g5e94g4b21ga7c3gd8e51f0b9a46" version="1">Czarowanie przez sobowtóra</content>
+  <content contentuid="h7b2e4d19gc63fg41a8gb95egf2c8a3d716b0" version="1">W swojej turze sobowtór może rzucić jeden z czarów przygotowanych przez kleryka, zużywając wydaną komórkę czaru i korzystając z jego ST obrony przed czarami oraz premii do ataku czarami.</content>
+  <content contentuid="h4e92a1c7g63bdg48f0g9c25ga07f1b53de86" version="1">Sztuczka sobowtóra</content>
+  <content contentuid="hb1c6082fg95a4g4e37g8d16gf3ae92c04751" version="1">Zużyj akcję, aby skierować magię przez swojego sobowtóra. W swojej turze sobowtór może rzucić jedną z twoich sztuczek, korzystając z twojego ST obrony przed czarami oraz premii do ataku czarami. Dzięki temu rzucasz sztuczkę tak, jakbyś znajdował się na miejscu iluzji.</content>
+  <content contentuid="h2d47b9e1g8c35g4a70gb61fg5e8d0c34a927" version="1">Sztuczka sobowtóra</content>
+  <content contentuid="h6f81c3a5g47deg4b92g8a03gd15f92c7be48" version="1">W swojej turze sobowtór może rzucić jedną ze sztuczek kleryka, korzystając z jego ST obrony przed czarami oraz premii do ataku czarami.</content>
   <content contentuid="h8774fb9bg4691ge891gcd62g04a6e30adc85" version="1">Odwróć uwagę wrogów iluzją. Ty i twoi sojusznicy macie &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AttackRoll"&gt;testach ataku&lt;/LSTag&gt; przeciwko istotom znajdującym się w promieniu [1] od iluzji, o ile atakujący również znajduje się w promieniu [1] od iluzji.</content>
   <content contentuid="h85297685gf059g72c0g4f9aga4eff80cbe14" version="1">Możesz rzucać czary tak, jakbyś znajdował się w przestrzeni iluzji, ale musisz używać własnych zmysłów.</content>
-  <content contentuid="hda020f21g72bagfe0cgda65g4bd7740d8934" version="1">Poruszaj dwulicowość</content>
+  <content contentuid="hda020f21g72bagfe0cgda65g4bd7740d8934" version="1">Przesuń sobowtóra</content>
   <content contentuid="h85215a15gab76gffacg9824gfed9a8a89e8b" version="1">W ramach akcji dodatkowej możesz przesunąć iluzję.</content>
   <content contentuid="h08ac1d1fgdd8ag32cbg0ebdgcb9a1bf0e653" version="1">Niesamowity unik</content>
   <content contentuid="h0c708c03g521bg250fg1d04g3a66d60c8fd3" version="1">Kiedy atakujący, którego widzisz, trafia cię testem ataku, możesz wykorzystać reakcję, aby zmniejszyć obrażenia z ataku o połowę (zaokrąglając w dół).</content>
@@ -6463,15 +6463,15 @@ Gdy istota trafi cię atakiem, do końca tej tury ma utrudnienie we wszystkich p
   <content contentuid="h3f4c0be2gf28cg9925g8be8g0c8a747faf6e" version="1">Możesz używać &lt;LSTag Type="Spell" Tooltip="Shout_PackHowl_Barbarian"&gt;Pobudzającego wycia&lt;/LSTag&gt;, a twoi sojusznicy mają &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AttackRoll"&gt;testach ataku&lt;/LSTag&gt; przeciwko przeciwnikom w obrębie [1] od ciebie.</content>
   <content contentuid="h162775ecg7b9egc133g5182g07c9126dbe3d" version="1">Dopóki trwa twój &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt;, możesz używać &lt;LSTag Type="Spell" Tooltip="Shout_PackHowl_Barbarian"&gt;Pobudzającego wycia&lt;/LSTag&gt;, a twoi sojusznicy wykonują z &lt;LSTag Tooltip="Advantage"&gt;ułatwieniem&lt;/LSTag&gt; &lt;LSTag Tooltip="AttackRoll"&gt;testy ataku&lt;/LSTag&gt; przeciwko wrogom w promieniu [1] od ciebie.</content>
   <content contentuid="hfc88b2cagdfdcg7342gecebg306e2918ed9e" version="1">Znajduje się w pobliżu barbarzyńcy w szale z Wilczym Sercem. &lt;br&gt;&lt;br&gt;Sojusznicy barbarzyńcy mają &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AttackRoll"&gt;testach ataku&lt;/LSTag&gt; przeciwko tej istocie.</content>
-  <content contentuid="h773e9cb8g4f4agad4egf609gdb85666d9d37" version="1">Poziom 3: Pomoc Landu</content>
-  <content contentuid="h89713adeg01adg81acg9f46g71f0e1a5f820" version="1">Poziom 6: Naturalne odzyskiwanie</content>
-  <content contentuid="h939b7cccgc964gc711gd6f5gecea12c2f0bf" version="1">Ponowna wersja Uderzenia Pustki</content>
-  <content contentuid="hb2dd14b4gba6bgdc59gf8f1g789a1ebe6b74" version="1">Ponowna wersja Uderzenia Pustki</content>
-  <content contentuid="h87fda05fg80fdg949dg6eb1g69542080219a" version="1">Zdobyto komórkę czaru poziomu [1]. Użyj tego komórki czaru przed utworzeniem kolejnego na tym samym poziomie.</content>
+  <content contentuid="h773e9cb8g4f4agad4egf609gdb85666d9d37" version="1">Poziom 3: Pomoc natury</content>
+  <content contentuid="h89713adeg01adg81acg9f46g71f0e1a5f820" version="1">Poziom 6: Naturalna regeneracja</content>
+  <content contentuid="h939b7cccgc964gc711gd6f5gecea12c2f0bf" version="1">Powtórz Uderzenie pustki</content>
+  <content contentuid="hb2dd14b4gba6bgdc59gf8f1g789a1ebe6b74" version="1">Powtórz Uderzenie pustki</content>
+  <content contentuid="h87fda05fg80fdg949dg6eb1g69542080219a" version="1">Uzyskano komórkę czaru poziomu [1]. Użyj tej komórki przed utworzeniem kolejnej na tym samym poziomie.</content>
   <content contentuid="hbb5691a5g5880g56bdg40c2g576cef554451" version="1">Wydaj punkty zaklinania, aby odblokować &lt;LSTag Tooltip="SpellSlot"&gt;komórkę czaru&lt;/LSTag&gt;. Utworzenie kolejnej komórki czaru tego samego poziomu nie przyniesie efektu, dopóki ta nie zostanie użyta.</content>
-  <content contentuid="hc69907d4g8c9eg708ag8797ge1e6e4d47653" version="1">Wydaj [1] punktów zaklinania, aby odblokować &lt;LSTag Tooltip="SpellSlot"&gt;komórkę czaru&lt;/LSTag&gt; [2]. poziomu. Utworzenie kolejnej komórki czaru tego samego poziomu nie przyniesie efektu, dopóki ta nie zostanie użyta.</content>
+  <content contentuid="hc69907d4g8c9eg708ag8797ge1e6e4d47653" version="1">Wydaj [1] punktów zaklinania, aby odblokować &lt;LSTag Tooltip="SpellSlot"&gt;komórkę czaru&lt;/LSTag&gt; poziomu [2]. Utworzenie kolejnej komórki czaru tego samego poziomu nie przyniesie efektu, dopóki ta nie zostanie użyta.</content>
   <content contentuid="h0709c013g99b0gdc6cg2addgb8ecc04296bb" version="1">Astralne zimno</content>
-  <content contentuid="hba2e93bcg0b57g355dg5803gd6ef0f19efec" version="2">Ma utrudnienie w następnym teście k20, który przeprowadza.</content>
+  <content contentuid="hba2e93bcg0b57g355dg5803gd6ef0f19efec" version="2">Ma utrudnienie w następnym teście k20, który wykonuje.</content>
   <content contentuid="h7ca33572ga86cgce48gd434gfe816699ddfd" version="1">Ślepota astralna</content>
   <content contentuid="hb37581e4g1f18gd1e2g5637g4da5058b4ddc" version="1">Postać grozy</content>
   <content contentuid="h790e3622gdcc2g6592g9c95g8de8f0b70afa" version="1">W ramach akcji dodatkowej stajesz się ucieleśnieniem przerażającej mocy swojego patrona. Poniższe korzyści utrzymują się przez 1 minutę, do chwili otrzymania stanu Obezwładnienia albo do zakończenia przemiany (bez użycia akcji). Możesz przemienić się tyle razy, ile wynosi twój modyfikator Charyzmy (co najmniej raz), a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
@@ -6501,9 +6501,9 @@ Przerażający awatar. Raz na turę, gdy trafisz istotę testem ataku, możesz z
   <content contentuid="h334bd2c8g7709g2b93g78b1g773fe3b8ebf1" version="1">Każdy z twoich ataków w formie Dzikiej postaci może zadać normalne obrażenia lub obrażenia od światłości. Dokonujesz tego wyboru za każdym razem, gdy uderzasz tymi atakami.</content>
   <content contentuid="h1bf178cfg495fgc014g2a3dg87805ddb3ddc" version="1">Rzucanie czarów jest zablokowane.</content>
   <content contentuid="h112c7e0eg78abgd915gaaeag4b58bbd6c408" version="2">Gdy korzystasz z tej akcji, nie podlegasz ograniczeniu &lt;LSTag Type="Status" Tooltip="ONE_SPELL_WITH_A_SPELL_SLOT_PER_TURN"&gt;Jeden czar z komórką czaru na turę&lt;/LSTag&gt;.</content>
-  <content contentuid="h33a18d4cgdf06g9238gf504ge24a7a01dabc" version="1">Kiedy rzucasz na Inicjatywę, możesz dodać do rzutu swoją premię z biegłości.</content>
+  <content contentuid="h33a18d4cgdf06g9238gf504ge24a7a01dabc" version="1">Gdy wykonujesz rzut na inicjatywę, możesz dodać do wyniku swoją premię z biegłości.</content>
   <content contentuid="h205a86a7g9af1g0e18g4b80gaaa69ea7a77e" version="1">Czujność</content>
-  <content contentuid="h3a9af277g0525g3e62g4bf1g23d2ae263ac0" version="2">Kiedy rzucasz na Inicjatywę, możesz dodać do rzutu swoją premię z biegłości.</content>
+  <content contentuid="h3a9af277g0525g3e62g4bf1g23d2ae263ac0" version="2">Gdy wykonujesz rzut na inicjatywę, możesz dodać do wyniku swoją premię z biegłości.</content>
   <content contentuid="h1d7e7829g98bcg7ec8g37bbg4e4af1943eb8" version="1">Adept rytuałów</content>
   <content contentuid="hb170c461g64a8ga1b1g8e92g84265039c932" version="1">Przywołujesz duchy z Planów Żywiołów, które przez pewien czas krążą wokół ciebie w 4,5-metrowej Emanacji. Dopóki czar się nie skończy, każdy wykonany przez ciebie atak zadaje dodatkowe obrażenia, gdy trafisz istotę w Emanacji. Te obrażenia to Kwas, Zimno, Ogień lub Błyskawica (twój wybór podczas wykonywania ataku).
 
@@ -6525,11 +6525,11 @@ Ponadto teren w Emanacji jest Trudnym Terenem dla twoich wrogów.</content>
   <content contentuid="hd88ee8a8g1552gb464g7097g6ea7fa9ece9c" version="1">Dopóki czar się nie skończy, każdy wykonany przez ciebie atak zadaje dodatkowe obrażenia od ognia, gdy trafisz istotę w Emanacji.</content>
   <content contentuid="hdc99cc75g8f81g0397g1018gfde4fcc5be57" version="1">Wyczarowanie mniejszych żywiołaków: Elektryczność</content>
   <content contentuid="h89c8ae11gbccagbb70g3473gb3bc505a78c1" version="1">Dopóki czar się nie skończy, każdy wykonany przez ciebie atak zadaje dodatkowe obrażenia od elektryczności, gdy trafisz istotę w Emanacji.</content>
-  <content contentuid="h94c82192gf055gfc18gd5bfgfcedb51b258c" version="1">Przywołaj cel mniejszych żywiołaków</content>
+  <content contentuid="h94c82192gf055gfc18gd5bfgfcedb51b258c" version="1">Cel wyczarowania mniejszych żywiołaków</content>
   <content contentuid="h20a9acf5g3464g7749g7665g0da6684092ca" version="1">Objęta emanacją czaru &lt;LSTag Type="Spell" Tooltip="Target_ConjureElementals_Minor_Container"&gt;Przywołanie mniejszego żywiołaka&lt;/LSTag&gt;: podłoże pod tą istotą jest trudnym terenem, a ataki rzucającego zadają jej dodatkowe obrażenia.</content>
-  <content contentuid="h3fc5f406g8b36gf617gf0f4ga02e99f55658" version="2">Smoczy Duch</content>
+  <content contentuid="h3fc5f406g8b36gf617gf0f4ga02e99f55658" version="2">Smoczy duch</content>
   <content contentuid="h8925bf96gcc33g196cg6b28ga8e21a86bf29" version="1">Przyzwanie smoka</content>
-  <content contentuid="h9d6713c3gcb8cgea0fg44deg1925c2bcb55d" version="1">Przywołujesz ducha smoka. Manifestuje się w niezajętej przestrzeni, którą możesz zobaczyć w zasięgu i wykorzystuje blok statystyk Smoczego Ducha. Istota znika, gdy jego punkty wytrzymałości spadną do 0 lub gdy czar dobiegnie końca.</content>
+  <content contentuid="h9d6713c3gcb8cgea0fg44deg1925c2bcb55d" version="1">Przywołujesz ducha smoka. Pojawia się on na widocznym, niezajętym miejscu w zasięgu i korzysta z bloku statystyk Smoczego ducha. Istota znika, gdy jej punkty wytrzymałości spadną do 0 albo gdy czar dobiegnie końca.</content>
   <content contentuid="h88c9e233gb77ag41d0gb825g12501107b4ba" version="1">Zwój przyzwania smoka</content>
   <content contentuid="h510fe56fgce89g4c30g9446g93901bf4db4c" version="1">Dostępne klasy: Mag</content>
   <content contentuid="h8933e173gb36agbf40ge97fg7e76f31c0d5c" version="1">Istotę nawiedzają jej najgorsze koszmary.&lt;br&gt;&lt;br&gt;Otrzymuje [1] na turę i ma &lt;LSTag Tooltip="Disadvantage"&gt;utrudnienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach cech&lt;/LSTag&gt; oraz &lt;LSTag Tooltip="AttackRoll"&gt;testach ataku&lt;/LSTag&gt;.</content>


### PR DESCRIPTION
## Summary

- align the Cleave, Push, and Topple mastery-property names with current Polish D&D 2024 terminology
- use the official Polish BG3 terms for Warding Flare, Invoke Duplicity, and the Flaming Fist
- align Land's Aid and Natural Recovery with the current Polish D&D 2024 community corpus
- fix recast-action labels, spell-slot grammar, duplicate/summon wording, and several clear agreement or repetition errors

## Validation

- 5,355 English and 5,355 Polish handles; no missing, extra, or duplicate content UIDs
- no content UID or version changes
- full structural and coverage audits: 0 findings
- spell audit: 0 structural errors, 0 language errors, 0 official title/description mismatches, and 0 missing custom spell titles
- `git diff --check` passes

## Credit request

As requested previously, please credit both translations to the community and link the name to our Discord:

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)

This pull request still changes only `polish.xml`, in accordance with the translation workflow.