### PR TITLE
Align embedded Polish feat labels

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -932,7 +932,7 @@ Po wybraniu czaru tryb się kończy.</content>
 
 Specjalizujesz się w manipulacji, masz skłonność do koloryzowania i chętnie wykorzystujesz to dla własnych korzyści. Naginanie prawdy i nastawianie sojuszników przeciwko sobie może z czasem przynieść jeszcze większe sukcesy.</content>
   <content contentuid="h4b835e70g04c6g5a06g0c6dg1a3127667686" version="1">Przestępca</content>
-  <content contentuid="hbcaf83c9gb788g62e0g6965g3fa62228f254" version="3">Atut: Alarm
+  <content contentuid="hbcaf83c9gb788g62e0g6965g3fa62228f254" version="3">Atut: Czujność
 
 Masz doświadczenie w łamaniu prawa oraz wykorzystywaniu szemranych kontaktów i powiązań. Czerpanie korzyści z działań przestępczych otworzy nowe możliwości w przyszłości.</content>
   <content contentuid="h71130c00gf7fegc295g7a78g226b23bab525" version="1">Artysta</content>
@@ -960,11 +960,11 @@ Dzicz jest twoim domem, a przetrwanie z dala od wygód cywilizacji — codzienno
 
 Odznaczasz się erudycją i ciekawością świata oraz niezaspokojonym pragnieniem wiedzy. Poznawanie rzadkich tajemnic świata inspiruje cię, by wykorzystać tę wiedzę do wyższych celów.</content>
   <content contentuid="h8109bc16gabcag925cgdd47gb46dba14be0c" version="1">Żołnierz</content>
-  <content contentuid="hc868035bgcc3dg4f6ag8137g0a3e325b8ba7" version="3">Atut: Dziki napastnik
+  <content contentuid="hc868035bgcc3dg4f6ag8137g0a3e325b8ba7" version="3">Atut: Brutalny napastnik
 
 Wyszkolono cię w walce i taktyce bojowej. Masz za sobą służbę w milicji, kompanii najemniczej czy korpusie oficerskim. Wykazując się odwagą i biegłością taktyczną na polu walki, zwiększasz swoją sprawność.</content>
   <content contentuid="hc87a3f0fgaf2eg6057g69fbg9ba7b0e2f7bb" version="1">Ulicznik</content>
-  <content contentuid="h9f4e80c6g4dd1gb652gbb63g04b844b503ae" version="3">Atut: Dziki napastnik
+  <content contentuid="h9f4e80c6g4dd1gb652gbb63g04b844b503ae" version="3">Atut: Brutalny napastnik
 
 Twoje dzieciństwo upłynęło w biedzie, dlatego wiesz, jak w pełni wykorzystać skąpe zasoby. Zaradność pozwala ci zachować ducha na drogę, która jest przed tobą.</content>
   <content contentuid="h15a25456g93c5g2128g2199gd75ca7acd724" version="1">Atut pochodzenia: Uzdolniony</content>
@@ -1018,7 +1018,7 @@ Zachęcająca pieśń. Po ukończeniu krótkiego albo długiego odpoczynku może
   <content contentuid="h7cf9e06ag9d1dga32egceb0gbe819d69f976" version="1">Atut pochodzenia: Brutalny napastnik</content>
   <content contentuid="hdea0235fg740bg417fgb072ga3c6f349d4c3" version="1">Wykonując ataki bronią, rzucasz dwukrotnie kośćmi obrażeń i wykorzystujesz najwyższy wynik.</content>
   <content contentuid="h4c3975fag2626gb08fg2d75g1948720b803b" version="1">Nawiedzeniec</content>
-  <content contentuid="h7177de01ge0f7g8a37g6b7cgdf616c3162ac" version="3">Atut: Alarm
+  <content contentuid="h7177de01ge0f7g8a37g6b7cgdf616c3162ac" version="3">Atut: Czujność
 
 Przerażająca chwila, osoba lub istota, której nie można zgładzić mieczem ani czarami, nawiedza twój umysł – kątem oka cały czas widzisz jej cień. Niesiesz ją ze sobą wszędzie, gdzie zaprowadzi cię twoja przygoda – a może to ona niesie ciebie?</content>
   <content contentuid="h474bba76g8c7bgfd74gc3c7g3360b0f62570" version="1">Atut pochodzenia: Szczęściarz</content>
@@ -1029,7 +1029,7 @@ Przerażająca chwila, osoba lub istota, której nie można zgładzić mieczem a
   <content contentuid="he017d973g0291gbe65g86dbgfc62954d6af5" version="3">Szybkie powstanie. Gdy masz stan Powalenia, możesz wstać, zużywając tylko 1,5 m ruchu.
 
 Skakanie. Raz na turę możesz wykonać Skok, zużywając tylko 3 m ruchu.</content>
