### PR TITLE
Align Polish Heroes of Faerun feat terms

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -2543,7 +2543,7 @@ Rodzina przede wszystkim. Raz na długi odpoczynek zapewniasz sobie i sojuszniko
   <content contentuid="he5401f43ga2cfgcd9dgcb25g6ce8548e686a" version="1">Sztuczka. Poznajesz sztuczkę Promień mrozu.
 
 Odmrożenie. Raz na turę, gdy trafisz istotę testem ataku i zadasz obrażenia od zimna, możesz tymczasowo osłabić jej obronę. Istota odejmuje 1k4 od następnego rzutu obronnego wykonanego przed końcem twojej następnej tury.</content>
-  <content contentuid="h046e98e9gd6d2gf0ecga207gad73de421d8c" version="1">Atut: Smocza blizna</content>
+  <content contentuid="h046e98e9gd6d2gf0ecga207gad73de421d8c" version="1">Atut: Smocze znamię</content>
   <content contentuid="h1b40d160ge647gb336gde38g35a23097c13b" version="1">Odporność na obrażenia. Gdy zyskujesz ten atut, wybierz: od kwasu, od zimna, od ognia, od elektryczności lub od trucizn. Masz odporność na wybrany typ obrażeń.
 
 Przerażająca moc. Gdy zadajesz obrażenia istocie w ramach Akcji Ataku lub Akcji Magii w swojej turze, możesz w ramach akcji dodatkowej w tej turze użyć zdolności Smoczy terror z atutu Nowicjusz Kultu Smoka.</content>
@@ -2555,15 +2555,15 @@ Przerażająca moc. Gdy zadajesz obrażenia istocie w ramach Akcji Ataku lub Akc
 Peszące uderzenie. Gdy trafisz istotę testem ataku, możesz spróbować ją speszyć. Cel musi wykonać udany rzut obronny na Mądrość (ST 8 + modyfikator cechy zwiększonej przez ten atut + twoja premia z biegłości); w razie niepowodzenia ma utrudnienie w rzutach obronnych do końca twojej następnej tury.
 
 Możesz skorzystać z tej korzyści tyle razy, ile wynosi twoja premia z biegłości, a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
-  <content contentuid="h077c85ecg890cg792bg6840gee3051f5be3e" version="1">Atut: Magia Dżina</content>
+  <content contentuid="h077c85ecg890cg792bg6840gee3051f5be3e" version="1">Atut: Magia dżina</content>
   <content contentuid="h0ef080f7gca72g7669g8b06g981e2feedb49" version="2">Zyskujesz dwie komórki czaru 1. poziomu i jedną komórkę czaru 2. poziomu.</content>
-  <content contentuid="h8ee570adg0fe2g0097g40e1g8134e53943ad" version="1">Atut: Praca zespołowa Harpera</content>
-  <content contentuid="h9e8fefadgbcc7g10f5ga4aage45ad3d82e96" version="2">Więdnąca gra słów. Kiedy podejmujesz akcję rozproszenia, aby pomóc sojusznikowi w teście ataku przeciwko wrogowi, wróg ten również ma utrudnienie przy pierwszym rzucie obronnym, jaki wykona przed rozpoczęciem twojej następnej tury.
+  <content contentuid="h8ee570adg0fe2g0097g40e1g8134e53943ad" version="1">Atut: Zgranie Harfiarzy</content>
+  <content contentuid="h9e8fefadgbcc7g10f5ga4aage45ad3d82e96" version="2">Cięta gra słów. Kiedy podejmujesz akcję rozproszenia, aby pomóc sojusznikowi w teście ataku przeciwko wrogowi, wróg ten również ma utrudnienie przy pierwszym rzucie obronnym, jaki wykona przed rozpoczęciem twojej następnej tury.
 
 Inspirująca siła woli. Masz ułatwienie w rzutach obronnych przeciwko stanom Przerażenia i Paraliżu.</content>
-  <content contentuid="h4aee3eacgaf72gc757g8d80g048d0a64e805" version="1">Atut: Lordowska stanowczość</content>
+  <content contentuid="h4aee3eacgaf72gc757g8d80g048d0a64e805" version="1">Atut: Lordowska determinacja</content>
   <content contentuid="h86fbc975g75b4gcf4cg3416geb64d948c1e4" version="1">Chorąży. Masz niewrażliwość na stany Powalenia, Zauroczenia i Przerażenia.</content>
