### PR TITLE
Align Polish expertise and subclass prose

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -768,20 +768,20 @@ Czasem magia gwałtownie przybiera na sile i zadaje dodatkowe obrażenia. Prawdo
   <content contentuid="heb8d0bd4gf518g09cbgdf04g875209dd858a" version="1">Raz na turę, gdy trafisz istotę bronią paktu, możesz zużyć komórkę czaru Magii Paktu, aby zadać celowi dodatkowe 1k8 obrażeń od mocy oraz kolejne 1k8 za każdy poziom zużytej komórki. Jeśli cel jest Ogromny lub mniejszy, możesz również nadać mu stan Powalenia.</content>
   <content contentuid="hd23c4cc6g5a99gc62eg7220ge0f7cee47aba" version="1">Raz na turę, gdy trafisz istotę bronią paktu, możesz zużyć komórkę czaru Magii Paktu, aby zadać celowi dodatkowe 1k8 obrażeń od mocy oraz kolejne 1k8 za każdy poziom zużytej komórki. Jeśli cel jest Ogromny lub mniejszy, możesz również nadać mu stan Powalenia.</content>
   <content contentuid="h24650f10g65f0gdad5g30cdg3e4777297c7c" version="1">Poziom 2: Uczony</content>
-  <content contentuid="h32ed567egee36g91e1g2accgb992c0f4d730" version="1">Podczas nauki magii zdobywasz również specjalizację w innej dziedzinie. Wybierz jedną z poniższych umiejętności, w której masz biegłość: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Wiedza Tajemna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;Historia&lt;/LSTag&gt;, Śledztwo, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medycyna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Przyroda&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religia&lt;/LSTag&gt;. Zyskujesz Znawstwo w wybranej umiejętności.</content>
-  <content contentuid="h2f5671feg10a3g6221g9db1gcd1af3a88f5b" version="1">Poziom 2: Ekspertyza</content>
-  <content contentuid="h9e315a90g0705gb2c6g1a8eg13de362924de" version="1">Zyskujesz ekspertyzę (patrz słownik zasad) w dwóch wybranych umiejętnościach, w których masz biegłość. &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Występy&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazja&lt;/LSTag&gt; są zalecane, jeśli masz w nich biegłość.
+  <content contentuid="h32ed567egee36g91e1g2accgb992c0f4d730" version="1">Podczas nauki magii wybierasz również inną dziedzinę specjalizacji. Wybierz jedną z poniższych umiejętności, w której masz biegłość: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Wiedza tajemna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;Historia&lt;/LSTag&gt;, Dochodzenie, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medycyna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Przyroda&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religia&lt;/LSTag&gt;. Zyskujesz znawstwo w wybranej umiejętności.</content>
+  <content contentuid="h2f5671feg10a3g6221g9db1gcd1af3a88f5b" version="1">Poziom 2: Znawstwo</content>
+  <content contentuid="h9e315a90g0705gb2c6g1a8eg13de362924de" version="1">Zyskujesz znawstwo (patrz słownik zasad) w dwóch wybranych umiejętnościach, w których masz biegłość. &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Występy&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazja&lt;/LSTag&gt; są zalecane, jeśli masz w nich biegłość.
 
-Na 9. poziomie barda zyskujesz ekspertyzę w dwóch kolejnych wybranych umiejętnościach, w których masz biegłość.</content>
+Na 9. poziomie barda zyskujesz znawstwo w dwóch kolejnych wybranych umiejętnościach, w których masz biegłość.</content>
   <content contentuid="h1d573d0cg0ef8gc58cg5d87gf7b0ce7fc23d" version="1">Poziom 10: Magiczne tajemnice</content>
   <content contentuid="hd5715a4dge184g890agee7ag4f904fb90c6b" version="1">Znasz sekrety rozmaitych tradycji magicznych. Za każdym razem, gdy osiągasz poziom barda — w tym również ten poziom — i zwiększa się wartość w kolumnie Przygotowane czary w tabeli cech barda, możesz wybrać dowolne nowe przygotowane czary z list czarów barda, kleryka, druida i maga. Wybrane czary są dla ciebie czarami barda (listę czarów każdej klasy znajdziesz w jej opisie). Ponadto za każdym razem, gdy zastępujesz czar przygotowany dla tej klasy, możesz zastąpić go czarem z jednej z tych list.</content>
   <content contentuid="hd4f3b039g6204g1bbagd21fgb72f806b54d8" version="1">Poziom 3: Inspiracja bojowa</content>
   <content contentuid="hd0e61f8bg955fgda33g3e08gc99c259c8a16" version="1">Poziom 3: Błogosławieństwa wiedzy</content>
