### PR TITLE
Improve Polish gameplay descriptions

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -2584,17 +2584,17 @@ Wszechstronny najemnik. Wybierz umiejętność, w której masz biegłość. Zysk
   <content contentuid="h8e3378b3gc69bgb63dgcd15gad7e31607dfd" version="1">Atut: Smocze znamię (odporność na truciznę)</content>
   <content contentuid="h8b2a4760g816bg9df8ge286g6fbe1c2b0bcd" version="1">Utrudnienie przy wszystkich rzutach obronnych.</content>
   <content contentuid="h6546b917g1c6dg4ca0g0808g9c4689c5032e" version="1">Peszące uderzenie</content>
-  <content contentuid="h1d522e3cgc9dcg916bgfa58g5cd59e1f7ebd" version="1">Kiedy trafisz istotę testem ataku, możesz spróbować spłoszyć cel. Cel musi wykonać udany rzut obronny na Mądrość lub mieć utrudnienie w rzucie obronnym do końca twojej następnej tury.</content>
+  <content contentuid="h1d522e3cgc9dcg916bgfa58g5cd59e1f7ebd" version="1">Gdy trafisz istotę testem ataku, możesz spróbować ją speszyć. Cel musi wykonać rzut obronny na Mądrość; w razie niepowodzenia ma utrudnienie w rzutach obronnych do końca twojej następnej tury.</content>
   <content contentuid="h5f50ef61g2ff2g155dg73ecgcdb03dd1d00d" version="1">Peszące uderzenie</content>
   <content contentuid="h2c67fd73g9c3bg2dc8gf508gba72fd03b787" version="1">Pokrzep sojusznika</content>
   <content contentuid="h5d1b146eg0fd5g7577gcd29g2497b1c1beae" version="1">Chorąży</content>
-  <content contentuid="h7f09b2d2g5ce4g617bgbbb7gae4f47ac82af" version="1">Masz odporność na stan Powalenia i masz ułatwienie w rzutach obronnych na Siłę.</content>
+  <content contentuid="h7f09b2d2g5ce4g617bgbbb7gae4f47ac82af" version="1">Masz niewrażliwość na stan Powalenia oraz ułatwienie w rzutach obronnych na Siłę.</content>
   <content contentuid="h11b2630egba57g41bfg86afga1a03173230e" version="1">Pokrzep sojusznika</content>
   <content contentuid="h74764f94g16bbg3291g6bf1g64f2467c1d2d" version="1">W ramach akcji dodatkowej dodajesz otuchy jednemu widocznemu sojusznikowi w promieniu 9 m. Sojusznik zyskuje tymczasowe punkty wytrzymałości w liczbie równej 2k6 plus twoja premia z biegłości. Możesz użyć tej akcji dodatkowej tyle razy, ile wynosi twoja premia z biegłości, a wszystkie użycia odzyskujesz po długim odpoczynku.</content>
   <content contentuid="h84f4adf1gf6eag1710g1245gca69206d05fe" version="1">Pokrzep sojusznika</content>
   <content contentuid="h2287dbd5gd1ffga56ag677eg771e23ed7f4c" version="1">Zyskaj tymczasowe punkty wytrzymałości równe 2k6 plus premia z biegłości rzucającego czar.</content>
   <content contentuid="h1bca3b80g61b0g1241gad6dg59a5b944962e" version="1">Odwet</content>
-  <content contentuid="h3b19c28cg80dcg38e9gc853g0c674ef3b5e5" version="1">Natychmiast po tym, jak istota w promieniu 1,5 m od ciebie uderzy cię atakiem wręcz, możesz wykonać atak okazyjny przeciwko tej istocie.</content>
+  <content contentuid="h3b19c28cg80dcg38e9gc853g0c674ef3b5e5" version="1">Natychmiast po tym, jak istota w promieniu 1,5 m od ciebie trafi cię atakiem wręcz, możesz wykonać przeciwko niej atak okazyjny.</content>
   <content contentuid="h7266774agddd3g954ag8493g86532999d2ae" version="1">Zapomniane Krainy: Bohaterowie Faerûnu: Ogólne atuty</content>
   <content contentuid="hb3bd7f59g0610g8deag20d1ga4bb317c1e9b" version="1">Zapomniane Krainy: Bohaterowie Faerûnu: Ogólne atuty</content>
   <content contentuid="h29ab3531g02fbgac9egf6b3g45f445778cb6" version="1">Władający zimnem</content>