-  <content contentuid="h4fa37f8dgea0ag8e9eg9222g12cdf8ef50af" version="1">Atut: Sportowiec</content>
+  <content contentuid="h4fa37f8dgea0ag8e9eg9222g12cdf8ef50af" version="1">Atut: Atleta</content>
   <content contentuid="hac8cf59bgb29dg6896g2a11g689bf333570e" version="3">Szybkie powstanie. Gdy masz stan Powalenia, możesz wstać, zużywając tylko 1,5 m ruchu.
 
 Skakanie. Raz na turę możesz wykonać Skok, zużywając tylko 3 m ruchu.</content>
@@ -1037,7 +1037,7 @@ Skakanie. Raz na turę możesz wykonać Skok, zużywając tylko 3 m ruchu.</cont
   <content contentuid="h9ed109c6ga680g6d73gce1ag6e136e676cb2" version="2">Ulepszony sprint. Gdy wykonujesz akcję Sprintu, twoja szybkość wzrasta o 3 m na czas tej akcji.
 
 Atak szarżą. Jeśli bezpośrednio przed trafieniem celu atakiem wręcz wykonywanym w ramach akcji Ataku przemieścisz się co najmniej 3 m w linii prostej w jego stronę, wybierz jeden z następujących efektów: dodaj 1k8 do rzutu obrażeń tego ataku albo odepchnij cel na maksymalnie 3 m, jeśli jest nie więcej niż o jeden rozmiar większy od ciebie. Z tej korzyści możesz skorzystać tylko raz na turę.</content>
-  <content contentuid="hbc6e4744g6835g4d25g3453g224b9eed2a70" version="1">Atut: Ładowarka</content>
+  <content contentuid="hbc6e4744g6835g4d25g3453g224b9eed2a70" version="1">Atut: Szarża</content>
   <content contentuid="h4e972de5g72bbgc7d9gfda3g1c89f2af41d0" version="2">Ulepszony &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Sprint&lt;/LSTag&gt;. Gdy wykonujesz akcję Sprintu, twoja szybkość wzrasta o 3 m na czas tej akcji.
 
 Atak szarżą. Jeśli bezpośrednio przed trafieniem celu atakiem wręcz wykonywanym w ramach akcji Ataku przemieścisz się co najmniej 3 m w linii prostej w jego stronę, wybierz jeden z następujących efektów: dodaj 1k8 do rzutu obrażeń tego ataku albo odepchnij cel na maksymalnie 3 m, jeśli jest nie więcej niż o jeden rozmiar większy od ciebie. Z tej korzyści możesz skorzystać tylko raz na turę.</content>
@@ -1045,18 +1045,18 @@ Atak szarżą. Jeśli bezpośrednio przed trafieniem celu atakiem wręcz wykonyw
   <content contentuid="hc7b891e9gd9c0g1617g0233ga492c5e47dc7" version="2">Strzelanie w walce wręcz. Obecność wroga w promieniu 1,5 m nie powoduje utrudnienia w twoich testach ataku z kuszy.
 
 Raniący bełt. Gdy trafisz istotę atakiem dystansowym, możesz nałożyć na nią stan &lt;LSTag Type="Status" Tooltip="GAPING_WOUND"&gt;Rozdzierających ran&lt;/LSTag&gt;.</content>
-  <content contentuid="h2b11e796g7a1fga346gb3e4g85e96274b6ef" version="1">Atut: Ekspert kuszy (Zranienie)</content>
+  <content contentuid="h2b11e796g7a1fga346gb3e4g85e96274b6ef" version="1">Atut: Specjalista kusznik (raniący bełt)</content>
   <content contentuid="h48bb1d7fga4e5g9f8fga414g0fe42c7616ac" version="1">Kiedy trafisz istotę atakiem dystansowym, ma ona szansę otrzymać stan &lt;LSTag Type="Status" Tooltip="GAPING_WOUND"&gt;rozdzierające rany&lt;/LSTag&gt;.</content>
-  <content contentuid="h9dde7fdcgac74g74cag98d7g044c58ef3023" version="1">Atut: Ekspert w kuszy (celnie)</content>
+  <content contentuid="h9dde7fdcgac74g74cag98d7g044c58ef3023" version="1">Atut: Specjalista kusznik (strzelanie w zwarciu)</content>
   <content contentuid="h32eff9e8g416dgc4dagd8e6g74260b215e68" version="1">Mistrz zasłony</content>
   <content contentuid="hd032f660g8a39g73eagc4bdgd4038c7dc8de" version="2">Parowanie. Jeśli trzymasz broń Finezja, a inna istota trafi cię atakiem wręcz, możesz wykonać reakcję, aby dodać swoją premię z biegłości do swojej klasy pancerza, potencjalnie powodując, że atak cię ominie. Otrzymujesz tę premię do AC przeciwko atakom wręcz do początku twojej następnej tury.</content>