-  <content contentuid="hc9341211ge6c1g1fd9gddbeg13315817fedb" version="1">Zyskujesz biegłość w dwóch wybranych umiejętnościach spośród następujących: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Wiedza tajemna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;Historia&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Natura&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religia&lt;/LSTag&gt;. Zyskujesz specjalizację w obu wybranych umiejętnościach.</content>
-  <content contentuid="ha8b64524g7467g0f1eg9214gbd3da8ce6302" version="1">Poziom 1: Ekspertyza</content>
-  <content contentuid="h75d54fe5g6285g141fgd2b8gca722e196ecc" version="1">Otrzymujesz wiedzę specjalistyczną w dwóch wybranych przez siebie biegłościach. &lt;LSTag Type="Skills" Tooltip="SleightOfHand"&gt;Zwinne dłonie&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Skradanie się&lt;/LSTag&gt; są zalecane, jeśli masz w nich biegłość.
+  <content contentuid="hc9341211ge6c1g1fd9gddbeg13315817fedb" version="1">Zyskujesz biegłość w dwóch wybranych umiejętnościach spośród następujących: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Wiedza tajemna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;Historia&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Przyroda&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religia&lt;/LSTag&gt;. Zyskujesz znawstwo w obu wybranych umiejętnościach.</content>
+  <content contentuid="ha8b64524g7467g0f1eg9214gbd3da8ce6302" version="1">Poziom 1: Znawstwo</content>
+  <content contentuid="h75d54fe5g6285g141fgd2b8gca722e196ecc" version="1">Zyskujesz znawstwo w dwóch wybranych umiejętnościach, w których masz biegłość. &lt;LSTag Type="Skills" Tooltip="SleightOfHand"&gt;Zwinne dłonie&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Skradanie się&lt;/LSTag&gt; są zalecane, jeśli masz w nich biegłość.
 
-Na 6. poziomie Łotra zyskujesz Znawstwo w kolejnych dwóch twoich biegłościach w umiejętnościach według wyboru.</content>
+Na 6. poziomie łotra zyskujesz znawstwo w dwóch kolejnych wybranych umiejętnościach, w których masz biegłość.</content>
   <content contentuid="hac07bd19g5886gc2efgf8dfgb838d23ca0bd" version="1">Poziom 5: Chytre uderzenie</content>
   <content contentuid="h4c3e9164gb5c2g35d0g405dgb887921e3e3a" version="1">Opracowujesz chytre sposoby wykorzystania ukradkowego ataku. Gdy zadajesz obrażenia ukradkowym atakiem, możesz dodać jeden z poniższych efektów Chytrego uderzenia.
 
@@ -2576,7 +2576,7 @@ Ostatni bastion. Gdy masz stan Zakrwawienia, masz ułatwienie w testach ataku.</
   <content contentuid="h2d5b87b6g1172g67b5gcfefg0bf170e5aaef" version="1">Atut: Taktyka Zhentarimów</content>
   <content contentuid="h06b8380ag7f73g106agdf63g8dabbadb964c" version="1">Odwet. Natychmiast po tym, jak istota w promieniu 1,5 m od ciebie trafi cię atakiem wręcz, możesz wykonać przeciwko niej atak okazyjny.
 
-Wszechstronny najemnik. Wybierz umiejętność, w której masz biegłość. Zyskujesz w niej fachowość.</content>
+Wszechstronny najemnik. Wybierz umiejętność, w której masz biegłość. Zyskujesz w niej znawstwo.</content>
   <content contentuid="h32fd92c5gd42cg926fgb1adg572674b52c38" version="1">Atut: Smocze znamię (odporność na kwas)</content>
   <content contentuid="hca54a12agc1f9g2a70g2257g737e96e7df9b" version="1">Atut: Smocze znamię (odporność na zimno)</content>
   <content contentuid="h0a63962age9c8g7392g84a8g55d4962d5732" version="1">Atut: Smocze znamię (odporność na ogień)</content>