@@ -2635,7 +2635,7 @@ Ostatni bastion. Gdy masz stan Zakrwawienia, masz ułatwienie w testach ataku.</
   <content contentuid="he09232a3g8429ge28bga994gd171ef3f3292" version="1">Odwet. Natychmiast po tym, jak istota w promieniu 1,5 m od ciebie trafi cię atakiem wręcz, możesz wykonać przeciwko niej atak okazyjny.
 
 Wszechstronny najemnik. Wybierz umiejętność, w której masz biegłość. Zyskujesz w niej fachowość.</content>
-  <content contentuid="h3566bf7ege17bg0f56g4fbdgfac65706f1a2" version="1">Tworząc swoją postać lub dostosowując się do niej, wybierz tylko jeden atut Początki magii. Wybranie więcej niż jednego może spowodować nieoczekiwane problemy.</content>
+  <content contentuid="h3566bf7ege17bg0f56g4fbdgfac65706f1a2" version="1">Podczas tworzenia postaci lub zmiany jej klasy wybierz tylko jeden atut Początki magii. Wybranie więcej niż jednego może spowodować nieoczekiwane problemy.</content>
   <content contentuid="hca895012gaf5dg78a6g7a2eg37692b43b104" version="2">Atut: Zabójcze łucznictwo</content>
   <content contentuid="hc67a4df3gcd8bgf957g4d35gee2424c14472" version="2">W ramach akcji dodatkowej możesz zapewnić sobie ułatwienie w teście ataku bronią dystansową w tej turze. Możesz skorzystać z tej akcji dodatkowej tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
   <content contentuid="h1f3d47b6gbc1fgf224g07d7g6347072349e6" version="2">Atut: Pogromca Smoków</content>
@@ -2663,9 +2663,9 @@ Gdy uzyskasz trafienie krytyczne atakiem bronią do walki wręcz, możesz dodatk
 
 W ramach akcji dodatkowej możesz zapewnić sobie ułatwienie w teście ataku bronią dystansową w tej turze. Możesz skorzystać z tej akcji dodatkowej tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
   <content contentuid="h6e348a1aga0b0g9788gb85dgeba21fa79668" version="1">Zabójca Smoków</content>
-  <content contentuid="ha77cb967ga90dgf3bagbb92g9b2af176e030" version="2">Legenda Barda Łucznika zainspirowała wielu młodych ludzi z Dale, którzy pragną dowieść swej wartości, zabijając potężnego potwora. Jak wielu przed tobą, od dawna rozmyślasz nad sposobami walki z ogromnymi istotami, licząc, że pewnego dnia zdobędziesz sławę, pokonując jedno z nich.
+  <content contentuid="ha77cb967ga90dgf3bagbb92g9b2af176e030" version="2">Legenda Barda Łucznika zainspirowała wielu młodych ludzi z Dale, którzy pragną dowieść swej wartości, zabijając potężnego potwora. Jak wielu przed tobą, od dawna rozmyślasz nad sposobami walki z ogromnymi istotami, licząc, że pewnego dnia zdobędziesz sławę, pokonując jedną z nich.
 
-Masz ułatwienie w testach ataku przeciwko Dużym lub większym istotom. Ponadto, gdy trafiasz takie istota, zadajesz dodatkowe obrażenia równe modyfikatorowi Siły.</content>
+Masz ułatwienie w testach ataku przeciwko istotom rozmiaru dużego lub większego. Ponadto, gdy trafiasz taką istotę, zadajesz dodatkowe obrażenia równe swojemu modyfikatorowi Siły.</content>
   <content contentuid="h27541f87g50d6gf441gbab6geae246f77643" version="1">Ostry strzał</content>
   <content contentuid="ha574dfdfgf055g69c1g9889gce2fffa674e6" version="3">Czarna Strzała, która powaliła smoka Smauga, mogła być do tego przeznaczona, lecz ręka, która posłała ją z taką siłą, była niezwykle mocna. Gdy rzucasz włócznią albo napinasz łuk, dbasz o pewny chwyt i celny strzał.
 
@@ -2681,43 +2681,43 @@ Gdy uzyskasz trafienie krytyczne atakiem bronią do walki wręcz, możesz dodatk
 
 Zyskujesz premię +1 do KP. Tracisz ją, jeśli masz stan Obezwładnienia albo dzierżysz tarczę.</content>
   <content contentuid="hc2022d67g4441g1ca0g979ag85847dde7f08" version="3">Niebiańskie objawienie</content>