-  <content contentuid="h208b7de3g5f3cge001gfe82gdd2940dee59c" version="1">Atut: Pojedynek w defensywie</content>
+  <content contentuid="h208b7de3g5f3cge001gfe82gdd2940dee59c" version="1">Atut: Mistrz zasłony</content>
   <content contentuid="hfd0b3091g52f6g2cd7ga7cbg9c61332d3252" version="1">Jeśli trzymasz broń Finezja, a inna istota trafi cię atakiem wręcz, możesz wykonać reakcję, aby dodać swoją premię z biegłości do swojej klasy pancerza, potencjalnie powodując, że atak cię ominie. Otrzymujesz tę premię do AC przeciwko atakom wręcz do początku twojej następnej tury.</content>
   <content contentuid="hfa2c5254ge5fag62b7gffb6g392787c61974" version="1">Oburęczny</content>
   <content contentuid="h2d809685g28ffge26ag3e6ag5fa20f63c9e3" version="7">Możesz korzystać z walki dwiema broniami, nawet jeśli twoje bronie nie mają właściwości &lt;LSTag Tooltip="Light"&gt;Lekka&lt;/LSTag&gt;. Nie możesz walczyć dwiema broniami &lt;LSTag Tooltip="TwoHanded"&gt;Dwuręcznymi&lt;/LSTag&gt;.&lt;br&gt;&lt;br&gt;Gdy w swojej turze wykonujesz akcję Ataku i atakujesz bronią do walki wręcz, możesz później w tej samej turze wykonać jeden atak drugą ręką w ramach akcji dodatkowej. Jeśli masz mistrzostwo we właściwości Nacięcie i trzymasz w drugiej ręce broń z tą właściwością, możesz wykonać do dwóch ataków drugą ręką na turę.</content>
-  <content contentuid="h720a62a8g5de9g9909gb1cagf61131cf2df9" version="1">Atut: Podwójny dzierżyciel (dodatkowy atak)</content>
+  <content contentuid="h720a62a8g5de9g9909gb1cagf61131cf2df9" version="1">Atut: Oburęczny (dodatkowy atak)</content>
   <content contentuid="h5cc813aagcb96gf7f3g42e4g17b7234b86eb" version="1">Możesz wykonać jeden atak z drugiej ręki, nie wydając akcji ani akcji dodatkowej. Możesz skorzystać z tej korzyści raz na turę.</content>
-  <content contentuid="h7ed3574cg898aga3cage4bcg72bfa5e60a5c" version="1">Atut: Podwójny posiadacz</content>
+  <content contentuid="h7ed3574cg898aga3cage4bcg72bfa5e60a5c" version="1">Atut: Oburęczny</content>
   <content contentuid="hb2bf6fc5g6c41geefag4186g751dda5c0a20" version="1">Atak drugiej ręki (dwie ręce)</content>
   <content contentuid="hfba39959g9b2dg1bffgffd6g069588fe122e" version="1">Badacz podziemi</content>
   <content contentuid="h9dd8a551g9f01g98dbg64f1ga485e59f0e9d" version="2">Zyskujesz &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Percepcji&lt;/LSTag&gt; wykonywanych, aby wykrywać ukryte przedmioty, oraz w &lt;LSTag Tooltip="SavingThrow"&gt;rzutach obronnych&lt;/LSTag&gt; wykonywanych, aby unikać pułapek lub opierać się ich efektom.
@@ -1072,7 +1072,7 @@ Szybki powrót do zdrowia. Po wyleczeniu odzyskujesz maksymalną możliwą &lt;L
   <content contentuid="h00f044d5gf4edgc900g397bgca53d410bdad" version="2">Mistrzostwo w Ciężkiej Broni. Gdy trafisz istotę bronią o właściwości Ciężka w ramach akcji Ataku w swojej turze, możesz sprawić, że broń zada dodatkowe obrażenia celowi. Dodatkowe obrażenia są równe twojej premii z biegłości.
 
 Rąbanie. Natychmiast po uzyskaniu trafienia krytycznego bronią do walki wręcz lub po zredukowaniu punktów wytrzymałości istoty do 0 przy jej użyciu, możesz wykonać jeden atak tą samą bronią jako akcję dodatkową.</content>