@@ -2634,7 +2634,7 @@ Ostatni bastion. Gdy masz stan Zakrwawienia, masz ułatwienie w testach ataku.</
   <content contentuid="h868d132cgda3cg9662gc17ega94ac1ad380e" version="1">Taktyka Zhentarimów</content>
   <content contentuid="he09232a3g8429ge28bga994gd171ef3f3292" version="1">Odwet. Natychmiast po tym, jak istota w promieniu 1,5 m od ciebie trafi cię atakiem wręcz, możesz wykonać przeciwko niej atak okazyjny.
 
-Wszechstronny najemnik. Wybierz umiejętność, w której masz biegłość. Zyskujesz w niej fachowość.</content>
+Wszechstronny najemnik. Wybierz umiejętność, w której masz biegłość. Zyskujesz w niej znawstwo.</content>
   <content contentuid="h3566bf7ege17bg0f56g4fbdgfac65706f1a2" version="1">Podczas tworzenia postaci lub zmiany jej klasy wybierz tylko jeden atut Początki magii. Wybranie więcej niż jednego może spowodować nieoczekiwane problemy.</content>
   <content contentuid="hca895012gaf5dg78a6g7a2eg37692b43b104" version="2">Atut: Zabójcze łucznictwo</content>
   <content contentuid="hc67a4df3gcd8bgf957g4d35gee2424c14472" version="2">W ramach akcji dodatkowej możesz zapewnić sobie ułatwienie w teście ataku bronią dystansową w tej turze. Możesz skorzystać z tej akcji dodatkowej tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
@@ -2662,14 +2662,14 @@ Gdy uzyskasz trafienie krytyczne atakiem bronią do walki wręcz, możesz dodatk
   <content contentuid="h0f8ca247g66e5g6260ga870g3e352f39fa6e" version="2">Elfy mają naturalny talent do celnego strzelania z łuku. Dzięki niemal doskonałemu opanowaniu tej sztuki twoje strzały trafiają z nadzwyczajną precyzją.
 
 W ramach akcji dodatkowej możesz zapewnić sobie ułatwienie w teście ataku bronią dystansową w tej turze. Możesz skorzystać z tej akcji dodatkowej tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
-  <content contentuid="h6e348a1aga0b0g9788gb85dgeba21fa79668" version="1">Zabójca Smoków</content>
+  <content contentuid="h6e348a1aga0b0g9788gb85dgeba21fa79668" version="1">Pogromca Smoków</content>
   <content contentuid="ha77cb967ga90dgf3bagbb92g9b2af176e030" version="2">Legenda Barda Łucznika zainspirowała wielu młodych ludzi z Dale, którzy pragną dowieść swej wartości, zabijając potężnego potwora. Jak wielu przed tobą, od dawna rozmyślasz nad sposobami walki z ogromnymi istotami, licząc, że pewnego dnia zdobędziesz sławę, pokonując jedną z nich.
 
 Masz ułatwienie w testach ataku przeciwko istotom rozmiaru dużego lub większego. Ponadto, gdy trafiasz taką istotę, zadajesz dodatkowe obrażenia równe swojemu modyfikatorowi Siły.</content>
   <content contentuid="h27541f87g50d6gf441gbab6geae246f77643" version="1">Ostry strzał</content>
   <content contentuid="ha574dfdfgf055g69c1g9889gce2fffa674e6" version="3">Czarna Strzała, która powaliła smoka Smauga, mogła być do tego przeznaczona, lecz ręka, która posłała ją z taką siłą, była niezwykle mocna. Gdy rzucasz włócznią albo napinasz łuk, dbasz o pewny chwyt i celny strzał.
 
-Podczas ataku bronią dystansową używasz modyfikatora Siły zarówno do testu ataku, jak i rzutu na obrażenia; do obu musisz użyć tego samego modyfikatora. Jeśli w tej samej turze przemieścisz się najwyżej o połowę swojej szybkości i trafisz istotę atakiem z broni dystansowej, możesz w ramach akcji dodatkowej sprawić, że atak zada dodatkowe 1k4 obrażeń typu zadawanego przez broń.</content>
+Podczas ataku bronią dystansową używasz modyfikatora Siły zarówno do testu ataku, jak i rzutu na obrażenia; do obu musisz użyć tego samego modyfikatora. Jeśli w tej samej turze przemieścisz się najwyżej o połowę swojej szybkości i trafisz istotę atakiem bronią dystansową, możesz w ramach akcji dodatkowej sprawić, że atak zada dodatkowe 1k4 obrażeń typu zadawanego przez broń.</content>
   <content contentuid="h2ffcb591g0cc8ga4f6g50f8g0b3e5ae7dcf0" version="1">Blask Gniewu</content>
   <content contentuid="h63f9716cgc2d1g6fcbg46fcg4c5e77c4be1d" version="2">Twój lud poniósł wiele porażek i odniósł wiele daremnych zwycięstw w wojnach z Cieniem. Śmiertelny gniew, który twoi pobratymcy żywią wobec Nieprzyjaciela, nasyca twoją broń blaskiem zimnego ognia.
 