-  <content contentuid="ha694feb3g0781gc772g6147gd804e68c64f8" version="3">Możesz przekształcić się w akcję dodatkową, korzystając z jednej z poniższych opcji (wybieraj tę opcję za każdym razem, gdy dokonujesz transformacji). Transformacja trwa 1 minutę lub do momentu jej zakończenia (nie jest wymagane żadne działanie). Kiedy dokonasz transformacji, nie możesz tego zrobić ponownie, dopóki nie zakończysz długiego odpoczynku.
+  <content contentuid="ha694feb3g0781gc772g6147gd804e68c64f8" version="3">Możesz dokonać przemiany w ramach akcji dodatkowej, korzystając z jednej z poniższych opcji (wybierasz ją przy każdej przemianie). Przemiana trwa 1 minutę albo do chwili, gdy ją zakończysz (bez użycia akcji). Po przemianie nie możesz dokonać kolejnej, dopóki nie ukończysz długiego odpoczynku.
 
-Raz na każdą twoją turę przed końcem tej transformacji możesz zadać dodatkowe obrażenia jednemu celowi, gdy zadajesz mu obrażenia atakiem lub czarem. Te dodatkowe obrażenia są równe twojej premii z biegłości, a ich typ to obrażenia nekrotyczne w przypadku Nekrotycznego całuna lub obrażenia od światłości w przypadku Niebiańskich skrzydeł i Wewnętrznego blasku.</content>
+Raz w każdej swojej turze przed końcem przemiany możesz zadać dodatkowe obrażenia jednemu celowi, gdy zadajesz mu obrażenia atakiem albo czarem. Dodatkowe obrażenia są równe twojej premii z biegłości. Są to obrażenia nekrotyczne w przypadku Nekrotycznego całunu albo obrażenia od światłości w przypadku Niebiańskich skrzydeł i Wewnętrznego blasku.</content>
   <content contentuid="hee581120gaebcg3ad5ge885ge712f8b5c11f" version="1">Uzdrawiające dłonie</content>
   <content contentuid="hfd0a6b5aga1ceg3d50gd059gcb8b4baca023" version="1">W ramach akcji Magii dotykasz istoty i rzucasz tyloma kośćmi k4, ile wynosi twoja premia z biegłości. Istota odzyskuje punkty wytrzymałości w liczbie równej sumie wyników.</content>
   <content contentuid="h30e3e09dgcb39g8c25g0d8egb9b774233e0b" version="1">Niebiańskie objawienie</content>
-  <content contentuid="hb4b6f30eg2b17g2d0dg2d38g75f0949d374e" version="4">Kiedy osiągniesz 3 poziom postaci, możesz dokonać transformacji w ramach akcji dodatkowej, korzystając z jednej z opcji. Transformacja trwa 1 minutę lub do momentu jej zakończenia (nie jest wymagane żadne działanie). Kiedy dokonasz transformacji, nie możesz tego zrobić ponownie, dopóki nie zakończysz długiego odpoczynku.
+  <content contentuid="hb4b6f30eg2b17g2d0dg2d38g75f0949d374e" version="4">Gdy osiągniesz 3. poziom postaci, możesz dokonać przemiany w ramach akcji dodatkowej, korzystając z jednej z dostępnych opcji. Przemiana trwa 1 minutę albo do chwili, gdy ją zakończysz (bez użycia akcji). Po przemianie nie możesz dokonać kolejnej, dopóki nie ukończysz długiego odpoczynku.
 
-Możesz zadać celowi dodatkowe obrażenia, zadając mu obrażenia atakiem lub czarem. Dodatkowe obrażenia są równe premii z biegłości. Rodzaj obrażeń to Nekrotyczne w przypadku Nekrotycznego Całunu lub Promienne w przypadku Niebiańskich Skrzydeł i Wewnętrznego Blasku.</content>
+Gdy zadajesz celowi obrażenia atakiem albo czarem, możesz zadać mu dodatkowe obrażenia równe swojej premii z biegłości. Są to obrażenia nekrotyczne w przypadku Nekrotycznego całunu albo obrażenia od światłości w przypadku Niebiańskich skrzydeł i Wewnętrznego blasku.</content>
   <content contentuid="h3f49f80egbab5g00d8gc75fg71bb7b054fc6" version="1">Wewnętrzny blask</content>