-  <content contentuid="h349877e7geb40gb92agf0ebg6d7a8824b88d" version="1">Atut: Wielki mistrz broni</content>
+  <content contentuid="h349877e7geb40gb92agf0ebg6d7a8824b88d" version="1">Atut: Mistrz broni dwuręcznej</content>
   <content contentuid="hf5c74f9cg9d34g5f2dgb774g506b6adf6782" version="1">Mistrzostwo w Ciężkiej Broni. Gdy trafisz istotę bronią o właściwości Ciężka w ramach akcji Ataku w swojej turze, możesz sprawić, że broń zada dodatkowe obrażenia celowi. Dodatkowe obrażenia są równe twojej premii z biegłości.
 
 Rąbanie. Natychmiast po uzyskaniu trafienia krytycznego bronią do walki wręcz lub po zredukowaniu punktów wytrzymałości istoty do 0 przy jej użyciu, możesz wykonać jeden atak tą samą bronią jako akcję dodatkową.</content>
@@ -1082,7 +1082,7 @@ Rąbanie. Natychmiast po uzyskaniu trafienia krytycznego bronią do walki wręcz
   <content contentuid="h514d8491g4149gd42dgac44g49eb428cfab7" version="1">Zyskujesz &lt;LSTag Tooltip="ArmourProficiency"&gt;biegłość&lt;/LSTag&gt; dzięki ciężkiemu pancerzowi.</content>
   <content contentuid="h839231bbgeb1bg509bgdb9cge3286fb2cd64" version="1">Mistrz ciężkiego pancerza</content>
   <content contentuid="h0266d9b6g2d5egdfa6g1bfag6db68cf5e3ff" version="1">Redukcja Obrażeń. Gdy zostaniesz trafiony atakiem podczas noszenia Ciężkiego pancerza, wszelkie obrażenia obuchowe, kłute i cięte zadane ci przez ten atak są zmniejszane o wartość równą twojej premii z biegłości.</content>
-  <content contentuid="h05dbc595g938dgf8c5geb8ag232d7f8f255a" version="1">Atut: Mistrz ciężkiej zbroi</content>
+  <content contentuid="h05dbc595g938dgf8c5geb8ag232d7f8f255a" version="1">Atut: Mistrz ciężkiego pancerza</content>
   <content contentuid="h321dea39gd6d7g8505g1460ga4f1c96684b4" version="1">Redukcja Obrażeń. Gdy zostaniesz trafiony atakiem podczas noszenia Ciężkiego pancerza, wszelkie obrażenia obuchowe, kłute i cięte zadane ci przez ten atak są zmniejszane o wartość równą twojej premii z biegłości.</content>
   <content contentuid="h494aa429g631cgf105g1994g4c64836d3f3d" version="1">Lekko opancerzony</content>
   <content contentuid="h1bf3ecc0g938dg39f4g8e16gfe946978878f" version="1">Trening w Pancerzu. Zyskujesz biegłość w Lekkich pancerzach i Tarczach.</content>
@@ -1092,14 +1092,14 @@ Rąbanie. Natychmiast po uzyskaniu trafienia krytycznego bronią do walki wręcz
   <content contentuid="h97c2a4b1gf596g1516g285eg988549b0ed6f" version="1">Przełamywanie koncentracji. Gdy zadasz obrażenia istocie utrzymującej koncentrację, ma ona utrudnienie w rzucie obronnym wykonywanym w celu jej podtrzymania.
 
 Chroniony umysł. Gdy nie powiedzie ci się rzut obronny na Inteligencję, Mądrość albo Charyzmę, możesz zamiast tego odnieść powodzenie. Po użyciu tej korzyści musisz ukończyć krótki albo długi odpoczynek, zanim użyjesz jej ponownie.</content>
-  <content contentuid="h686b506cg3f99g1c96gdcfcgfd54e5d46f19" version="1">Atut: Pogromca Magów</content>
+  <content contentuid="h686b506cg3f99g1c96gdcfcgfd54e5d46f19" version="1">Atut: Zabójca magów</content>
   <content contentuid="hfc9071adg34ddg859egdda4g444a72c4713f" version="1">Przełamywanie koncentracji. Gdy zadasz obrażenia istocie utrzymującej koncentrację, ma ona utrudnienie w rzucie obronnym wykonywanym w celu jej podtrzymania.
 
 Chroniony umysł. Gdy nie powiedzie ci się rzut obronny na Inteligencję, Mądrość albo Charyzmę, możesz zamiast tego odnieść powodzenie. Po użyciu tej korzyści musisz ukończyć krótki albo długi odpoczynek, zanim użyjesz jej ponownie.</content>
   <content contentuid="h64d74f86g3068g8d76g0cd1g2ed854b87962" version="1">Strzeżony umysł</content>
   <content contentuid="hd944c877g9f95g1749ge647gfe18b6b31562" version="1">Gdy nie zdasz rzutu obronnego na Inteligencję, Mądrość albo Charyzmę, możesz zamiast tego uznać go za udany. Po skorzystaniu z tej korzyści nie możesz zrobić tego ponownie, dopóki nie ukończysz krótkiego albo długiego odpoczynku.</content>
   <content contentuid="hf3cb4188g698ag0e09ge5b7g7087f12e55e8" version="1">Atut: Adept sztuk walki</content>