@@ -2693,11 +2693,11 @@ Gdy zadajesz celowi obrażenia atakiem albo czarem, możesz zadać mu dodatkowe 
   <content contentuid="h3f49f80egbab5g00d8gc75fg71bb7b054fc6" version="1">Wewnętrzny blask</content>
   <content contentuid="h947e63dfge856g93fdge133g7915f597706a" version="1">Palące światło chwilowo bije z twoich oczu i ust. Na czas przemiany emitujesz jasne światło w promieniu 3 m oraz słabe światło w promieniu dalszych 3 m. Na koniec każdej twojej tury każda istota w promieniu 3 m od ciebie otrzymuje obrażenia od światłości równe twojej premii z biegłości.</content>
   <content contentuid="hfae2afebg7426gcf8cg5c76g65cdce3c393d" version="1">Niebiańskie skrzydła</content>
-  <content contentuid="h80c3bb0dgd84cg63b6g9b47g339cb3415da6" version="1">Z twoich pleców na chwilę wyrastają dwa widmowe skrzydła. Dopóki transformacja się nie zakończy, masz szybkość lotu równą swojej szybkości.</content>
+  <content contentuid="h80c3bb0dgd84cg63b6g9b47g339cb3415da6" version="1">Z twoich pleców na chwilę wyrastają dwa widmowe skrzydła. Do końca przemiany masz szybkość lotu równą swojej szybkości.</content>
   <content contentuid="h618cb471geddfg2d11g70feg9e12919e4a68" version="1">Nekrotyczny całun</content>
   <content contentuid="h6a146679g10b4gcab6g7371g8809ef5326f6" version="2">Twoje oczy na chwilę stają się otchłaniami ciemności, a z pleców wyrastają nielotne skrzydła. Wybrane przez ciebie istoty w promieniu 3 m muszą wykonać rzut obronny na Charyzmę; w razie niepowodzenia otrzymują stan Przerażenia na 1 minutę.</content>
   <content contentuid="h34ab3782g568fg1b60g9a2eg148d28686613" version="1">Niebiańskie skrzydła</content>
-  <content contentuid="hbcd3d36fgdc84gb744gaaf6ge51968dbc88e" version="1">Z twoich pleców na chwilę wyrastają dwa widmowe skrzydła. Dopóki transformacja się nie zakończy, masz szybkość lotu równą swojej szybkości.</content>
+  <content contentuid="hbcd3d36fgdc84gb744gaaf6ge51968dbc88e" version="1">Z twoich pleców na chwilę wyrastają dwa widmowe skrzydła. Do końca przemiany masz szybkość lotu równą swojej szybkości.</content>
   <content contentuid="hb450a1d2g4f77g57dbg4c25gd3acee588f18" version="1">Wewnętrzny blask</content>
   <content contentuid="h4049a129gb079gf0dagb270g0aa72eb1171d" version="1">Palące światło chwilowo bije z twoich oczu i ust. Na czas przemiany emitujesz jasne światło w promieniu 3 m oraz słabe światło w promieniu dalszych 3 m. Na koniec każdej twojej tury każda istota w promieniu 3 m od ciebie otrzymuje obrażenia od światłości równe twojej premii z biegłości.</content>
   <content contentuid="h5455adb5gc4c2g9159g585eg6c24762cbd53" version="1">Nekrotyczny całun</content>
@@ -2706,7 +2706,7 @@ Gdy zadajesz celowi obrażenia atakiem albo czarem, możesz zadać mu dodatkowe 
   <content contentuid="h868292b4g07bag5039g7a39g8b646671c67e" version="2">Ma karę 1k4 do &lt;LSTag Tooltip="SavingThrow"&gt;rzutów obronnych&lt;/LSTag&gt;.</content>
   <content contentuid="h6ef5198eg577fg6ca6gc4d9gb725efc2c584" version="1">Myślowy odłamek</content>
   <content contentuid="h8c610e61ga284gbdd9gf4c4gc19e363942ea" version="1">Kolegium Księżyca</content>