-  <content contentuid="h947e63dfge856g93fdge133g7915f597706a" version="1">Palące światło chwilowo promieniuje z twoich oczu i ust. Na czas trwania czaru rzucasz Jasne Światło w promieniu 3 m i Przyćmione Światło na dodatkowe 3 m, a na koniec każdej twojej tury każda istota w promieniu 3 m od ciebie otrzymuje obrażenia od światłości równe twojej premii z biegłości.</content>
+  <content contentuid="h947e63dfge856g93fdge133g7915f597706a" version="1">Palące światło chwilowo bije z twoich oczu i ust. Na czas przemiany emitujesz jasne światło w promieniu 3 m oraz słabe światło w promieniu dalszych 3 m. Na koniec każdej twojej tury każda istota w promieniu 3 m od ciebie otrzymuje obrażenia od światłości równe twojej premii z biegłości.</content>
   <content contentuid="hfae2afebg7426gcf8cg5c76g65cdce3c393d" version="1">Niebiańskie skrzydła</content>
   <content contentuid="h80c3bb0dgd84cg63b6g9b47g339cb3415da6" version="1">Z twoich pleców na chwilę wyrastają dwa widmowe skrzydła. Dopóki transformacja się nie zakończy, masz szybkość lotu równą swojej szybkości.</content>
   <content contentuid="h618cb471geddfg2d11g70feg9e12919e4a68" version="1">Nekrotyczny całun</content>
-  <content contentuid="h6a146679g10b4gcab6g7371g8809ef5326f6" version="2">Twoje oczy stają się kałużami ciemności, a z pleców na chwilę wyrastają nielotne skrzydła. Wybrane przez ciebie istoty w promieniu 3 m od ciebie muszą wykonać pomyślny rzut obronny na Charyzmę lub mieć stan Przerażenia przez 1 minutę.</content>
+  <content contentuid="h6a146679g10b4gcab6g7371g8809ef5326f6" version="2">Twoje oczy na chwilę stają się otchłaniami ciemności, a z pleców wyrastają nielotne skrzydła. Wybrane przez ciebie istoty w promieniu 3 m muszą wykonać rzut obronny na Charyzmę; w razie niepowodzenia otrzymują stan Przerażenia na 1 minutę.</content>
   <content contentuid="h34ab3782g568fg1b60g9a2eg148d28686613" version="1">Niebiańskie skrzydła</content>
   <content contentuid="hbcd3d36fgdc84gb744gaaf6ge51968dbc88e" version="1">Z twoich pleców na chwilę wyrastają dwa widmowe skrzydła. Dopóki transformacja się nie zakończy, masz szybkość lotu równą swojej szybkości.</content>
   <content contentuid="hb450a1d2g4f77g57dbg4c25gd3acee588f18" version="1">Wewnętrzny blask</content>
-  <content contentuid="h4049a129gb079gf0dagb270g0aa72eb1171d" version="1">Palące światło chwilowo promieniuje z twoich oczu i ust. Na czas trwania czaru rzucasz Jasne Światło w promieniu 3 m i Przyćmione Światło na dodatkowe 3 m, a na koniec każdej twojej tury każda istota w promieniu 3 m od ciebie otrzymuje obrażenia od światłości równe twojej premii z biegłości.</content>
+  <content contentuid="h4049a129gb079gf0dagb270g0aa72eb1171d" version="1">Palące światło chwilowo bije z twoich oczu i ust. Na czas przemiany emitujesz jasne światło w promieniu 3 m oraz słabe światło w promieniu dalszych 3 m. Na koniec każdej twojej tury każda istota w promieniu 3 m od ciebie otrzymuje obrażenia od światłości równe twojej premii z biegłości.</content>
   <content contentuid="h5455adb5gc4c2g9159g585eg6c24762cbd53" version="1">Nekrotyczny całun</content>