-  <content contentuid="h8c96ebffgfa30ge6e9g2670ge4e2af8fb180" version="1">Atut: Mistrz średniej zbroi</content>
+  <content contentuid="h8c96ebffgfa30ge6e9g2670ge4e2af8fb180" version="1">Atut: Mistrz średniego pancerza</content>
   <content contentuid="h9f345cf4g20e3g3adbg0568g4c6d7a467ed6" version="2">Szybki</content>
   <content contentuid="h9aba9e0ag4af1g9f8fg922ag7e65e5b8a86b" version="2">Zwiększenie szybkości. Twoja szybkość wzrasta o 3 m.
 
@@ -1141,12 +1141,12 @@ Reakcyjne uderzenie. Gdy trzymasz kij bojowy, włócznię albo broń o właściw
   <content contentuid="ha5d92735g8afdga8f3ge1c5g5b06d62a50e6" version="1">Atut: Odporność (Siła)</content>
   <content contentuid="he4365c80ga72cgc5ebg1ae0g6a84db454a82" version="1">Atut: Odporność (Mądrość)</content>
   <content contentuid="h1015def7gafdbg59d8g86d2g26b83e1c4b9e" version="1">Wartownik</content>
-  <content contentuid="h531047f9gd6d4g5415g3f87gada7b4be2fa4" version="1">Gdy przeciwnik w zasięgu walki wręcz atakuje sojusznika, możesz użyć &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;reakcji&lt;/LSTag&gt;, aby zaatakować go bronią. Wybrany sojusznik nie może mieć atutu Strażnik.
+  <content contentuid="h531047f9gd6d4g5415g3f87gada7b4be2fa4" version="1">Gdy przeciwnik w zasięgu walki wręcz atakuje sojusznika, możesz użyć &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;reakcji&lt;/LSTag&gt;, aby zaatakować go bronią. Wybrany sojusznik nie może mieć atutu Wartownik.
 
 Masz &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="OpportunityAttack"&gt;atakach okazyjnych&lt;/LSTag&gt;, a gdy trafisz istotę atakiem okazyjnym, nie może się ona przemieszczać do końca swojej tury.</content>
-  <content contentuid="h7e48c498g5f4dgcd45g58fdgd35b898ea7df" version="1">Atut: Strażnik (Zemsta)</content>
-  <content contentuid="h23b78c62ge069ge2ccg2684g43996096895b" version="1">Atut: Strażnik (ułatwienie okazji)</content>
-  <content contentuid="h5fb8bed9g9cd0g8557g68degf654e2c0ae58" version="1">Atut: Wartownik (Sidła)</content>
+  <content contentuid="h7e48c498g5f4dgcd45g58fdgd35b898ea7df" version="1">Atut: Wartownik (odwet)</content>
+  <content contentuid="h23b78c62ge069ge2ccg2684g43996096895b" version="1">Atut: Wartownik (ułatwienie w atakach okazyjnych)</content>
+  <content contentuid="h5fb8bed9g9cd0g8557g68degf654e2c0ae58" version="1">Atut: Wartownik (unieruchomienie)</content>
   <content contentuid="h90887d29g0a12g4a4eg7f87ga23f7765f7dc" version="1">Strzelec wyborowy</content>
   <content contentuid="h5b4e785ag06afgf727gca99g7e0aa28facda" version="3">Omijanie osłony. Twoje &lt;LSTag Tooltip="RangedWeaponAttack"&gt;ataki bronią dystansową&lt;/LSTag&gt; nie otrzymują kar wynikających z &lt;LSTag Tooltip="HighGroundRules"&gt;zasady ułatwienia wysokości&lt;/LSTag&gt;.
 
@@ -1177,7 +1177,7 @@ Osłona tarczą. Gdy podlegasz efektowi, który pozwala ci wykonać rzut obronny
 Rzucanie czarów w zwarciu. Przebywanie w odległości 1,5 m od wroga nie nakłada utrudnienia na twoje testy ataku czarami.
 
 Zwiększony zasięg. Zwiększa zasięg czarów o 50%.</content>
-  <content contentuid="h83a93112gc496g26f6g27f3ge5d63171ca0b" version="2">Atut: Czar Snajpera (dystansowy)</content>
+  <content contentuid="h83a93112gc496g26f6g27f3ge5d63171ca0b" version="2">Atut: Mistyczny strzelec (dystansowy)</content>
   <content contentuid="h14ab49cfg831ag83b9g1ddcgbadda155b2c0" version="2">Osłona obejścia. Twoje ataki czarami dystansowymi nie podlegają karom na mocy &lt;LSTag Tooltip="HighGroundRules"&gt;Zasady Wysokiego Poziomu&lt;/LSTag&gt;.
 
 Zwiększony zasięg. Zwiększa zasięg czarów o 50%.</content>