-  <content contentuid="h75370f04gff6egfa29g73e5g4e8d6739e8fa" version="1">Atut: Dotyk Mythal</content>
+  <content contentuid="h75370f04gff6egfa29g73e5g4e8d6739e8fa" version="1">Atut: Dotknięty przez mythal</content>
   <content contentuid="h81877b18gdacfg553cge0c9g65813ccf4557" version="1">Rzucane przez ciebie czary mogą wyzwalać przypływy nieposkromionej magii. Raz na turę, natychmiast po rzuceniu czaru z użyciem komórki czaru, możesz rzucić 1k20. Jeśli wypadnie 20, wykonaj rzut w tabeli Przypływ dzikiej magii, aby wywołać magiczny efekt.</content>
   <content contentuid="h3860f913g1f6fg4b18g9ecfgabcab0169949" version="1">Atut: Odporność Zakonu</content>
   <content contentuid="hddb981a7g0a29gd059gf634g1b2d20e1a8fd" version="1">Gdy korzystasz ze zdolności Stań jako jedność (Nowicjusz Rękawicy), sojusznicy w promieniu 1,5 m od ciebie są odporni na Powalenie i mają ułatwienie w rzutach obronnych na Siłę.</content>
@@ -2573,25 +2573,25 @@ Inspirująca siła woli. Masz ułatwienie w rzutach obronnych przeciwko stanom P
 Ostatni bastion. Gdy masz stan Zakrwawienia, masz ułatwienie w testach ataku.</content>
   <content contentuid="h9de5f3bdgd036g8fc7gc000g9f162c3acfc6" version="1">Atut: Adept magicznego ognia</content>
   <content contentuid="h94e22d9cg05ceg0802gc712g372cd3b8f030" version="1">Rzucane przez ciebie czary i wykonywane ataki ignorują &lt;LSTag Tooltip="Resistant"&gt;odporność&lt;/LSTag&gt; na obrażenia od światłości. Ponadto, gdy zadajesz czarem obrażenia od światłości, w rzucie nie może wypaść 1.</content>
-  <content contentuid="h2d5b87b6g1172g67b5gcfefg0bf170e5aaef" version="1">Atut: Taktyka Zhentarima</content>
+  <content contentuid="h2d5b87b6g1172g67b5gcfefg0bf170e5aaef" version="1">Atut: Taktyka Zhentarimów</content>
   <content contentuid="h06b8380ag7f73g106agdf63g8dabbadb964c" version="1">Odwet. Natychmiast po tym, jak istota w promieniu 1,5 m od ciebie trafi cię atakiem wręcz, możesz wykonać przeciwko niej atak okazyjny.
 
 Wszechstronny najemnik. Wybierz umiejętność, w której masz biegłość. Zyskujesz w niej fachowość.</content>
-  <content contentuid="h32fd92c5gd42cg926fgb1adg572674b52c38" version="1">Atut: Smocza blizna (Odporność na kwas)</content>
-  <content contentuid="hca54a12agc1f9g2a70g2257g737e96e7df9b" version="1">Atut: Smocze blizny (Odporność na zimno)</content>
-  <content contentuid="h0a63962age9c8g7392g84a8g55d4962d5732" version="1">Atut: Smocze blizny (odporność na ogień)</content>
-  <content contentuid="h7dded34cg6b05gddbbg76fcg1c9672c5bb9f" version="1">Atut: Smocze blizny (Odporność na błyskawice)</content>
-  <content contentuid="h8e3378b3gc69bgb63dgcd15gad7e31607dfd" version="1">Atut: Smocza blizna (Odporność na truciznę)</content>
+  <content contentuid="h32fd92c5gd42cg926fgb1adg572674b52c38" version="1">Atut: Smocze znamię (odporność na kwas)</content>
+  <content contentuid="hca54a12agc1f9g2a70g2257g737e96e7df9b" version="1">Atut: Smocze znamię (odporność na zimno)</content>
+  <content contentuid="h0a63962age9c8g7392g84a8g55d4962d5732" version="1">Atut: Smocze znamię (odporność na ogień)</content>
+  <content contentuid="h7dded34cg6b05gddbbg76fcg1c9672c5bb9f" version="1">Atut: Smocze znamię (odporność na elektryczność)</content>
+  <content contentuid="h8e3378b3gc69bgb63dgcd15gad7e31607dfd" version="1">Atut: Smocze znamię (odporność na truciznę)</content>
   <content contentuid="h8b2a4760g816bg9df8ge286g6fbe1c2b0bcd" version="1">Utrudnienie przy wszystkich rzutach obronnych.</content>