-  <content contentuid="h3a16b87eg8dd3g9578gd609gbf2f106aa676" version="1">Twoje oczy na chwilę stają się bezdennie czarne, a z pleców wyrastają nielotne, widmowe skrzydła. Wszystkie istoty poza twoimi sojusznikami w promieniu 3 m od ciebie muszą wykonać udany rzut obronny na Charyzmę albo otrzymują stan Przerażenia do końca twojej następnej tury.</content>
+  <content contentuid="h3a16b87eg8dd3g9578gd609gbf2f106aa676" version="1">Twoje oczy na chwilę stają się otchłaniami ciemności, a z pleców wyrastają nielotne, widmowe skrzydła. Wszystkie istoty poza twoimi sojusznikami w promieniu 3 m muszą wykonać rzut obronny na Charyzmę; w razie niepowodzenia otrzymują stan Przerażenia do końca twojej następnej tury.</content>
   <content contentuid="h14b0a7adg6f8dg3aefgbc10ge9f1398e2825" version="1">Wewnętrzny blask</content>
   <content contentuid="h868292b4g07bag5039g7a39g8b646671c67e" version="2">Ma karę 1k4 do &lt;LSTag Tooltip="SavingThrow"&gt;rzutów obronnych&lt;/LSTag&gt;.</content>
   <content contentuid="h6ef5198eg577fg6ca6gc4d9gb725efc2c584" version="1">Myślowy odłamek</content>
   <content contentuid="h8c610e61ga284gbdd9gf4c4gc19e363942ea" version="1">Kolegium Księżyca</content>
   <content contentuid="h759d592bgce3eg0689gb28cgb0e2182d4aba" version="1">Kolegium Księżyca wywodzi swoje początki z prastarych kręgów druidycznych Wysp Moonshae, które powierzyły pierwszym bardom tej tradycji zadanie spisywania dziejów wysp oraz ich mieszkańców. Bardowie z tego kolegium czerpią z magii fey oraz pierwotnej mocy księżycowych studni, aby wspierać swoich sojuszników, chronić świat natury i tworzyć swe inspirujące, bardowskie dzieła.</content>
-  <content contentuid="h9223661bgace2gba01g10dcgfc1ea09add5a" version="1">Poziom 3: Inspiracja Księżyca</content>
+  <content contentuid="h9223661bgace2gba01g10dcgfc1ea09add5a" version="1">Poziom 3: Inspiracja księżyca</content>
   <content contentuid="he8fec49dgf4c3g6a97g790bg3a7f505054bf" version="1">Przepływa przez ciebie pierwotna, wiecznie zmienna moc księżyca, zapewniając następujące korzyści.
 
 Inspirujące zaćmienie. Gdy w ramach akcji dodatkowej dajesz istocie kość &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;bardowskiej inspiracji&lt;/LSTag&gt;, możesz otrzymać &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;stan Niewidzialności&lt;/LSTag&gt; i w ramach tej samej akcji teleportować się na odległość do 9 m na widoczne, wolne pole. Niewidzialność trwa do początku twojej następnej tury, lecz kończy się wcześniej natychmiast po wykonaniu testu ataku, zadaniu obrażeń albo rzuceniu czaru.
 
 Księżycowa witalność. Raz na turę, gdy za pomocą czaru przywracasz istocie punkty wytrzymałości, możesz wydać kość bardowskiej inspiracji i zwiększyć liczbę przywróconych punktów o wynik rzutu tą kością. Szybkość istoty zwiększa się również o 3 m do końca jej następnej tury.</content>
-  <content contentuid="haca3aef8ga626gc323g22acg746bfa4a9426" version="1">Poziom 3: Pierwotna Wiedza</content>
+  <content contentuid="haca3aef8ga626gc323g22acg746bfa4a9426" version="1">Poziom 3: Pierwotna wiedza</content>
   <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">Uczysz się druidyzmu i jednej sztuczki z listy czarów druida. Liczy się to dla ciebie jako czar Barda, ale nie wlicza się do liczby znanych sztuczek.
 
 Ponadto wybierz jedną z umiejętności: &lt;LSTag Type="Skills" Tooltip="AnimalHandling"&gt;Opieka nad zwierzętami&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Intuicja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medycyna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Natura&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Percepcja&lt;/LSTag&gt; lub &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Przetrwanie&lt;/LSTag&gt;. Masz biegłość w tej umiejętności.</content>
-  <content contentuid="h3911c437g16cagdddcgede4gaa0c643aec8c" version="1">Poziom 6: Błogosławieństwa Światła Księżyca</content>
+  <content contentuid="h3911c437g16cagdddcgede4gaa0c643aec8c" version="1">Poziom 6: Błogosławieństwa światła księżyca</content>
   <content contentuid="haa5e73d8ga7e5ge281g8b67gae695bb23d75" version="1">Zawsze masz przygotowany czar Księżycowy promień.
 
 Gdy rzucasz Księżycowy promień, wybrana widoczna istota w promieniu 18 m od ciebie odzyskuje 2k4 punkty wytrzymałości.