-  <content contentuid="h759d592bgce3eg0689gb28cgb0e2182d4aba" version="1">Kolegium Księżyca wywodzi swoje początki z prastarych kręgów druidycznych Wysp Moonshae, które powierzyły pierwszym bardom tej tradycji zadanie spisywania dziejów wysp oraz ich mieszkańców. Bardowie z tego kolegium czerpią z magii fey oraz pierwotnej mocy księżycowych studni, aby wspierać swoich sojuszników, chronić świat natury i tworzyć swe inspirujące, bardowskie dzieła.</content>
+  <content contentuid="h759d592bgce3eg0689gb28cgb0e2182d4aba" version="1">Kolegium Księżyca wywodzi się z prastarych kręgów druidycznych Wysp Moonshae, które powierzyły pierwszym bardom tej tradycji spisywanie dziejów wysp i ich mieszkańców. Bardowie tego kolegium wykorzystują magię fey wysp oraz pierwotną moc księżycowych studni, by wspierać sojuszników, chronić świat natury i znajdować natchnienie dla swej bardowskiej twórczości.</content>
   <content contentuid="h9223661bgace2gba01g10dcgfc1ea09add5a" version="1">Poziom 3: Inspiracja księżyca</content>
   <content contentuid="he8fec49dgf4c3g6a97g790bg3a7f505054bf" version="1">Przepływa przez ciebie pierwotna, wiecznie zmienna moc księżyca, zapewniając następujące korzyści.
 
@@ -2714,9 +2714,9 @@ Inspirujące zaćmienie. Gdy w ramach akcji dodatkowej dajesz istocie kość &lt
 
 Księżycowa witalność. Raz na turę, gdy za pomocą czaru przywracasz istocie punkty wytrzymałości, możesz wydać kość bardowskiej inspiracji i zwiększyć liczbę przywróconych punktów o wynik rzutu tą kością. Szybkość istoty zwiększa się również o 3 m do końca jej następnej tury.</content>
   <content contentuid="haca3aef8ga626gc323g22acg746bfa4a9426" version="1">Poziom 3: Pierwotna wiedza</content>
-  <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">Uczysz się druidyzmu i jednej sztuczki z listy czarów druida. Liczy się to dla ciebie jako czar Barda, ale nie wlicza się do liczby znanych sztuczek.
+  <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">Poznajesz język druidzki i jedną sztuczkę z listy czarów druida. Sztuczka ta jest dla ciebie czarem barda, ale nie wlicza się do liczby znanych przez ciebie sztuczek.
 
-Ponadto wybierz jedną z umiejętności: &lt;LSTag Type="Skills" Tooltip="AnimalHandling"&gt;Opieka nad zwierzętami&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Intuicja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medycyna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Natura&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Percepcja&lt;/LSTag&gt; lub &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Przetrwanie&lt;/LSTag&gt;. Masz biegłość w tej umiejętności.</content>
+Ponadto wybierz jedną z następujących umiejętności: &lt;LSTag Type="Skills" Tooltip="AnimalHandling"&gt;Opieka nad zwierzętami&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Intuicja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medycyna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Przyroda&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Percepcja&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Sztuka przetrwania&lt;/LSTag&gt;. Zyskujesz biegłość w wybranej umiejętności.</content>
   <content contentuid="h3911c437g16cagdddcgede4gaa0c643aec8c" version="1">Poziom 6: Błogosławieństwa światła księżyca</content>
   <content contentuid="haa5e73d8ga7e5ge281g8b67gae695bb23d75" version="1">Zawsze masz przygotowany czar Księżycowy promień.
 
@@ -2739,7 +2739,7 @@ Po użyciu tej cechy do zmodyfikowania Księżycowego promienia nie możesz zrob
 
 Chorąży polega na rozsądku, odwadze i wierności kodeksowi rycerskiemu, które kierują nim w walce ze złoczyńcami. Samotny chorąży jest wykwalifikowanym wojownikiem, ale dowodząc grupą sojuszników, potrafi przekształcić nawet słabo wyposażoną milicję w zaciekły oddział bojowy.</content>
   <content contentuid="h40c5a6a5g42eagbba6g5c64g5ece9eb7fe14" version="1">Poziom 3: Rycerski wysłannik</content>