-  <content contentuid="h6546b917g1c6dg4ca0g0808g9c4689c5032e" version="1">Frustrujące uderzenie</content>
+  <content contentuid="h6546b917g1c6dg4ca0g0808g9c4689c5032e" version="1">Peszące uderzenie</content>
   <content contentuid="h1d522e3cgc9dcg916bgfa58g5cd59e1f7ebd" version="1">Kiedy trafisz istotę testem ataku, możesz spróbować spłoszyć cel. Cel musi wykonać udany rzut obronny na Mądrość lub mieć utrudnienie w rzucie obronnym do końca twojej następnej tury.</content>
-  <content contentuid="h5f50ef61g2ff2g155dg73ecgcdb03dd1d00d" version="1">Frustrujące uderzenie</content>
-  <content contentuid="h2c67fd73g9c3bg2dc8gf508gba72fd03b787" version="1">Zachęcaj Sojusznika</content>
-  <content contentuid="h5d1b146eg0fd5g7577gcd29g2497b1c1beae" version="1">Nosiciel sztandaru</content>
+  <content contentuid="h5f50ef61g2ff2g155dg73ecgcdb03dd1d00d" version="1">Peszące uderzenie</content>
+  <content contentuid="h2c67fd73g9c3bg2dc8gf508gba72fd03b787" version="1">Pokrzep sojusznika</content>
+  <content contentuid="h5d1b146eg0fd5g7577gcd29g2497b1c1beae" version="1">Chorąży</content>
   <content contentuid="h7f09b2d2g5ce4g617bgbbb7gae4f47ac82af" version="1">Masz odporność na stan Powalenia i masz ułatwienie w rzutach obronnych na Siłę.</content>
-  <content contentuid="h11b2630egba57g41bfg86afga1a03173230e" version="1">Zachęcaj Sojusznika</content>
+  <content contentuid="h11b2630egba57g41bfg86afga1a03173230e" version="1">Pokrzep sojusznika</content>
   <content contentuid="h74764f94g16bbg3291g6bf1g64f2467c1d2d" version="1">W ramach akcji dodatkowej dodajesz otuchy jednemu widocznemu sojusznikowi w promieniu 9 m. Sojusznik zyskuje tymczasowe punkty wytrzymałości w liczbie równej 2k6 plus twoja premia z biegłości. Możesz użyć tej akcji dodatkowej tyle razy, ile wynosi twoja premia z biegłości, a wszystkie użycia odzyskujesz po długim odpoczynku.</content>
-  <content contentuid="h84f4adf1gf6eag1710g1245gca69206d05fe" version="1">Zachęcaj Sojusznika</content>
+  <content contentuid="h84f4adf1gf6eag1710g1245gca69206d05fe" version="1">Pokrzep sojusznika</content>
   <content contentuid="h2287dbd5gd1ffga56ag677eg771e23ed7f4c" version="1">Zyskaj tymczasowe punkty wytrzymałości równe 2k6 plus premia z biegłości rzucającego czar.</content>
   <content contentuid="h1bca3b80g61b0g1241gad6dg59a5b944962e" version="1">Odwet</content>
   <content contentuid="h3b19c28cg80dcg38e9gc853g0c674ef3b5e5" version="1">Natychmiast po tym, jak istota w promieniu 1,5 m od ciebie uderzy cię atakiem wręcz, możesz wykonać atak okazyjny przeciwko tej istocie.</content>
@@ -2613,17 +2613,17 @@ Przerażająca moc. Gdy zadajesz obrażenia istocie w ramach Akcji Ataku lub Akc
 Peszące uderzenie. Gdy trafisz istotę testem ataku, możesz spróbować ją speszyć. Cel musi wykonać udany rzut obronny na Mądrość (ST 8 + modyfikator cechy zwiększonej przez ten atut + twoja premia z biegłości); w razie niepowodzenia ma utrudnienie w rzutach obronnych do końca twojej następnej tury.
 
 Możesz skorzystać z tej korzyści tyle razy, ile wynosi twoja premia z biegłości, a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
-  <content contentuid="h2aff44fbga1d3g84a9g91cege594afc8805c" version="1">Magia geniuszy</content>
+  <content contentuid="h2aff44fbga1d3g84a9g91cege594afc8805c" version="1">Magia dżina</content>
   <content contentuid="h55dcc998g2b80g48f8g46ddg8233ec32e4b0" version="1">Zyskujesz dwie komórki czaru 1. poziomu i jedną komórkę czaru 2. poziomu.</content>
   <content contentuid="h2f66b26dg1725g05e8g8305g92b9060c4712" version="2">Zgranie Harfiarzy</content>