@@ -2740,11 +2740,11 @@ Po użyciu tej cechy do zmodyfikowania Księżycowego promienia nie możesz zrob
 Chorąży polega na rozsądku, odwadze i wierności kodeksowi rycerskiemu, które kierują nim w walce ze złoczyńcami. Samotny chorąży jest wykwalifikowanym wojownikiem, ale dowodząc grupą sojuszników, potrafi przekształcić nawet słabo wyposażoną milicję w zaciekły oddział bojowy.</content>
   <content contentuid="h40c5a6a5g42eagbba6g5c64g5ece9eb7fe14" version="1">Poziom 3: Rycerski wysłannik</content>
   <content contentuid="ha6aeb659gba2ag0648g1d28g8d765621e3a9" version="1">Zdobywasz wiedzę specjalistyczną we wszystkich następujących umiejętnościach: &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Intuicja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Zastraszanie&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazja&lt;/LSTag&gt; oraz &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Występy&lt;/LSTag&gt;.</content>
-  <content contentuid="h3f223b42g605egefc2g504ag6ef36cc460ed" version="1">Poziom 3: Odzyskiwanie grupowe</content>
+  <content contentuid="h3f223b42g605egefc2g504ag6ef36cc460ed" version="1">Poziom 3: Grupowa regeneracja</content>
   <content contentuid="ha8111f35ge4bag28bcg4d99g339262b0a595" version="2">Gdy używasz Drugiego oddechu, aby odzyskać punkty wytrzymałości, możesz wybrać w emanacji o promieniu 9 m, której źródłem jesteś, maksymalnie tylu sojuszników, ile wynosi twój modyfikator Charyzmy. Każdy z nich odzyskuje punkty wytrzymałości w liczbie równej sumie 1k10 i twojego poziomu wojownika.</content>
   <content contentuid="hc240e7f1g2979geff6gfcc4g1d63a78b39bd" version="1">Poziom 7: Taktyka zespołowa</content>
-  <content contentuid="h3cc7fa69g03fdgb1f5g1a26g3dbd2b575ce8" version="1">Kiedy korzystasz z Grupowego odzyskiwania, każdy wybrany sojusznik ma ułatwienie w testach k20 aż do początku twojej następnej tury.</content>
-  <content contentuid="h4def2360g5a4cgbe2fge70fgbe9d99d7fa1f" version="1">Poziom 10: Fala Zjednoczenia</content>
+  <content contentuid="h3cc7fa69g03fdgb1f5g1a26g3dbd2b575ce8" version="1">Gdy korzystasz z Grupowej regeneracji, każdy wybrany sojusznik ma ułatwienie w testach k20 do początku twojej następnej tury.</content>
+  <content contentuid="h4def2360g5a4cgbe2fge70fgbe9d99d7fa1f" version="1">Poziom 10: Mobilizujący zryw</content>
   <content contentuid="h9e1cff8dg946cga7ccgaeddg5ee4b899b6c6" version="1">Gdy używasz Przypływu sił, możesz wybrać w emanacji o promieniu 9 m, której źródłem jesteś, maksymalnie tylu sojuszników, ile wynosi twój modyfikator Charyzmy. Każdy z nich również zyskuje korzyść z Przypływu sił.</content>
   <content contentuid="h20c820b5g9ed5g6cf5gf004ge0cc7d3c1bb8" version="1">Grupowa regeneracja</content>
   <content contentuid="h6bfa7986g7edeg322fgd99egace84461fcf5" version="1">Wybierz w emanacji o promieniu 9 m, której źródłem jesteś, maksymalnie tylu sojuszników, ile wynosi twój modyfikator Charyzmy. Każdy z nich odzyskuje punkty wytrzymałości w liczbie równej sumie 1k10 i twojego poziomu wojownika.</content>