@@ -1189,13 +1189,13 @@ Możesz również w ramach &lt;LSTag Type="ActionResource" Tooltip="ReactionActi
   <content contentuid="h71ada843g58a3g712bgd82agc840de1595e5" version="2">Zyskujesz &lt;LSTag Tooltip="Proficiency"&gt;biegłość&lt;/LSTag&gt; w posługiwaniu się bronią bojową.
 
 Otrzymujesz dwie wybrane przez siebie właściwości mistrzostwa w broni.</content>
-  <content contentuid="h70813330g91cdg841fgd506g43cca562e934" version="1">Atut: Czar Snajpera (Wręcz)</content>
+  <content contentuid="h70813330g91cdg841fgd506g43cca562e934" version="1">Atut: Mistyczny strzelec (wręcz)</content>
   <content contentuid="hd8edfd84g6945ged2dg5a75gac1ea9cf87c7" version="1">Rzucanie czarów w zwarciu. Przebywanie w odległości 1,5 m od wroga nie nakłada utrudnienia na twoje testy ataku czarami.</content>
   <content contentuid="he811ea2cg5f7ega90cgc208g301ddc5eb96c" version="1">Atut: Mag bitewny</content>
   <content contentuid="h2d86c838g5e8cg8763gdf9bgaeb1290ded87" version="1">Masz &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="SavingThrow"&gt;rzutach obronnych&lt;/LSTag&gt; wykonywanych, by utrzymać &lt;LSTag Tooltip="Concentration"&gt;koncentrację&lt;/LSTag&gt; na czarze.
 
 W ramach &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;reakcji&lt;/LSTag&gt; możesz rzucić &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Porażający uścisk&lt;/LSTag&gt; na cel opuszczający twój zasięg walki wręcz.</content>
-  <content contentuid="h6f27cfe3g88f5geb3eg8790gd6ce157dfac9" version="1">Atut: Mistrz broni</content>
+  <content contentuid="h6f27cfe3g88f5geb3eg8790gd6ce157dfac9" version="1">Atut: Mistrz oręża</content>
   <content contentuid="hba5a50e4g4e44gccaag18b0ga7d653029db5" version="3">Zyskujesz &lt;LSTag Tooltip="Proficiency"&gt;biegłość&lt;/LSTag&gt; w posługiwaniu się bronią bojową.
 
 Otrzymujesz dwie wybrane przez siebie właściwości mistrzostwa w broni.</content>
@@ -1620,7 +1620,7 @@ Przy niepowodzeniu przez czas trwania czaru ma utrudnienie we wszystkich testach
 Masz &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="SavingThrow"&gt;rzutach obronnych&lt;/LSTag&gt; wykonywanych, by unikać pułapek, oraz &lt;LSTag Tooltip="Resistant"&gt;odporność&lt;/LSTag&gt; na obrażenia od pułapek.
 
 Widzisz w ciemności na odległość do [1].</content>
-  <content contentuid="h1e93417ag9497g58f3ge9aag2e54d8ba4076" version="1">Atut: Trwały</content>
+  <content contentuid="h1e93417ag9497g58f3ge9aag2e54d8ba4076" version="1">Atut: Twardziel</content>
   <content contentuid="hf12dc8a9g3079g890agb1ffgdf7b91f3c03d" version="2">Oporny na śmierć. Masz ułatwienie na Rzuty Obronne przeciwko Śmierci.
 
 Szybki powrót do zdrowia. Po wyleczeniu odzyskujesz maksymalną możliwą &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;.</content>
@@ -1660,7 +1660,7 @@ Leczenie. Za każdym razem, gdy przywracasz istocie punkty wytrzymałości, odzy
 Leczenie. Za każdym razem, gdy przywracasz istocie punkty wytrzymałości, odzyskuje ona dodatkowe punkty wytrzymałości w liczbie równej twojej premii z biegłości.</content>
   <content contentuid="h871f4affg0f96gce2fg8f99g76c6d4b04da1" version="2">Podręcznik gracza: Atuty pochodzenia</content>
   <content contentuid="hc54d8cd4g6034g8a1ag1af3g0f14cef04940" version="2">Podręcznik gracza: Ogólne atuty</content>