-  <content contentuid="h03d01a13gaf6ag041ag792ag03d578243374" version="1">Więdnąca gra słów. Kiedy podejmujesz akcję rozproszenia, aby pomóc sojusznikowi w teście ataku przeciwko wrogowi, wróg ten również ma utrudnienie przy pierwszym rzucie obronnym, jaki wykona przed rozpoczęciem twojej następnej tury.
+  <content contentuid="h03d01a13gaf6ag041ag792ag03d578243374" version="1">Cięta gra słów. Kiedy podejmujesz akcję rozproszenia, aby pomóc sojusznikowi w teście ataku przeciwko wrogowi, wróg ten również ma utrudnienie przy pierwszym rzucie obronnym, jaki wykona przed rozpoczęciem twojej następnej tury.
 
 Inspirująca siła woli. Masz ułatwienie w rzutach obronnych przeciwko stanom Przerażenia i Paraliżu.</content>
   <content contentuid="h073d0597g8104g5749g9c62g13790ccd3f2b" version="1">Lordowska determinacja</content>
   <content contentuid="hca4c73c6g5ff9g1e2dg6288g9bd5466da9c1" version="1">Chorąży. Masz niewrażliwość na stany Powalenia, Zauroczenia i Przerażenia.</content>
   <content contentuid="h4da279bag6b5fg0d46gfa98g0b2a70b0ce8e" version="1">Dotknięty przez mythal</content>
   <content contentuid="hb1afe5dagdd44g9fb0ga44bgfc95f9dd8e59" version="1">Rzucane przez ciebie czary mogą wyzwalać przypływy nieposkromionej magii. Raz na turę, natychmiast po rzuceniu czaru z użyciem komórki czaru, możesz rzucić 1k20. Jeśli wypadnie 20, wykonaj rzut w tabeli Przypływ dzikiej magii, aby wywołać magiczny efekt.</content>
-  <content contentuid="h9cc613dfgb0bcgce96gb19bg02330e4dff7a" version="1">Zamówienia Odporność</content>
+  <content contentuid="h9cc613dfgb0bcgce96gb19bg02330e4dff7a" version="1">Odporność Zakonu</content>
   <content contentuid="h4d3fa3f2g1f1aga0c3gb83bg94d626b6b33f" version="1">Gdy korzystasz ze zdolności Stań jako jedność (Nowicjusz Rękawicy), sojusznicy w promieniu 1,5 m od ciebie są odporni na Powalenie i mają ułatwienie w rzutach obronnych na Siłę.</content>
   <content contentuid="h322b2b28g4f47gfef1g0501g09a299ea04dd" version="1">Komendant Purpurowego Smoka</content>
   <content contentuid="h4f5ef875gef6dg93aag6e38g370f1fde0a68" version="2">Pokrzepienie sojusznika. W ramach akcji dodatkowej dodajesz otuchy jednemu widocznemu sojusznikowi w promieniu 9 m. Zyskuje on tymczasowe punkty wytrzymałości w liczbie równej 2k6 plus twoja premia z biegłości. Możesz użyć tej akcji dodatkowej tyle razy, ile wynosi twoja premia z biegłości, a wszystkie użycia odzyskujesz po długim odpoczynku.


### PR DESCRIPTION
## Summary

- align embedded Heroes of Faerûn feat labels with the canonical titles already used by their standalone entries
- normalize all Dragonscarred variants to `Smocze znamię` and consistent resistance labels
- replace the misleading `Magia geniuszy` and broken `Zamówienia Odporność` with `Magia dżina` and `Odporność Zakonu`
- use the established `Zgranie Harfiarzy`, `Lordowska determinacja`, `Dotknięty przez mythal`, and `Taktyka Zhentarimów` terms
- replace literal or inconsistent action labels with `Cięta gra słów`, `Peszące uderzenie`, `Pokrzep sojusznika`, and `Chorąży`

## Validation

- 5,355 English and 5,355 Polish handles; no missing, extra, or duplicate content UIDs
- no content UID or version changes
- full structural and coverage audits: 0 findings
- spell audit: 0 structural errors, 0 language errors, 0 official title/description mismatches, and 0 missing custom spell titles
- LanguageTool reports no actionable findings in the changed strings
- `git diff --check` passes

## Credit request

Please use the same community credit and Discord link for both translations:

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)

This pull request changes only `polish.xml`, in accordance with the translation workflow.