@@ -2752,13 +2752,13 @@ Chorąży polega na rozsądku, odwadze i wierności kodeksowi rycerskiemu, któr
   <content contentuid="h02149e62gbafbgc9c5g274fg20af94229331" version="1">Wybierz w emanacji o promieniu 9 m, której źródłem jesteś, maksymalnie tylu sojuszników, ile wynosi twój modyfikator Charyzmy. Każdy z nich zyskuje korzyść z twojego Przypływu sił.</content>
   <content contentuid="hcc7a8ccdg1f74g8794gabebg481d991a2048" version="1">Taktyka zespołowa</content>
   <content contentuid="hfb637e3bg85b6g0960g0cb5g7005f951cbcd" version="1">Ma ułatwienie w testach k20 do początku twojej następnej tury.</content>
-  <content contentuid="ha112c9d1gc29dg2a81g78e9g5ee83dc15b44" version="1">Poziom 3: Lodowy Odkrywca</content>
+  <content contentuid="ha112c9d1gc29dg2a81g78e9g5ee83dc15b44" version="1">Poziom 3: Lodowy odkrywca</content>
   <content contentuid="hdf72a045g6802g6864g7289gb8715a4c18b6" version="2">Przenikliwe zimno. Obrażenia od twoich ataków bronią, czarów Łowcy i cech Łowcy ignorują Odporność na obrażenia od zimna.
 
 Odporność na mróz. Masz Odporność na obrażenia od zimna.
 
 Polarne uderzenia. Kiedy trafiasz istotę testem ataku przy użyciu broni, możesz zadać celowi dodatkowe 1k4 obrażeń od zimna; cel może otrzymać te dodatkowe obrażenia tylko raz na turę. Gdy osiągasz 11. poziom Łowcy, te dodatkowe obrażenia wzrastają do 1k6.</content>
-  <content contentuid="hf2ce8883g7e85g48fcgfb85geaec662b97b7" version="1">Poziom 3: Szron myśliwego</content>
+  <content contentuid="hf2ce8883g7e85g48fcgfb85geaec662b97b7" version="1">Poziom 3: Szron łowcy</content>
   <content contentuid="hf17390fdg279dg4294gb86ag4e1049c6b097" version="1">Lód pokrywa szronem ciebie i twoją ofiarę, chroniąc cię i krępując jej ruchy. Gdy rzucasz Znak łowcy, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej 1k10 plus twój poziom Łowcy.
 
 Ponadto istota oznaczona twoim Znakiem łowcy nie może wykonywać akcji Odstąpienia.</content>
@@ -2773,7 +2773,7 @@ Po użyciu tej zdolności musisz ukończyć długi odpoczynek, zanim użyjesz je
 
 Możesz użyć tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości (co najmniej raz), a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
   <content contentuid="hd3324082ga20dg104bg944cg8e9d750a54a5" version="1">Szron łowcy</content>
-  <content contentuid="h7d1048f2gc9feg4128g633ag3409fc6ecdc6" version="1">Nie może wykonać akcji Odłączenia.</content>
+  <content contentuid="h7d1048f2gc9feg4128g633ag3409fc6ecdc6" version="1">Nie może wykonać akcji Odstąpienia.</content>
   <content contentuid="hfb12d0cdg48ffg1464gb153g8e462f617426" version="1">Szron łowcy</content>
   <content contentuid="h319bdef0g52b5g7c9dg095eg8fdb31fd0953" version="1">Otrzymujesz tymczasowe punkty wytrzymałości równe 1k10 plus twój poziom Łowcy.</content>
   <content contentuid="hbf27e726g8355g4950ga017g8d4589b1b9aa" version="1">Krzepiąca dusza</content>


### PR DESCRIPTION
## Summary
- corrects Polish gameplay descriptions with broken grammar or misleading mechanics in the Heroes of Faerûn, aasimar, Banneret, College of the Moon, and Winter Walker sections
- uses the official Polish BG3 wording for changing class and for the Disengage action
- aligns duplicate feature labels such as Group Recovery, Rallying Surge, and Hunter's Rime
- preserves every English `contentuid` and `version`; this PR changes only `polish.xml`

## Validation
- 5,355 source entries and 5,355 Polish entries
- no duplicate, missing, extra, empty, or version-mismatched handles
- no official terminology mismatches or untranslated non-whitelisted entries
- no spell structure, spell language, spell-title, or translation-coverage findings
- LanguageTool found no actionable issue in the 20 changed handles (`k20` was the only dictionary warning)

## Credit request
Please use the following linked credit wherever the Polish and Ukrainian translation credits are listed on GitHub (README/wiki):

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)