-  <content contentuid="ha6aeb659gba2ag0648g1d28g8d765621e3a9" version="1">Zdobywasz wiedzę specjalistyczną we wszystkich następujących umiejętnościach: &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Intuicja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Zastraszanie&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazja&lt;/LSTag&gt; oraz &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Występy&lt;/LSTag&gt;.</content>
+  <content contentuid="ha6aeb659gba2ag0648g1d28g8d765621e3a9" version="1">Zyskujesz znawstwo we wszystkich następujących umiejętnościach: &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Intuicja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Zastraszanie&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazja&lt;/LSTag&gt; oraz &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Występy&lt;/LSTag&gt;.</content>
   <content contentuid="h3f223b42g605egefc2g504ag6ef36cc460ed" version="1">Poziom 3: Grupowa regeneracja</content>
   <content contentuid="ha8111f35ge4bag28bcg4d99g339262b0a595" version="2">Gdy używasz Drugiego oddechu, aby odzyskać punkty wytrzymałości, możesz wybrać w emanacji o promieniu 9 m, której źródłem jesteś, maksymalnie tylu sojuszników, ile wynosi twój modyfikator Charyzmy. Każdy z nich odzyskuje punkty wytrzymałości w liczbie równej sumie 1k10 i twojego poziomu wojownika.</content>
   <content contentuid="hc240e7f1g2979geff6gfcc4g1d63a78b39bd" version="1">Poziom 7: Taktyka zespołowa</content>
@@ -2753,13 +2753,13 @@ Chorąży polega na rozsądku, odwadze i wierności kodeksowi rycerskiemu, któr
   <content contentuid="hcc7a8ccdg1f74g8794gabebg481d991a2048" version="1">Taktyka zespołowa</content>
   <content contentuid="hfb637e3bg85b6g0960g0cb5g7005f951cbcd" version="1">Ma ułatwienie w testach k20 do początku twojej następnej tury.</content>
   <content contentuid="ha112c9d1gc29dg2a81g78e9g5ee83dc15b44" version="1">Poziom 3: Lodowy odkrywca</content>
-  <content contentuid="hdf72a045g6802g6864g7289gb8715a4c18b6" version="2">Przenikliwe zimno. Obrażenia od twoich ataków bronią, czarów Łowcy i cech Łowcy ignorują Odporność na obrażenia od zimna.
+  <content contentuid="hdf72a045g6802g6864g7289gb8715a4c18b6" version="2">Przenikliwe zimno. Obrażenia zadawane przez twoje ataki bronią, czary łowcy i cechy łowcy ignorują odporność na obrażenia od zimna.
 
-Odporność na mróz. Masz Odporność na obrażenia od zimna.
+Odporność na mróz. Masz odporność na obrażenia od zimna.
 
-Polarne uderzenia. Kiedy trafiasz istotę testem ataku przy użyciu broni, możesz zadać celowi dodatkowe 1k4 obrażeń od zimna; cel może otrzymać te dodatkowe obrażenia tylko raz na turę. Gdy osiągasz 11. poziom Łowcy, te dodatkowe obrażenia wzrastają do 1k6.</content>
+Polarne uderzenia. Gdy trafiasz istotę testem ataku bronią, możesz zadać celowi dodatkowe 1k4 obrażeń od zimna. Cel może otrzymać te dodatkowe obrażenia tylko raz na turę. Gdy osiągasz 11. poziom łowcy, dodatkowe obrażenia wzrastają do 1k6.</content>
   <content contentuid="hf2ce8883g7e85g48fcgfb85geaec662b97b7" version="1">Poziom 3: Szron łowcy</content>
-  <content contentuid="hf17390fdg279dg4294gb86ag4e1049c6b097" version="1">Lód pokrywa szronem ciebie i twoją ofiarę, chroniąc cię i krępując jej ruchy. Gdy rzucasz Znak łowcy, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej 1k10 plus twój poziom Łowcy.
+  <content contentuid="hf17390fdg279dg4294gb86ag4e1049c6b097" version="1">Szron pokrywa cię i twoją zdobycz, chroniąc cię i krępując jej ruchy. Gdy rzucasz Znak łowcy, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej sumie 1k10 i twojego poziomu łowcy.
 
 Ponadto istota oznaczona twoim Znakiem łowcy nie może wykonywać akcji Odstąpienia.</content>
   <content contentuid="h61ea7154gfc5cg2d12gf82ega36108b6e52c" version="1">Poziom 3: Czary zimowego wędrowca</content>