-  <content contentuid="hd28472dcg3ccag8ba5g3424g645e17f370db" version="1">Atut: Kruszarka</content>
+  <content contentuid="hd28472dcg3ccag8ba5g3424g645e17f370db" version="1">Atut: Zgniatacz</content>
   <content contentuid="h9ac2c1d5gd0dcga37bgf4d5gb17546182f77" version="3">Odepchnięcie. Gdy trafisz istotę atakiem zadającym obrażenia obuchowe, możesz przesunąć ją o 1,5 m na niezajęte miejsce, jeśli cel jest od ciebie większy najwyżej o jeden rozmiar.
 
 Wzmocnione trafienie krytyczne. Gdy uzyskasz trafienie krytyczne zadające istocie obrażenia obuchowe, testy ataku przeciwko niej mają ułatwienie do początku twojej następnej tury.</content>
@@ -1684,7 +1684,7 @@ Wzmocnione trafienie krytyczne. Gdy uzyskasz trafienie krytyczne zadające istoc
   <content contentuid="he322b215g4b74g107eg1abfg1d7e848abd23" version="2">Podcięcie. Raz na turę, gdy trafisz istotę atakiem zadającym obrażenia cięte, możesz zmniejszyć jej szybkość o 3 m do początku swojej następnej tury.
 
 Wzmocnione trafienie krytyczne. Gdy uzyskasz trafienie krytyczne zadające istocie obrażenia cięte, wykonuje ona z utrudnieniem testy ataku do początku twojej następnej tury.</content>
-  <content contentuid="h2bcebb1fgce9aga6edgfb96gb1208491f0c1" version="1">Atut: Wojownik na koniu</content>
+  <content contentuid="h2bcebb1fgce9aga6edgfb96gb1208491f0c1" version="1">Atut: Kawalerzysta</content>
   <content contentuid="h3242d16eg8787g1d4cg8a1ag1ed7c22edd47" version="2">Gdy dosiadasz wierzchowca, masz ułatwienie w testach ataku wręcz przeciwko istotom o małym lub mniejszym rozmiarze. Ponadto, gdy jesteś na wierzchowcu, nie możesz z niego zsiąść ani przewrócić się na ziemię w wyniku otrzymania obrażeń.</content>
   <content contentuid="hadc251cegfa83ge72dgb40fg8799ee8d6cfe" version="1">Atak rumaka</content>
   <content contentuid="h6abe2717g78bdgfbc5g2d30g1cc22e96ca24" version="1">Rusz naprzód i zaatakuj pierwszego wroga na swojej drodze.</content>
@@ -2132,7 +2132,7 @@ Po użyciu tej cechy nie możesz zrobić tego ponownie, dopóki nie ukończysz k
   <content contentuid="h917f9908g4fcbge66dgb997gdac87ffc4aff" version="1">Czar kończy się, gdy twoje punkty wytrzymałości spadną do 0. Kończy się również, jeśli zostanie ponownie rzucony na którąkolwiek z połączonych istot. Działa tylko wtedy, gdy ty i cel znajdujecie się nie dalej niż 18 m od siebie.</content>
   <content contentuid="h90381d36g6a66g678dgc622g940db553e2a2" version="1">Atut: Dotknięty przez Fey</content>
   <content contentuid="hfaef3824g8845gb735gf4dfgd86da7822941" version="1">Wybierz jeden czar 1. kręgu ze szkoły wróżenia lub uroków. Zawsze masz przygotowany ten czar oraz Krok przez mgłę. Otrzymujesz również jedną komórkę czaru 1. kręgu i jedną komórkę 2. kręgu.</content>
-  <content contentuid="h373ea885g4542g96b0g1626g9afe46582637" version="1">Atut: Dotyk Cienia</content>
+  <content contentuid="h373ea885g4542g96b0g1626g9afe46582637" version="1">Atut: Dotknięty przez Cień</content>
   <content contentuid="h0c8f8629gcdb5g21d2g6ba3g68301d16a9ea" version="1">Wybierz jeden czar 1. kręgu ze szkoły iluzji lub nekromancji. Zawsze masz przygotowany ten czar oraz &lt;LSTag Type="Spell" Tooltip="Target_Invisibility"&gt;Niewidzialność&lt;/LSTag&gt;. Otrzymujesz również jedną komórkę czaru 1. kręgu i jedną komórkę 2. kręgu.</content>
   <content contentuid="h3e078741g3071gaa98ga931g651f9cac58d8" version="1">Dotknięty przez Fey</content>
   <content contentuid="h9dd19073g7262gabe8g561dga56e7269712b" version="1">Wybierz jeden czar 1. kręgu ze szkoły wróżenia lub uroków. Zawsze masz przygotowany ten czar oraz Krok przez mgłę. Otrzymujesz również jedną komórkę czaru 1. kręgu i jedną komórkę 2. kręgu.</content>