@@ -2775,7 +2775,7 @@ Możesz użyć tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości
   <content contentuid="hd3324082ga20dg104bg944cg8e9d750a54a5" version="1">Szron łowcy</content>
   <content contentuid="h7d1048f2gc9feg4128g633ag3409fc6ecdc6" version="1">Nie może wykonać akcji Odstąpienia.</content>
   <content contentuid="hfb12d0cdg48ffg1464gb153g8e462f617426" version="1">Szron łowcy</content>
-  <content contentuid="h319bdef0g52b5g7c9dg095eg8fdb31fd0953" version="1">Otrzymujesz tymczasowe punkty wytrzymałości równe 1k10 plus twój poziom Łowcy.</content>
+  <content contentuid="h319bdef0g52b5g7c9dg095eg8fdb31fd0953" version="1">Zyskujesz tymczasowe punkty wytrzymałości w liczbie równej sumie 1k10 i twojego poziomu łowcy.</content>
   <content contentuid="hbf27e726g8355g4950ga017g8d4589b1b9aa" version="1">Krzepiąca dusza</content>
   <content contentuid="h3b19ec2fg1828gff82g805cg351bdc1b191b" version="1">W ramach akcji Magii wybierz maksymalnie tyle widocznych istot, ile wynosi twój modyfikator Mądrości (co najmniej jedną). Każda wybrana istota odzyskuje punkty wytrzymałości w liczbie równej sumie 1k10 i twojego poziomu łowcy, a przez 1 godzinę wykonuje z ułatwieniem rzuty obronne pozwalające uniknąć stanu Przerażenia albo go zakończyć.</content>
   <content contentuid="haf330cbag9da5g81b9gc9c4g13038dc4bc59" version="1">Krzepiąca dusza</content>
@@ -3053,7 +3053,7 @@ W formie smoka możesz atakować pazurami i używać broni oddechowej. Zyskujesz
 
 Druidzi z tego Kręgu wiedzą, że smoki i smocza magia są tak samo połączone ze światem jak rośliny czy zwierzęta, i wykorzystują to połączenie, aby przekształcić się w wyjątkową i potężną smoczą formę.</content>
   <content contentuid="hea0350ecg3563gf151g3949ge2a04d0eb3da" version="1">Poziom 3: Smocza Wiedza</content>
-  <content contentuid="hda6df4cdg93a3gab23g3fd8ga7f8a4585d19" version="1">Zdobędziesz wiedzę specjalistyczną w zakresie kontroli &lt;LSTag Type="Skills" Tooltip="History"&gt;Historia&lt;/LSTag&gt;.</content>
+  <content contentuid="hda6df4cdg93a3gab23g3fd8ga7f8a4585d19" version="1">Zyskujesz znawstwo w testach &lt;LSTag Type="Skills" Tooltip="History"&gt;Historii&lt;/LSTag&gt;.</content>
   <content contentuid="h8ea85d5eg5bc3gd5aagf3e6g7179f506b3ef" version="1">Poziom 3: Kształt Smoka</content>
   <content contentuid="hc9360440gfe54g46f9gbb9dge1b352d710ba" version="2">W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby przybrać wyjątkową Smoczą Postać. Stajesz się wówczas średnim smokiem poruszającym się na czterech łapach, ale zachowujesz swoje zwykłe statystyki i zmysły.
 
@@ -3067,7 +3067,7 @@ Po przybraniu Smoczej Postaci zyskujesz tymczasowe punkty wytrzymałości w licz
   <content contentuid="he87fc2b8g89e0g6349gbba8g169827090bfc" version="1">Jeździec autostradą</content>
   <content contentuid="h71ff1a29gf725g3e28gb5bfg5096950ebc3f" version="1">Podążając zaułkami, Autostrada zasiewa strach w sercu każdego podróżnika i żądnego grosza kupca. Zbiegają ze zdobyczą na szybkim i lojalnym rumaku, a następnie szybko uciekają.</content>
   <content contentuid="hf94de242ge211g147egfef6gf0c946d2ffe0" version="1">Poziom 3: Wyzwalacz włosów</content>