@@ -2180,7 +2180,7 @@ Po użyciu tej cechy nie możesz zrobić tego ponownie, dopóki nie ukończysz k
   <content contentuid="h97a5bcafge6d2g4934ga19bg37906036d192" version="1">Cienista magia: Promień zatrucia</content>
   <content contentuid="h46162844g8514g42c9g8a0bg5ec0e854c4ee" version="1">Dotknięty przez cień: Gniewne ugodzenie</content>
   <content contentuid="h6d721699g12f1g47a5g9e59gb8faf326752a" version="1">Cienista magia: Gniewne ugodzenie</content>
-  <content contentuid="h217127dag7542g9cacg618cg5aa51ecced4b" version="1">Atut: Inspirujący przywódca</content>
+  <content contentuid="h217127dag7542g9cacg618cg5aa51ecced4b" version="1">Atut: Przywódca</content>
   <content contentuid="h008b1355g9855gf610g8c06gec5ceab5ab6f" version="1">Po zakończeniu krótkiego lub długiego odpoczynku możesz dać inspirujący występ — wygłosić przemowę, zaśpiewać albo zatańczyć. Z tej zdolności możesz skorzystać raz na krótki odpoczynek. Każdy sojusznik w promieniu 9 m od ciebie zyskuje wówczas tymczasowe punkty wytrzymałości w liczbie równej sumie poziomu swojej postaci i twojej premii z biegłości.</content>
   <content contentuid="h38de6e70g3483gb2a8gf232gce6933397614" version="1">Przywódca</content>
   <content contentuid="ha3aeca2ag84a7g9aa2gc23cg0d41a7036cc2" version="1">Po zakończeniu krótkiego lub długiego odpoczynku możesz dać inspirujący występ — wygłosić przemowę, zaśpiewać albo zatańczyć. Z tej zdolności możesz skorzystać raz na krótki odpoczynek. Każdy sojusznik w promieniu 9 m od ciebie zyskuje wówczas tymczasowe punkty wytrzymałości w liczbie równej sumie poziomu swojej postaci i twojej premii z biegłości.</content>
@@ -2504,7 +2504,7 @@ Jak wielu mieszkańców Wysp Moonshae, od najmłodszych lat czcisz błogosławio
 
 Dorastasz w krainie żyjących boskich królów, słuchając niezliczonych opowieści o starożytnych imperiach i pogrzebanych miastach. Według nich Mulhorand przepełniają zapomniane bogactwa — bezcenne skarby czekające na każdego, kto ma dość sprytu i odwagi, by ich szukać. Podejmujesz się eksploracji krypt, grobowców i piramid swojej ojczyzny, aby odzyskać relikty własnego ludu.</content>
   <content contentuid="h21f658cdg376fg2dd1gdeaeg3ea987213e26" version="1">Kustosz mythalu</content>
-  <content contentuid="hc52cd33bg7738g4b5eg085dgfcbe54464a64" version="1">Atut: Szczęście
+  <content contentuid="hc52cd33bg7738g4b5eg085dgfcbe54464a64" version="1">Atut: Szczęściarz
 
 Mythale są źródłami potężnej magii, zdolnej zmieniać Splot, a nawet samą naturę rzeczywistości. Większość z nich została stworzona w zamierzchłych czasach, a wiele od tamtej pory uległo uszkodzeniu lub zapadło w uśpienie. Jako kustosz mythalu z Dalelands twoje pierwsze zetknięcie z mythalem prawdopodobnie miało miejsce w ruinach Myth Drannoru. Wędrujesz po Faerûnie w poszukiwaniu innych zrujnowanych miejsc mocy, pragnąc zgłębić historię i potęgę mythali — a może nawet przywrócić do działania jeden z uszkodzonych.</content>
   <content contentuid="h099b8c13g6adeg4d63g45deg207f06214cb4" version="1">Giermek Purpurowego Smoka</content>


### PR DESCRIPTION
## Summary

- align embedded feat labels with the canonical Polish names already used by BG3 and the standalone feat entries
- replace literal or inconsistent labels such as `Alarm`, `Ładowarka`, `Kruszarka`, and `Czar Snajpera`
- keep internal Crossbow Expert, Dual Wielder, Sentinel, and Spell Sniper variants under one consistent base feat name
- use the current Polish D&D 2024 term `Kawalerzysta` for Mounted Combatant, which has no shipped BG3 title
- correct the remaining Sentinel description reference from `Strażnik` to `Wartownik`

## Validation

- 5,355 English and 5,355 Polish handles; no missing, extra, or duplicate content UIDs
- no content UID or version changes
- official embedded feat-prefix mismatches: 0
- full structural and coverage audits: 0 findings
- spell audit: 0 structural errors, 0 language errors, 0 official title/description mismatches, and 0 missing custom spell titles
- `git diff --check` passes

## Credit request

Please use the same community credit and Discord link for both translations:

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)

This pull request changes only `polish.xml`, in accordance with the translation workflow.