-  <content contentuid="h83b92101gfc2bg31e9gf707gf2e81d4a43fc" version="3">Zdobywasz wiedzę specjalistyczną w posługiwaniu się bronią palną. Ponadto możesz wykonać jeden atak bronią w pierwszej turze walki, nie korzystając z akcji.</content>
+  <content contentuid="h83b92101gfc2bg31e9gf707gf2e81d4a43fc" version="3">Zyskujesz znawstwo w posługiwaniu się bronią palną. Ponadto w pierwszej turze walki możesz wykonać jeden atak bronią bez użycia akcji.</content>
   <content contentuid="hcc27b910g6850g1264gef1agb05f75743b92" version="1">Poziom 3: Zaufany wierzchowiec</content>
   <content contentuid="h4bf647c4g9622g1b59gd3ccg7614d1ac3969" version="1">Zawsze masz przygotowany czar Znalezienie wierzchowca. Za pomocą tej cechy możesz rzucić go bez zużywania komórki czaru ani komponentów, a Inteligencja jest twoją cechą bazową do tego czaru.
 
@@ -3373,9 +3373,9 @@ Wątpliwość jest pewnością. Nie muszę przekonywać wroga, mogę jedynie zas
 Zaufaj mi. Za każde kłamstwo, które wypowiadam, mówię prawdę dziesięciokrotnie. Kto zawsze kłamie, nic nie mówi.
 
 Nigdy nie mów tego samego kłamstwa dwa razy. Nadużywana umiejętność staje się zbyt przewidywalna. Ruszaj się, zmieniaj cele, każ im zgadywać.</content>
-  <content contentuid="hb052fe34g86bfg992cg2672g146c445e9dc4" version="1">Gdy Moloch przyjmie cię jako swojego illriggera, zyskujesz &lt;LSTag Tooltip="Expertise"&gt;ekspertyzę&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazji&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Oszustwa&lt;/LSTag&gt;.</content>
+  <content contentuid="hb052fe34g86bfg992cg2672g146c445e9dc4" version="1">Gdy Moloch przyjmie cię jako swojego illriggera, zyskujesz &lt;LSTag Tooltip="Expertise"&gt;znawstwo&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazji&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Oszustwa&lt;/LSTag&gt;.</content>
   <content contentuid="h02827317g8f4fgf0ebgdc73g2e240e81362a" version="1">Poziom 3: Błogosławieństwo Molocha</content>
-  <content contentuid="h4b29ebdegfa87g42bege4a2g3b10f7973640" version="1">Gdy Moloch przyjmie cię jako swojego illriggera, zyskujesz &lt;LSTag Tooltip="Expertise"&gt;ekspertyzę&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazji&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Oszustwa&lt;/LSTag&gt;.</content>
+  <content contentuid="h4b29ebdegfa87g42bege4a2g3b10f7973640" version="1">Gdy Moloch przyjmie cię jako swojego illriggera, zyskujesz &lt;LSTag Tooltip="Expertise"&gt;znawstwo&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazji&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Oszustwa&lt;/LSTag&gt;.</content>
   <content contentuid="h6dff901fgee2cg0571g1cd5g5cccc5298b3e" version="1">Poziom 3: Urok wroga</content>
   <content contentuid="h3eabef8fg88cagb8c2g7625g98663b906cac" version="3">Kiedy użyjesz swojej akcji dodatkowej, aby umieścić &lt;LSTag Type="Spell" Tooltip="Target_Seal"&gt;pieczęć&lt;/LSTag&gt; na istocie, możesz go oczarować na 10 tur.</content>
   <content contentuid="he8f7350dgec9cga3c4g613agaeb7f4a54136" version="1">Poziom 3: Słodko-miodowe ostrze</content>


### PR DESCRIPTION
## Summary
- aligns every remaining Polish translation of the `Expertise` rules term with the official Baldur's Gate 3 term `znawstwo`
- improves Polish wording in selected aasimar, College of the Moon, Winter Walker, Dragon-Slayer, and ranged-attack descriptions
- aligns official Polish BG3 skill names such as `Wiedza tajemna`, `Dochodzenie`, `Przyroda`, and `Sztuka przetrwania`
- preserves every English `contentuid` and `version`; this PR changes only `polish.xml`

## Validation
- 5,355 source entries and 5,355 Polish entries
- no duplicate, missing, extra, empty, order-mismatched, or version-mismatched handles
- no tag or placeholder mismatches
- no official terminology mismatches, untranslated non-whitelisted entries, or translation-coverage findings
- no spell structure, spell language, spell-title, spell-description, or missing custom-title findings
- LanguageTool found no actionable issue in the 19 changed handles; its 9 dictionary warnings cover proper names, D&D terms, and dice notation only

## Credit request
Please use the following linked credit wherever the Polish and Ukrainian translation credits are listed on GitHub (README/wiki):

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
