### PR TITLE
Refine Polish feature and spell names

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -81,7 +81,7 @@ Podcięcie ścięgna. Szybkość celu zostaje zmniejszona o [1] do początku two
   <content contentuid="h5acf268bg7a2dgd7c7g4d2dg20caffe2e8a4" version="1">Możesz kopnąć cel ważący maksymalnie dwa razy więcej niż pozwalałoby &lt;LSTag Type="Spell" Tooltip="Target_Shove"&gt;popchnięcie&lt;/LSTag&gt;.</content>
   <content contentuid="h0e7ef600g82aegeba0g077eg2ddad69731f8" version="1">Otacza cię dzika magia barbarzyńcy. Twoja &lt;LSTag Tooltip="ArmourClass"&gt;Klasa Pancerza&lt;/LSTag&gt; zwiększa się o wartość równą twojej premii do obrażeń szału, dopóki trwa twój &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt;.</content>
   <content contentuid="hd75d1783g8062gae55g78a6g651f55455f7f" version="1">Poziom 2: Specjalista od wszystkiego</content>
-  <content contentuid="h6002075bg4feegb25ag03b5g8e88a4351c0f" version="1">Poziom 5: Czcionka inspiracji</content>
+  <content contentuid="h6002075bg4feegb25ag03b5g8e88a4351c0f" version="1">Poziom 5: Źródło inspiracji</content>
   <content contentuid="h5d1b01ffgd776g8ca4gd2edgb4e5e0068ad7" version="1">Ponadto możesz zużyć komórkę czaru (bez konieczności użycia akcji), aby odzyskać jedno zużyte użycie Bardowskiej inspiracji.</content>
   <content contentuid="h3c4853cag177dg4ea8g0c15gde7e940ee735" version="1">Źródło inspiracji</content>
   <content contentuid="h7c14769cg0f8ag7968g4156g1272fd5b7850" version="3">Zużyj komórkę czaru, aby odzyskać jedno użycie bardowskiej inspiracji.</content>
@@ -114,7 +114,7 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="he6319c8dga9bagd985gfc80gc057d99c3f06" version="1">Pomoc</content>
   <content contentuid="h8c0c79e8geefage313gb534gd315de67d298" version="1">Zwiększ maksymalną liczbę punktów wytrzymałości swoich sojuszników o [1].</content>
   <content contentuid="hbdf4d91ege560gf373gb78fgc694716131ec" version="1">Słowo blasku</content>
-  <content contentuid="h0dd0eba8g9b93g7909g9d9cg2a09e01a4c46" version="2">Poziom 1: Boski Porządek: Obrońca</content>
+  <content contentuid="h0dd0eba8g9b93g7909g9d9cg2a09e01a4c46" version="2">Poziom 1: Boski porządek: Obrońca</content>
   <content contentuid="h82c38cb3g39e6g13c8g7a26g5c63f737aa79" version="1">Obrońca: Wyszkolony do walki, zyskujesz biegłość w posługiwaniu się bronią wojenną i trenując w ciężkiej zbroi.</content>
   <content contentuid="hd91012edgb1a6g4aabg14d4g0d685464de55" version="1">Taumaturg: Znasz jedną dodatkową sztuczkę z listy czarów Kleryka. Ponadto twoje mistyczne połączenie z boskością daje ci premię do testów Inteligencji (&lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Wiedza Tajemna&lt;/LSTag&gt; lub &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religia&lt;/LSTag&gt;). Premia równa się twojemu modyfikatorowi Mądrości (co najmniej +1).</content>
   <content contentuid="h5eae110bgf170g8febg7b95gaf9957eab275" version="1">Wskazówki</content>
@@ -127,15 +127,15 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="h4d2d81f9g6a4cg493ege377gd246536aefa0" version="1">Żałobny dzwon</content>
   <content contentuid="h5d663b96gee20gd7abg28bdgde325d686903" version="1">Boski porządek</content>
   <content contentuid="hf078c843g4ca9gd89bgde69g7b94c3d7e9b4" version="1">Poświęcasz się jednej z poniższych świętych ról według własnego wyboru.</content>
-  <content contentuid="hc0f7da49g83b0g2364gd22fg0e72e6d0f671" version="1">Poziom 1: Boski Porządek: Słowo Promienia</content>
-  <content contentuid="h4d5b8b7cg1eddg15a0g6e0cgb4e68f50ee06" version="1">Poziom 1: Boski porządek: Przewodnictwo</content>
+  <content contentuid="hc0f7da49g83b0g2364gd22fg0e72e6d0f671" version="1">Poziom 1: Boski porządek: Słowo blasku</content>
+  <content contentuid="h4d5b8b7cg1eddg15a0g6e0cgb4e68f50ee06" version="1">Poziom 1: Boski porządek: Wskazówki</content>
   <content contentuid="h865f785bge303g1b8ag2f0egee91191a55fd" version="1">Poziom 1: Boski porządek: Światło</content>
-  <content contentuid="h0bfe486dga99eg5aefg818agacd35ff6e130" version="2">Poziom 1: Boski Rozkaz: Pękające Ścięgno</content>
-  <content contentuid="hd5ac78c8g2d8cg02bag6ebbg2f9ccd67bc36" version="1">Poziom 1: Boski Porządek: Opór</content>
-  <content contentuid="h63c03147gca42g60bdgfa7ag47ceb695bc38" version="1">Poziom 1: Boski Zakon: Święty Płomień</content>
-  <content contentuid="hf2f5e5c4g141ag2b8egb90cg9ff6727b6910" version="1">Poziom 1: Boski rozkaz: Oszczędź umierających</content>
-  <content contentuid="h50136471gff21g505fg888cgf856fc01281a" version="1">Poziom 1: Boski Porządek: Taumaturgia</content>
-  <content contentuid="h9b0eeaeeg6a13gc99dg6669gc97c57ec0db5" version="1">Poziom 1: Boski rozkaz: Zabij umarłych</content>
+  <content contentuid="h0bfe486dga99eg5aefg818agacd35ff6e130" version="2">Poziom 1: Boski porządek: Pękające ścięgno</content>
+  <content contentuid="hd5ac78c8g2d8cg02bag6ebbg2f9ccd67bc36" version="1">Poziom 1: Boski porządek: Odporność</content>
+  <content contentuid="h63c03147gca42g60bdgfa7ag47ceb695bc38" version="1">Poziom 1: Boski porządek: Święty płomień</content>
+  <content contentuid="hf2f5e5c4g141ag2b8egb90cg9ff6727b6910" version="1">Poziom 1: Boski porządek: Powstrzymanie śmierci</content>
+  <content contentuid="h50136471gff21g505fg888cgf856fc01281a" version="1">Poziom 1: Boski porządek: Taumaturgia</content>
+  <content contentuid="h9b0eeaeeg6a13gc99dg6669gc97c57ec0db5" version="1">Poziom 1: Boski porządek: Żałobny dzwon</content>
   <content contentuid="h84a7d362gf65ag0f66g6103g7d1f4fc707d2" version="1">Poziom 2: Akt wiary</content>
   <content contentuid="h619804afg28a4g6f48g9db2gb39ec7c1d073" version="1">Możesz ukierunkować boską energię, aby wywoływać specjalne efekty, takie jak &lt;LSTag Type="Spell" Tooltip="Target_DivineSpark"&gt;Boska iskra&lt;/LSTag&gt; i Odpędzanie nieumarłych. Za każdym razem, gdy używasz Aktu wiary, wybierasz jeden z nich. Na wyższych poziomach kleryka zyskujesz dodatkowe efekty i użycia. Jedno użycie odzyskujesz po krótkim odpoczynku, a wszystkie po długim odpoczynku. ST rzutów obronnych oblicza się na podstawie twojego ST obrony przed czarami.</content>
   <content contentuid="h0fdb1f5ag867fg21d4g6beeg681eae4df812" version="1">Boska Iskra</content>
@@ -244,26 +244,26 @@ Dodaj połowę swojego modyfikatora Mądrości do &lt;LSTag Tooltip="AbilityChec
   <content contentuid="h853f3b07gf693g964eg9f97g97a2cfda50ef" version="1">Każda istota w emanacji [1], której źródłem jesteś, wykonuje rzut obronny na Kondycję. Przy niepowodzeniu otrzymuje obrażenia od dźwięku.</content>
   <content contentuid="hbd2e3aa0g3258g4710g9504gbadee9cd0ea6" version="1">Poziom 1: Druid</content>
   <content contentuid="h59f8cb26gc1aag4dc3g0939ge1b311504647" version="1">Znasz druidzki — sekretny język Druidów. Podczas nauki tej pradawnej mowy udało ci się również odblokować magię porozumiewania się ze zwierzętami; zawsze masz przygotowany czar Rozmawianie ze zwierzętami.</content>
-  <content contentuid="h1193aa13ge0d7ge702g2f85ga0c0527d229d" version="2">Poziom 1: Pierwotny Rozkaz: Strażnik</content>
+  <content contentuid="h1193aa13ge0d7ge702g2f85ga0c0527d229d" version="2">Poziom 1: Pierwotny porządek: Strażnik</content>
   <content contentuid="h236eb2e6g63d1g6008gac03gd13912a2af7b" version="1">Strażnik. Wyszkolony do walki, zyskujesz biegłość w żołnierskich broniach i szkolenie w średnich pancerzach.</content>
-  <content contentuid="hdc66e2feg6dc9g8e0dg69c3g1ac135e77240" version="1">Poziom 1: Pierwotny Porządek: Przewodnictwo</content>
+  <content contentuid="hdc66e2feg6dc9g8e0dg69c3g1ac135e77240" version="1">Poziom 1: Pierwotny porządek: Wskazówki</content>
   <content contentuid="h261201bdgf3e1gc0a9g001bg9f21c4b6eb0b" version="1">Mag. Znasz jedną dodatkową sztuczkę z listy czarów druida. Ponadto twoja mistyczna więź z naturą zapewnia ci premię do testów Inteligencji (&lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Wiedza Tajemna&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Przyroda&lt;/LSTag&gt;). Premia jest równa twojemu modyfikatorowi Mądrości (co najmniej +1).</content>
   <content contentuid="hf498864agc7beg3cdbgca11g269c576f1a01" version="1">Wskazówki</content>
   <content contentuid="h4e0c0b74gabceg8644g0a67g8c877d23dd83" version="1">Poziom 1: Pierwotny porządek: Trujący rozprysk</content>
   <content contentuid="h3635dadfgfe4eg55c4g39dfgaf968256d2d8" version="1">Trujący rozprysk</content>
-  <content contentuid="h5307ff13g4736g2ce2ga66fg11f20a990de2" version="2">Poziom 1: Pierwotny Rozkaz: Wytwórz Płomień</content>
+  <content contentuid="h5307ff13g4736g2ce2ga66fg11f20a990de2" version="2">Poziom 1: Pierwotny porządek: Wywołanie płomienia</content>
   <content contentuid="h5169409cg04adgc907gd30eg09ebe8d3738c" version="1">Wywołanie płomienia</content>
-  <content contentuid="h55c47b09ga380g8cf2g15b8g2bedd46fe8e9" version="2">Poziom 1: Pierwotny Rozkaz: Opór</content>
+  <content contentuid="h55c47b09ga380g8cf2g15b8g2bedd46fe8e9" version="2">Poziom 1: Pierwotny porządek: Odporność</content>
   <content contentuid="h69ae862bga7a4g2605g04a4gd9317e169763" version="1">Odporność</content>
   <content contentuid="hd0c364a3g050eg598bgd2fdg4c1b525be149" version="2">Poziom 1: Pierwotny porządek: Shillelagh</content>
   <content contentuid="h599263a1g8987g0f3dgf199g149b6068247f" version="1">Shillelagh</content>
-  <content contentuid="hab8ea7d9g7419g79d4ge012g86380a295a02" version="3">Poziom 1: Pierwotny rozkaz: Oszczędź umierających</content>
+  <content contentuid="hab8ea7d9g7419g79d4ge012g86380a295a02" version="3">Poziom 1: Pierwotny porządek: Powstrzymanie śmierci</content>
   <content contentuid="hf5a7c07dg5d75g8b41g3ce4g8e350dae85b9" version="1">Powstrzymanie śmierci</content>
-  <content contentuid="hd5bb58c8g9203g4533gc615ga31bea2a2187" version="2">Poziom 1: Pierwotny Rozkaz: Gwiezdny ognik</content>
+  <content contentuid="hd5bb58c8g9203g4533gc615ga31bea2a2187" version="2">Poziom 1: Pierwotny porządek: Gwiezdny ognik</content>
   <content contentuid="h8891553bg7ca5g791ag4b95g5a72f6e71ed4" version="1">Gwiezdny ognik</content>
-  <content contentuid="hc7a0905fg5836g8050gb036gd435c6a53ffd" version="2">Poziom 1: Pierwotny Rozkaz: Cierniowy Bicz</content>
+  <content contentuid="hc7a0905fg5836g8050gb036gd435c6a53ffd" version="2">Poziom 1: Pierwotny porządek: Cierniowy bicz</content>
   <content contentuid="h1793f9fbgf70agf3acge48bg70b646b51326" version="1">Cierniowy bicz</content>
-  <content contentuid="h566f5dd1g1db3g0d0age62cg0ff1909892ef" version="2">Poziom 1: Pierwotny Rozkaz: Piorun</content>
+  <content contentuid="h566f5dd1g1db3g0d0age62cg0ff1909892ef" version="2">Poziom 1: Pierwotny porządek: Grzmot</content>
   <content contentuid="hf81ea6f0gb2bcg2e34g72c5gfeb99fd56826" version="1">Grzmot</content>
   <content contentuid="ha16fbd5eg7072g66aeg7f0eg739d38d2a607" version="1">Pierwotny porządek</content>
   <content contentuid="h22f70fd0g4354g1c46g6712gdc288b7803e5" version="1">Poświęcasz się jednej z poniższych świętych ról według własnego wyboru.</content>
@@ -328,7 +328,7 @@ Tymczasowe punkty wytrzymałości: Zyskujesz liczbę tymczasowych punktów wytrz
   <content contentuid="he3035afbgf846g4686gf4e6gc39575739bed" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Ogień)</content>
   <content contentuid="hd0a6f226g6b60g6204gb543g086832d392ff" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Błyskawica)</content>
   <content contentuid="h193b9818gd62dg67b7gf4e0g1d6b13d33a89" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Grzmot)</content>
-  <content contentuid="h86990efage02cg7a58gc14dgac02e5274f97" version="1">Poziom 5: Dzikie Odrodzenie</content>
+  <content contentuid="h86990efage02cg7a58gc14dgac02e5274f97" version="1">Poziom 5: Dzikie odrodzenie</content>
   <content contentuid="hb6ef2813g5893gbc58ga19aga900b5ff9a74" version="1">Możesz przywrócić jedno użycie Dzikiej postaci, wydając komórkę czaru (nie jest wymagana żadna akcja).</content>
   <content contentuid="h4fc2af8fg81c5g79b5g40c7gfd252be60f4c" version="1">Dzikie odrodzenie</content>
   <content contentuid="h70ae88b1gd34eg0e8ag5b7bga526ea0cf7a6" version="1">Możesz przywrócić jedno użycie Dzikiej postaci, wydając komórkę czaru (nie jest wymagana żadna akcja).</content>
@@ -345,12 +345,12 @@ Tymczasowe punkty wytrzymałości: Zyskujesz liczbę tymczasowych punktów wytrz
 Księżycowy blask. Każdy twój atak w dzikiej postaci może zadawać obrażenia zwykłego typu albo obrażenia od światłości. Wybierasz typ obrażeń za każdym razem, gdy trafiasz takim atakiem.
 
 Zwiększona wytrzymałość. Możesz dodawać swój modyfikator Mądrości do rzutów obronnych na Kondycję.</content>
-  <content contentuid="h7f91f61fg551cg9fe6g9a0cg340e7bc48a41" version="1">Poziom 10: Krok Światła Księżyca</content>
+  <content contentuid="h7f91f61fg551cg9fe6g9a0cg340e7bc48a41" version="1">Poziom 10: Krok w blasku księżyca</content>
   <content contentuid="h4b611e19g3e33g0533g1f8cg44ab465667b3" version="1">Przenosisz się magicznie i pojawiasz ponownie w rozbłysku księżycowego światła. W ramach akcji dodatkowej teleportujesz się na odległość do [1] na widoczne, niezajęte miejsce. Możesz użyć tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości (co najmniej raz), a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
   <content contentuid="h9203385fgb0d0gc75egca31g0264dad5cc14" version="1">Krok w blasku księżyca</content>
   <content contentuid="hde80ec9cg7cdbg9ea0g9225gb25148c847a9" version="1">W magiczny sposób przenosisz się, pojawiając się ponownie w rozbłysku księżyca.</content>
-  <content contentuid="hcf67e29ag6032g30cfgf7dbg0fb20210f91d" version="1">Ładowanie krokowe w świetle księżyca</content>
-  <content contentuid="hcd5cf1b2gd583gccb7gb15cg0cd8f525eccb" version="1">Liczba przypadków, w których możesz użyć Kroku Księżycowego Światła.</content>
+  <content contentuid="hcf67e29ag6032g30cfgf7dbg0fb20210f91d" version="1">Użycie Kroku w blasku księżyca</content>
+  <content contentuid="hcd5cf1b2gd583gccb7gb15cg0cd8f525eccb" version="1">Liczba użyć Kroku w blasku księżyca.</content>
   <content contentuid="h019511d5gb330g2cd9gd860g84e25789d117" version="1">Pojawia się na tobie konstelacja mądrego smoka. Gdy wykonujesz &lt;LSTag Tooltip="SavingThrow"&gt;rzut obronny&lt;/LSTag&gt;, aby utrzymać &lt;LSTag Tooltip="Concentration"&gt;koncentrację&lt;/LSTag&gt; na czarze, wynik 9 albo niższy traktujesz jak 10.</content>
   <content contentuid="h539b326cga713g3705gbe13g1aa9f8c71bde" version="1">Poziom 2: Umysł taktyczny</content>
   <content contentuid="h61388cf8g2c44ge32ege2c8gd43ed94d46c8" version="1">Masz talent do taktyki na polu bitwy i poza nim. Możesz zużyć jedno użycie Drugiego oddechu, aby zwiększyć szanse powodzenia testu cechy. Rzuć 1k10 i dodaj wynik do testu, co może zmienić niepowodzenie w powodzenie.</content>
@@ -1341,15 +1341,15 @@ Na koniec każdej tury istnieje szansa, że pojawi się ponownie na Planie Mater
   <content contentuid="h8a7a7954g6da6g0f9cgced3g9dfea486d831" version="2">Przywołujesz wirujące sztylety w cylindrze o promieniu 1,5 m i wysokim na 12 m, wyśrodkowanym w punkcie w zasięgu. Każda istota na tym obszarze otrzymuje obrażenia cięte. Istota również otrzymuje te obrażenia, jeśli zakończy w tym miejscu swoją turę lub jeśli Cylinder poruszy się na jego pole. Istota otrzymuje te obrażenia tylko raz na turę.
 
 W późniejszych turach możesz wykonać akcję Magii, aby przesunąć Cylinder o maksymalnie 9 m.</content>
-  <content contentuid="h81c2ba2bgde76gcf4dgb0feg9c1e82f5c048" version="1">Przesuń Chmurę Sztyletów</content>
+  <content contentuid="h81c2ba2bgde76gcf4dgb0feg9c1e82f5c048" version="1">Przesuń Chmurę sztyletów</content>
   <content contentuid="h397f04c0gccd3gd295ga021g620c652c55a6" version="1">Wykonaj akcję Magii, aby teleportować sztylety na odległość do 9 m.</content>
-  <content contentuid="h933efb07gb6d9g6ac3g1616gcb30169f9ef8" version="1">Przesuń Chmurę Sztyletów</content>
+  <content contentuid="h933efb07gb6d9g6ac3g1616gcb30169f9ef8" version="1">Przesuń Chmurę sztyletów</content>
   <content contentuid="hdc6544c3gfdf8g7fbeg01beg66ea43bb6f3b" version="1">Wykonaj akcję Magii, aby teleportować sztylety na odległość do 9 m.</content>
-  <content contentuid="hf9903a34g76c3gfdf1g4be2g6ded0a0cde47" version="1">Przesuń Chmurę Sztyletów</content>
+  <content contentuid="hf9903a34g76c3gfdf1g4be2g6ded0a0cde47" version="1">Przesuń Chmurę sztyletów</content>
   <content contentuid="h32b22995g2857gfa18gcd1cg50ffda0195dd" version="1">Wykonaj akcję Magii, aby teleportować sztylety na odległość do 9 m.</content>
-  <content contentuid="h91d412b9gc3c1g03ddg9d69g14b5660c1d16" version="1">Przesuń Chmurę Sztyletów</content>
+  <content contentuid="h91d412b9gc3c1g03ddg9d69g14b5660c1d16" version="1">Przesuń Chmurę sztyletów</content>
   <content contentuid="ha97083f1g4db3gf664gd422g662591619c09" version="1">Wykonaj akcję Magii, aby teleportować sztylety na odległość do 9 m.</content>
-  <content contentuid="haaf05dcegc1c7g957cg76bagbacf907adfb7" version="1">Przesuń Chmurę Sztyletów</content>
+  <content contentuid="haaf05dcegc1c7g957cg76bagbacf907adfb7" version="1">Przesuń Chmurę sztyletów</content>
   <content contentuid="h80951a8egaf3eg2e55g487ag32eaf1d2ca05" version="1">Wykonaj akcję Magii, aby teleportować sztylety na odległość do 9 m.</content>
   <content contentuid="h37831829g4ea6g1feeg1915gea8f0fa699b7" version="1">Kolorowy rozprysk</content>
   <content contentuid="h3e1a2984ge2d3ge837gff22gc2ac69bcf687" version="1">&lt;LSTag Type="Status" Tooltip="COLOR_SPRAY"&gt;Oślep&lt;/LSTag&gt; istoty o łącznej puli punktów wytrzymałości wynoszącej [1].</content>
@@ -1923,7 +1923,7 @@ Być może psychiczny wiatr z Planu Astralnego przyniósł ci energię psioniczn
   <content contentuid="h65ae228fgd955g4d7fg5f83g914fe7e83123" version="1">Poziom 3: Czary psioniczne</content>
   <content contentuid="hd2d76fb0g487cg3ab3g3908g9f58ed8e7217" version="1">Po osiągnięciu określonych poziomów Zaklinacza wskazanych w tabeli Czarów psionicznych zawsze masz przygotowane wymienione w niej czary.
 
-Na 3. poziomie są to Ramiona Hadara, Wyciszenie emocji, Wykrycie myśli, Fałszywe podszepty i Okruch umysłu; na 5. poziomie dodatkowo — Głód Hadara; na 7. poziomie — Czarne macki Evarda; a na 9. poziomie — Telekineza.</content>
+Na 3. poziomie są to Ramiona Hadara, Wyciszenie emocji, Wykrycie myśli, Fałszywe podszepty i Myślowy odłamek; na 5. poziomie dodatkowo — Głód Hadara; na 7. poziomie — Czarne macki Evarda; a na 9. poziomie — Telekineza.</content>
   <content contentuid="hc47eeb0bg59b3g6c84g97bbg6e37b0afac07" version="1">Poziom 6: Czary psioniczne</content>
   <content contentuid="h50cb5cf3g3c73g27b1gaca7g9a573996ab32" version="1">Poziom 6: Obrona psychiczna</content>
   <content contentuid="h9cc59e90gba0dg93e0gfef2g7374298fdf05" version="1">Masz odporność na obrażenia psychiczne. Co więcej, masz odporność na stany zauroczenia i przerażenia.</content>
@@ -3120,7 +3120,7 @@ Jeśli runa wymaga rzutu obronnego, jej ST rzutu obronnego wynosi 8 + twoja prem
   <content contentuid="hdbd971c9g92f8ga84bg8f1eg267b38cd8ffc" version="1">Dodatkowe obrażenia zadawane przez Potęgę Olbrzyma wzrastają do 1k8.</content>
   <content contentuid="hb3ae9e73g81e6g120dg8548g27684eff651f" version="1">Przywołaj Runę Chmury</content>
   <content contentuid="hfd1bcc8cg898egba47gb579gfd786513a783" version="1">&lt;LSTag Type="Status" Tooltip="CHARMED"&gt;Zaurocz&lt;/LSTag&gt; atakującego cię wroga. Jeśli to możliwe, zaatakuje on inny cel.</content>
-  <content contentuid="h3a4d5e28gabe3g3168ge119g17a00c4aa941" version="1">Przywołaj Runę Ognia</content>
+  <content contentuid="h3a4d5e28gabe3g3168ge119g17a00c4aa941" version="1">Przywołaj Runę ognia</content>
   <content contentuid="h80302dc6gefa4ga829g206ag2011c0e0baca" version="2">Gdy trafiasz istotę atakiem bronią, możesz aktywować runę i przywołać płonące kajdany. Cel otrzymuje dodatkowe 2k6 obrażeń od ognia oraz stan unieruchomienia na 1 minutę. Dopóki jest unieruchomiony kajdanami, na początku każdej swojej tury otrzymuje 2k6 obrażeń od ognia. Na koniec każdej swojej tury cel powtarza rzut obronny, rozpraszając kajdany przy powodzeniu.</content>
   <content contentuid="h06dee418g7023gcae2g1dd4g7246a7a21faf" version="1">Runa ognia</content>
   <content contentuid="h0738e060g6dbdgd884ga7eag9103f532652e" version="1">Dopóki cel jest unieruchomiony kajdanami, na początku każdej swojej tury otrzymuje 2k6 obrażeń od ognia. Na koniec każdej swojej tury powtarza rzut obronny, rozpraszając kajdany przy powodzeniu.</content>
@@ -3172,7 +3172,7 @@ Jeśli runa wymaga rzutu obronnego, jej ST rzutu obronnego wynosi 8 + twoja prem
   <content contentuid="h30b03151g5293g0f58g25ecg192e954a1d18" version="1">Będąc w zwierzęcej postaci, nie możesz rozmawiać ani rzucać czarów. Przyjmujesz atrybuty swojej bestii — z wyjątkiem &lt;LSTag Tooltip="Intelligence"&gt;Inteligencji&lt;/LSTag&gt;, &lt;LSTag Tooltip="Wisdom"&gt;Mądrości&lt;/LSTag&gt; i &lt;LSTag Tooltip="Charisma"&gt;Charyzmy&lt;/LSTag&gt;.</content>
   <content contentuid="hec2215cegc8c3g171bg67cdg7de02f56bba6" version="1">Będąc w zwierzęcej postaci, nie możesz rozmawiać ani rzucać czarów. Przyjmujesz atrybuty swojej bestii — z wyjątkiem &lt;LSTag Tooltip="Intelligence"&gt;Inteligencji&lt;/LSTag&gt;, &lt;LSTag Tooltip="Wisdom"&gt;Mądrości&lt;/LSTag&gt; i &lt;LSTag Tooltip="Charisma"&gt;Charyzmy&lt;/LSTag&gt;.</content>
   <content contentuid="hcdf4a03bg59c5gb1b2g3204g37cf5a2339c0" version="1">Mistyczny strzał</content>
-  <content contentuid="hcb4e031eg6175g6174g6466gcc87b839601d" version="1">Kiedy trafisz cel atakiem Palców, możesz wydać jedną kość ryzyka i dodać ją do rzutu obrażeń.</content>
+  <content contentuid="hcb4e031eg6175g6174g6466gcc87b839601d" version="1">Gdy trafisz cel atakiem Pistoletów z palców, możesz zużyć jedną kość ryzyka i dodać jej wynik do rzutu na obrażenia.</content>
   <content contentuid="h4afbde24g3b4ag6245gdfc5gf40fbb6dd7b9" version="1">Poziom 3: Bum, nie żyjesz!</content>
   <content contentuid="hf051b82fgb193ga37bg540ege6200dcbd93e" version="1">Zamiast broni możesz używać magii.
 
@@ -3261,7 +3261,7 @@ Ponadto wykonywanie ataku dystansowego w promieniu 1,5 m od wrogiej istoty nie n
   <content contentuid="h8993f01fgfd8fg8b11g17cdg458c682aad00" version="3">Wymaga co najmniej 7. poziomu illriggera.
 
 Gdy w ramach akcji dodatkowej umieszczasz albo przenosisz pieczęć na istotę o rozmiarze dużym lub mniejszym, możesz aktywować tę łaskę (bez użycia akcji). Przywołujesz piekielne łańcuchy, które chwytają cel i zmuszają go do wykonania rzutu obronnego na Siłę. Przy niepowodzeniu możesz przyciągnąć cel do 3 m w swoją stronę albo nadać mu stan pochwycenia do końca swojej następnej tury.</content>
-  <content contentuid="h4087e43dg1626g7141gb492g08612b1d6f08" version="4">Poziom 7: Wulgarny kanał</content>
+  <content contentuid="h4087e43dg1626g7141gb492g08612b1d6f08" version="4">Poziom 7: Płomienny kanał</content>
   <content contentuid="h283a80a7gdc57ge48fg2323g0a19321fd070" version="2">Wymaga poziomu Illriggera 7 lub wyższego.
 
 Możesz wydać pieczęć jako akcję dodatkową, aby teleportować się na odległość do 9 m do niezajętego miejsca, które widzisz.</content>
@@ -3504,11 +3504,11 @@ Władcy Cienia przysięgają, że nie ujawnią swojej prawdziwej lojalności, a 
   <content contentuid="hf4e2d046gfe51gee1fgca6egd11cfae1cc2b" version="1">Dotknięta istota zabierze [1], gdy wykona atak lub rzuci czar.</content>
   <content contentuid="hc58d9767g1e05ga4fbg2a36g65ca51bde0df" version="1">Mściwe ostrze</content>
   <content contentuid="he2b377c7gee20g2ee0g3dbfgee7830f06a0c" version="1">Dotknięta istota zabierze [1], gdy wykona atak lub rzuci czar.</content>
-  <content contentuid="h5632b4f6g50degba74g0caaga04a7e569f75" version="1">Uszkodzenia Mściwego Ostrza</content>
+  <content contentuid="h5632b4f6g50degba74g0caaga04a7e569f75" version="1">Obrażenia Mściwego ostrza</content>
   <content contentuid="hc56ef434ged5age205g9a97gb782719764b7" version="1">Dotknięta istota zabierze [1], gdy wykona atak lub rzuci czar.</content>
-  <content contentuid="h144805ebgf1c3gf55bg8676gdc4af6ca5ea9" version="1">Uszkodzenia Mściwego Ostrza</content>
+  <content contentuid="h144805ebgf1c3gf55bg8676gdc4af6ca5ea9" version="1">Obrażenia Mściwego ostrza</content>
   <content contentuid="hd34956d4gadb8gbb08g3933g92ca0f294aa0" version="1">Dotknięta istota zabierze [1], gdy wykona atak lub rzuci czar.</content>
-  <content contentuid="h3078333fg393bg6e2agaff6gd37adce9760c" version="1">Uszkodzenia Mściwego Ostrza</content>
+  <content contentuid="h3078333fg393bg6e2agaff6gd37adce9760c" version="1">Obrażenia Mściwego ostrza</content>
   <content contentuid="h2e0904bcg79degaba1gba2dg85730cb20f7e" version="1">Dotknięta istota zabierze [1], gdy wykona atak lub rzuci czar.</content>
   <content contentuid="h8d142314g1c16g6319gcdcag74ad54f9f60e" version="1">Mściwe ostrze</content>
   <content contentuid="h89a134d0g96d7ga7b7g8000gde7bf71cecdc" version="1">Piekielny bicz</content>
@@ -3976,7 +3976,7 @@ Siła ognia. Rzuty obrażeń działa oraz liczba tymczasowych punktów wytrzyma�
   <content contentuid="h9c04874bg78bdgf61ag7978g3898f2f266ca" version="1">Wymaga dostrojenia przez Druida lub Łowcy.
 
 Kiedy rzucasz czar przywracające punkty wytrzymałości, możesz rzucić k4 i dodać wyrzuconą liczbę do liczby przywróconych punktów wytrzymałości.</content>
-  <content contentuid="h463f00d2g43d4g6387ga3e8g5af46bc31369" version="2">Odłamek umysłu (utrzymujący się)</content>
+  <content contentuid="h463f00d2g43d4g6387ga3e8g5af46bc31369" version="2">Myślowy odłamek (utrzymujący się)</content>
   <content contentuid="h0e4f0ac6g2f7egd603gf1dfgbe7d59c073b3" version="1">Krąg Marzeń</content>
   <content contentuid="h59958a6fg7ff5g9780g1b47g688c0909621b" version="1">Druidzi z Kręgu Snów pochodzą z krain silnie związanych z Feywild i jego sennymi domenami. Opieka nad światem natury czyni ich naturalnymi sprzymierzeńcami fey o dobrym charakterze. Druidzi ci pragną wypełniać świat cudami rodem ze snów. Ich magia leczy rany i niesie radość strapionym sercom, a chronione przez nich krainy są jasne i urodzajne — sen miesza się tam z rzeczywistością, a znużeni mogą znaleźć odpoczynek.</content>
   <content contentuid="h853388a0g259bga78age028g6a93fbf44c57" version="1">Poziom 3: Balsam Letniego Dworu</content>
@@ -4072,24 +4072,24 @@ Magiczne wzmocnienie. Gdy atakujesz magiczną bronią, możesz użyć swojego mo
 Obeznanie z bronią. Zyskujesz biegłość w broniach żołnierskich. Możesz używać broni, w której masz biegłość, jako Magicznego Fokusu dla swoich czarów Wynalazcy.</content>
   <content contentuid="hd5cef72fg7633gfff7g44f5g7c4e863fdc13" version="1">Gotowość bojowa</content>
   <content contentuid="h9e3e17e5gec22g340bgdae4g359fcaa6dc68" version="1">Kiedy atakujesz magiczną bronią, możesz użyć swojego modyfikatora Inteligencji zamiast modyfikatora Siły lub Zręczności, do testów ataku i rzutów na obrażenia.</content>
-  <content contentuid="h41d2ff5cgefb3g4750gfbbfg9ce76cd22456" version="1">Poziom 3: Stalowy Obrońca</content>
+  <content contentuid="h41d2ff5cgefb3g4750gfbbfg9ce76cd22456" version="1">Poziom 3: Stalowy obrońca</content>
   <content contentuid="h0844a944gf85ag2577g8e77g23dcd6a6e387" version="1">Twoje majsterkowanie zapewniło ci towarzysza: Stalowego obrońcę. Jest przyjazny tobie i twoim towarzyszom oraz wykonuje twoje polecenia. Jeśli zginął, możesz w ramach akcji użyć narzędzi kowalskich i zużyć komórkę czaru co najmniej 1. poziomu, aby go ożywić.</content>
   <content contentuid="h7b9311b6gf2bag9d7eg4407g3cb8f90b5541" version="1">Odbicie ataku</content>
   <content contentuid="hda3785acgb4c8g1e09g6f52ga7964ee4a86e" version="1">Kiedy istota, którą obrońca widzi w promieniu 1,5 m od niej, wykonuje test ataku przeciwko celowi innemu niż obrońca, istota wywołująca wykonuje test ataku z utrudnieniem.</content>
   <content contentuid="hf909a1bage22fg8286gcfedg0f187d283bee" version="1">Rozdarcie wzmocnione mocą</content>
   <content contentuid="h0830e0b7g5f29g2f2egddefgdf29c01c0374" version="1">Stalowy obrońca</content>
-  <content contentuid="he182f30fgc762gfc22g6adegda911d4ae8ea" version="1">Twoje majsterkowanie dało ci towarzysza, Stalowego Obrońcę.</content>
+  <content contentuid="he182f30fgc762gfc22g6adegda911d4ae8ea" version="1">Twoje majsterkowanie dało ci towarzysza — stalowego obrońcę.</content>
   <content contentuid="hc3c4873cg8a6ega479gb1f6g3037781e3e20" version="3">Stalowy obrońca</content>
   <content contentuid="h074e1d16gaccag0b0bg55e9g233c194cbe67" version="1">Kowal bitewny</content>
   <content contentuid="h4bf8da96g64a3g0f5eg135bg7645978583b0" version="1">Kowal bitewny łączy umiejętności obrońcy i medyka: specjalizuje się w ochronie innych oraz naprawie zarówno wyposażenia, jak i leczeniu sprzymierzeńców. W pracy wspiera go stalowy obrońca — stworzony przez niego ochronny towarzysz.</content>
-  <content contentuid="h6d2cfddegb7bag99e2g6ffbg6a101cdf219d" version="1">Poziom 9: Tajemny Wstrząs</content>
+  <content contentuid="h6d2cfddegb7bag99e2g6ffbg6a101cdf219d" version="1">Poziom 9: Tajemny wstrząs</content>
   <content contentuid="h1ad514dega841gc35dg8804ga474e60b45ea" version="2">Gdy trafisz cel magiczną bronią albo gdy twój &lt;LSTag Type="Spell" Tooltip="Target_SteelDefender"&gt;Stalowy obrońca&lt;/LSTag&gt; trafi cel, możesz poprzez uderzenie wyzwolić niszczycielską energię. Cel otrzymuje dodatkowe 2k6 obrażeń od mocy.
 
 Zamiast tego możesz wyzwolić energię odnawiającą, wybierając widoczną istotę lub przedmiot w promieniu 9 m. Energia uzdrawia wybrany cel, przywracając mu 2k6 punktów wytrzymałości.</content>
   <content contentuid="h4f02276agb1b7g8939g8d33g4138f4f9a52f" version="1">Możesz użyć tej energii tyle razy, ile wynosi twój modyfikator Inteligencji (co najmniej raz), ale nie możesz tego zrobić więcej niż raz na turę. Odzyskujesz wszystkie użycia, gdy kończysz długi odpoczynek.</content>
   <content contentuid="hfcff03d7g3b43gc2c2g568eg228ec39a2a92" version="2">Niszczycielska energia</content>
   <content contentuid="h7a33c7b9g8cc0g6c2bg348fg50d1aa50e0f5" version="2">Gdy trafisz cel magiczną bronią, możesz skierować przez uderzenie magiczną energię i wyzwolić Niszczycielską energię. Cel otrzymuje dodatkowe 2k6 obrażeń od mocy.</content>
-  <content contentuid="hcbe0e0aeg4adbgf201g248cg78fdbe7712a4" version="1">Tajemny Szarpnięcie (Stalowy Obrońca)</content>
+  <content contentuid="hcbe0e0aeg4adbgf201g248cg78fdbe7712a4" version="1">Tajemny wstrząs (stalowy obrońca)</content>
   <content contentuid="ha41d11dbgba7eg921eg929fg846ff3d63c75" version="1">Niszczycielska energia (stalowy obrońca)</content>
   <content contentuid="h2a2d4c40ge64cg5bd8gb073g4424cebf9004" version="1">Gdy twój &lt;LSTag Type="Spell" Tooltip="Target_SteelDefender"&gt;Stalowy obrońca&lt;/LSTag&gt; trafi cel, możesz skierować przez uderzenie magiczną energię i wyzwolić Niszczycielską energię. Cel otrzymuje dodatkowe 2k6 obrażeń od mocy.</content>
   <content contentuid="h10e88f31ga340g7220g57cagf79b60b98df3" version="1">Tajemny wstrząs</content>
@@ -4325,8 +4325,8 @@ Gdy przeklęty cel zostanie trafiony atakiem przez ciebie albo widocznego przez 
   <content contentuid="h9a3aa8d6g3cb8g0884g6d9eg5f6c2e19ad7b" version="1">Poziom 3: Gniew Dziczy</content>
   <content contentuid="hdce7e79bg8885g6824g9637g6951304ec5c7" version="1">Poziom 7: Głodna Moc</content>
   <content contentuid="hf0a74333g96ebgca45ge544g1b9f0f8411cb" version="1">Poziom 11: Zgnilizna i przemoc</content>
-  <content contentuid="h02a16612g51dege910g582fg8824be4f2aee" version="1">Po osiągnięciu poziomu Łowcy wskazanego w tabeli Czarów Strażnika Pustki zawsze masz przygotowane wymienione w niej czary: na 3. poziomie — Gniewne ugodzenie, na 5. poziomie — Zbroja śmierci, a na 9. poziomie — Widmowy rumak.</content>
-  <content contentuid="hd23192ffgdf59ga725g1c97g7e364650fe0c" version="1">Na 3. poziomie zawsze masz przygotowane Gniewne ugodzenie, na 5. poziomie — Zbroję śmierci, a na 9. poziomie — Widmowego rumaka.</content>
+  <content contentuid="h02a16612g51dege910g582fg8824be4f2aee" version="1">Po osiągnięciu poziomu Łowcy wskazanego w tabeli Czarów Strażnika Pustki zawsze masz przygotowane wymienione w niej czary: na 3. poziomie — Gniewne ugodzenie, na 5. poziomie — Zbroja śmierci, a na 9. poziomie — Widmowy wierzchowiec.</content>
+  <content contentuid="hd23192ffgdf59ga725g1c97g7e364650fe0c" version="1">Na 3. poziomie zawsze masz przygotowane Gniewne ugodzenie, na 5. poziomie — Zbroję śmierci, a na 9. poziomie — Widmowego wierzchowca.</content>
   <content contentuid="h4d2b70ecgee46g15a5g5c0bga91856311ba5" version="1">Czerpiesz moc z dziwnych, pradawnych koszmarów tej krainy. Wyrastają z ciebie nienaturalne narośla, takie jak krwawe poroże lub gnijące kły, a twój cień wydłuża się albo wije wokół ciebie. W ramach akcji dodatkowej możesz zużyć jedno użycie Ulubionego Wroga, aby przybrać upiorną postać i zyskać poniższe korzyści na 1 minutę, do chwili obezwładnienia lub śmierci albo do zakończenia przemiany (bez użycia akcji).
 
 Pradawny pancerz. Twoje ciało spowijają zgniła kora i zwierzęca szczecina, co zapewnia ci premię +1 do KP. Premia wzrasta do +2 na 11. poziomie łowcy.
@@ -4456,8 +4456,8 @@ Przy powodzeniu cel otrzymuje tylko połowę obrażeń.</content>
   <content contentuid="ha989ddfeg14aege15egc09fgf298fc8f086e" version="1">Patron Wielki Przedwieczny</content>
   <content contentuid="h3504f51eg1ac0gd563g881eg515b53b1f37b" version="1">Wybierając tę podklasę, możesz związać się z niewysłowionym bytem z Odległej Dziedziny albo z pradawnym bogiem — istotą taką jak Tharizdun, Skuty Bóg; Zargon, Powracający; Hadar, Mroczny Głód; lub Wielki Cthulhu. Możesz też przyzywać moc kilku bytów, nie wiążąc się z żadnym z nich. Motywy tych istot są niepojęte, a Wielki Przedwieczny może być obojętny wobec twojego istnienia. Poznane sekrety pozwalają ci jednak czerpać od niego dziwną magię.</content>
   <content contentuid="h68dcfb27g52ddg20aag7977g147e317f34ce" version="1">Poziom 3: Czary Hexblade</content>
-  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">Magia twojego patrona sprawia, że zawsze masz przygotowane określone czary. Gdy osiągasz poziom Czarownika wskazany w tabeli Czarów Hexblade’a, od tej pory zawsze masz przygotowane wymienione w niej czary. Na 3. poziomie są to &lt;LSTag Type="Spell" Tooltip="Shout_ArcaneVigor"&gt;Magiczna krzepa&lt;/LSTag&gt;, Urok, Magiczna broń, Tarcza i Gniewne ugodzenie; na 5. poziomie — Nałożenie klątwy i Przywołanie ognia zaporowego; na 7. poziomie — Swoboda ruchu i Wstrząsające ugodzenie; na 9. poziomie — Uderzenie stalowego wiatru.</content>
-  <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">Na 3. poziomie zyskujesz Magiczną krzepę, Urok, Magiczną broń, Tarczę i Gniewne ugodzenie; na 5. poziomie — Nałożenie klątwy i Przywołanie ognia zaporowego; na 7. poziomie — Swobodę ruchu i Wstrząsające ugodzenie; na 9. poziomie — Uderzenie stalowego wiatru.</content>
+  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">Magia twojego patrona sprawia, że zawsze masz przygotowane określone czary. Gdy osiągasz poziom Czarownika wskazany w tabeli Czarów Hexblade’a, od tej pory zawsze masz przygotowane wymienione w niej czary. Na 3. poziomie są to &lt;LSTag Type="Spell" Tooltip="Shout_ArcaneVigor"&gt;Magiczna krzepa&lt;/LSTag&gt;, Urok, Magiczna broń, Tarcza i Gniewne ugodzenie; na 5. poziomie — Nałożenie klątwy i Przywołanie ognia zaporowego; na 7. poziomie — Swoboda ruchu i Wstrząsające ugodzenie; na 9. poziomie — Uderzenie stalowego wichru.</content>
+  <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">Na 3. poziomie zyskujesz Magiczną krzepę, Urok, Magiczną broń, Tarczę i Gniewne ugodzenie; na 5. poziomie — Nałożenie klątwy i Przywołanie ognia zaporowego; na 7. poziomie — Swobodę ruchu i Wstrząsające ugodzenie; na 9. poziomie — Uderzenie stalowego wichru.</content>
   <content contentuid="hfa17cac1gac88g9d72gf29eg0946ab8c0bb4" version="1">Poziom 3: Manifestacja Hexblade’a</content>
   <content contentuid="ha92a78f3ge96agd47egb8ddg6ad716d3cc56" version="3">Urok Hexblade’a. Możesz rzucić Urok bez zużywania komórki czaru tyle razy, ile wynosi twój modyfikator Charyzmy (co najmniej raz). Odzyskujesz wszystkie użycia po długim odpoczynku. Gdy rzucasz Urok, widmowa broń przypominająca twojego patrona zaczyna krążyć wokół objętego nim celu.
 
@@ -4558,7 +4558,7 @@ Cechy fizyczne goliatów przypominają olbrzymów z ich rodów. Niektórzy wygl�
   <content contentuid="hcf571c87ge866geaedge93eg4b1d41f25793" version="1">Goliat</content>
   <content contentuid="h53df4a2egf34cge0cegdbaeg961cb646fadd" version="1">Goliaci są odległymi potomkami olbrzymów i poszukują wyżyn przekraczających te, które osiągnęli ich przodkowie.</content>
   <content contentuid="hce152759gc1e1g418cgcf1agfab6759d882e" version="1">Rodowód olbrzymów: Olbrzym chmurowy</content>
-  <content contentuid="had6cf5adg8eb1gc683g7f11gab246e2b6b44" version="2">Wycieczka Chmury (Chmurkowy Olbrzym). W ramach akcji dodatkowej magicznie teleportujesz się na odległość do 9 m do niezajętego miejsca, które widzisz.</content>
+  <content contentuid="had6cf5adg8eb1gc683g7f11gab246e2b6b44" version="2">Wędrówka chmur (olbrzym chmurowy). W ramach akcji dodatkowej magicznie teleportujesz się na odległość do 9 m na widoczne, niezajęte miejsce.</content>
   <content contentuid="h297e6dcbgbedbg0037ga402g524f90049893" version="1">Rodowód olbrzymów: Olbrzym ognisty</content>
   <content contentuid="he807aa9age4ccga253g9743gd1a253159665" version="1">Oparzenie Ognia (Ognisty Olbrzym). Kiedy trafisz cel testem ataku i zadasz mu obrażenia, możesz także zadać temu celowi 1k10 obrażeń od ognia.</content>
   <content contentuid="h51b85e6cg91c9g2e69ga921ga3e9856e5b2c" version="1">Rodowód olbrzymów: Olbrzym mroźny</content>
@@ -4794,9 +4794,9 @@ Ponadto za każdym razem, gdy istota w cylindrze rzuca czar, wykonuje rzut obron
 Podczas rzucania tego czaru możesz wskazać istoty, na które nie będzie on działać.</content>
   <content contentuid="h563db1bag0ff4gf88bgaa5dg36f6eab08bb4" version="1">Burza magicznego ognia</content>
   <content contentuid="hd62f5a63g6062g55cfg4eb3g09082565784c" version="1">Ilekroć istota w Cylindrze rzuca czar, istota to wykonuje rzut obronny na Kondycję. W przypadku nieudanego rzutu obronnego czar rozprasza się bez efektu, a akcja, akcja dodatkowa lub reakcja użyte do jego rzucenia zostają zmarnowane.</content>
-  <content contentuid="hf91e618bg7cfcg3668g95bbg4b7e8eb659d9" version="2">Burza magiczny ogień: Zakłócenie czarów</content>
+  <content contentuid="hf91e618bg7cfcg3668g95bbg4b7e8eb659d9" version="2">Burza magicznego ognia: Zakłócenie czarów</content>
   <content contentuid="h150cb7degdc6bg252agb2cag7b6c5033e87d" version="1">Ilekroć istota w Cylindrze rzuca czar, istota to wykonuje rzut obronny na Kondycję. W przypadku nieudanego rzutu obronnego czar rozprasza się bez efektu, a akcja, akcja dodatkowa lub reakcja użyte do jego rzucenia zostają zmarnowane.</content>
-  <content contentuid="h2d7fc4afgebcbg804ag8764g1902de76e587" version="1">Burza Magicznego Ognia: Obrażenia od światłości</content>
+  <content contentuid="h2d7fc4afgebcbg804ag8764g1902de76e587" version="1">Burza magicznego ognia: Obrażenia od światłości</content>
   <content contentuid="h5acbb969gf7e6g885egf07ag2ca3bb42d3a7" version="1">Przerażający początek</content>
   <content contentuid="h834e8d02gd8f9g2e05ge709gc3ecb8d0d3da" version="1">Przybierasz przerażający wyraz twarzy, aby nastraszyć widoczną istotę w zasięgu. Cel musi wykonać rzut obronny na Mądrość; w razie niepowodzenia otrzymuje stan przerażenia do początku twojej następnej tury.</content>
   <content contentuid="hbca64bf4ga835g10c5gba60g0c68950c7135" version="1">Święte słowo</content>
@@ -5607,18 +5607,18 @@ Ponadto przez czas trwania czaru możesz wykonywać Odstąpienie w ramach akcji 
   <content contentuid="h19186d60g16e9g1e3bgcbc7g45d59987d331" version="1">Przywołujesz drobinki tańczącego płomienia, które unoszą się i dryfują wokół ciebie przez pewien czas. Na początku każdej swojej tury niesprzymierzone istoty w promieniu 6 m od płomieni muszą wykonać pomyślny rzut obronny na Mądrość, w przeciwnym razie zostaną zauroczone do początku swojej następnej tury. Zauroczone w ten sposób istota zostaje obezwładnione i ma szybkość 0.</content>
   <content contentuid="h3a8c610bga3d0g98a5g372eg5d265e61eef9" version="1">Taniec ognia</content>
   <content contentuid="h35662d22ga130g4004gd1e2g502f46f7dbd4" version="1">Przywołujesz drobinki tańczącego płomienia, które unoszą się i dryfują wokół ciebie przez pewien czas. Na początku każdej swojej tury niesprzymierzone istoty w promieniu 6 m od płomieni muszą wykonać pomyślny rzut obronny na Mądrość, w przeciwnym razie zostaną zauroczone do początku swojej następnej tury. Zauroczone w ten sposób istota zostaje obezwładnione i ma szybkość 0.</content>
-  <content contentuid="h39f64ea5gb60eg3361ga734gb5f1af066885" version="1">Aura Tańca Ognia</content>
+  <content contentuid="h39f64ea5gb60eg3361ga734gb5f1af066885" version="1">Aura Tańca ognia</content>
   <content contentuid="h6f008cdbg3350gd976g5f94g72ed94e99398" version="1">Widmowe cięcie</content>
-  <content contentuid="hc78c376dg616ag7239gb066ga93738880899" version="2">Widmowy atak bronią sieczną</content>
-  <content contentuid="h63ced89eg89ebg0483ga272g25ce1e27bec3" version="1">Widmowy cel cięcia</content>
-  <content contentuid="h95052719gb237gac57g92e1g14b60980710f" version="1">Spektralny Atak Cięciem</content>
+  <content contentuid="hc78c376dg616ag7239gb066ga93738880899" version="2">Atak bronią: Widmowe cięcie</content>
+  <content contentuid="h63ced89eg89ebg0483ga272g25ce1e27bec3" version="1">Cel Widmowego cięcia</content>
+  <content contentuid="h95052719gb237gac57g92e1g14b60980710f" version="1">Atak Widmowym cięciem</content>
   <content contentuid="he35c6486g7f21gd1fag785egf414f915b565" version="1">Wysyłasz widmową kopię siebie, aby powalić wroga. Wykonaj atak czarem wręcz przeciwko istocie znajdującej się w promieniu 6 m od ciebie. Po trafieniu cel otrzymuje obrażenia [1] odpowiadające typowi obrażeń twojej broni.
 
 Następnie możesz wydać swoją akcję, aby poruszyć się na odległość do 6 m w linii prostej w stronę celu, przecinając widmową ścieżkę i wykonać przeciwko niemu akcję Ataku. Aby skorzystać z tej akcji, musisz zaatakować bronią białą używaną do rzucenia tego czaru.</content>
   <content contentuid="h1baba05fg926fg3fbeg861bg6aa1ecd27bef" version="1">Obrażenia zwiększają się o 1k8, a przebyty dystans o 3 m za każdy poziom komórki czaru powyżej 1.</content>
   <content contentuid="hd212fcfagf0edg6619ga792g36f58b10cd9d" version="1">Krąg mocy</content>
   <content contentuid="h72f29464ga410gf4f8g9388gc7bc97ac7ac0" version="1">Przez cały czas trwania efektu emanuje od ciebie aura w postaci emanacji na odległość 9 m. Będąc w aurze, ty i twoi sojusznicy macie ułatwienie w rzutach obronnych przeciwko czarom i innym magicznym efektom i otrzymujecie od nich tylko połowę obrażeń.</content>
-  <content contentuid="h5f04addfg41ecgbc72gedadga5ba2a2eea90" version="1">Aura Kręgu Mocy</content>
+  <content contentuid="h5f04addfg41ecgbc72gedadga5ba2a2eea90" version="1">Aura Kręgu mocy</content>
   <content contentuid="hc52cdfedg87a2g694bg6d16g81bc875203c5" version="1">Przez cały czas trwania efektu emanuje od ciebie aura w postaci emanacji na odległość 9 m. Będąc w aurze, ty i twoi sojusznicy macie ułatwienie w rzutach obronnych przeciwko czarom i innym magicznym efektom i otrzymujecie od nich tylko połowę obrażeń.</content>
   <content contentuid="h5e4da7bfg3d53g34b0g1618g433a0364acc2" version="1">Krąg mocy</content>
   <content contentuid="hbf2c5134g52beg6d66g0aa1ga4e82c15a448" version="1">Masz ułatwienie w rzutach obronnych przeciwko czarom i efektom magicznym oraz odporność na obrażenia od czarów.</content>
@@ -6023,7 +6023,7 @@ Rządź żelazną pięścią. Kiedy już zwyciężysz, nie toleruj sprzeciwu. Tw
 
 Siła przede wszystkim. Będziesz rządził, dopóki nie powstanie silniejszy. Musisz więc stać się potężniejszy i stawić czoła wyzwaniu, w przeciwnym razie popadniesz w ruinę.</content>
   <content contentuid="h903867a1g3cfdg2b4fge6ebg7a3e79936727" version="1">Poziom 3: Czary Przysięgi Podboju</content>
-  <content contentuid="hbf3f7449g1ed3gab0dgc670g9f81ada8e42a" version="1">Paladyni, którzy złożą Przysięgę Podboju, uzyskują dostęp do Zbroi Agathys i Dowództwa na 3. poziomie, Utrzymywania Osoby i Broni Duchowej na 5. poziomie oraz Obdarzania Klątwą i Strachem na 9. poziomie.</content>
+  <content contentuid="hbf3f7449g1ed3gab0dgc670g9f81ada8e42a" version="1">Paladyni, którzy złożą Przysięgę Podboju, uzyskują dostęp do Zbroi Agathys i Rozkazu na 3. poziomie, Unieruchomienia osoby i Duchowej broni na 5. poziomie oraz Nałożenia klątwy i Strachu na 9. poziomie.</content>
   <content contentuid="ha9bb3551ge412g5c19g5e97g106901d50282" version="1">Poziom 3: Pokonywanie obecności</content>
   <content contentuid="h5bee8c93gf2c8gd340g65cfge6d42d8c4a32" version="2">Możesz użyć Mocy przysięgi, aby emanować aurą grozy. Zmuszasz każdą wybraną przez siebie widoczną istotę w promieniu 9 m od ciebie do wykonania rzutu obronnego na Mądrość. Przy niepowodzeniu istota otrzymuje stan przerażenia na 1 minutę. Na koniec każdej swojej tury może powtórzyć rzut obronny; powodzenie kończy ten stan.</content>
   <content contentuid="h996c924egb5b7g1b84g76a7g77794f881ec6" version="1">Poziom 3: Uderzenie kierowane</content>
@@ -6112,7 +6112,7 @@ Dampiry często powstają w wyniku spotkań z wampirami; niektórzy są potomkam
   <content contentuid="h02533ba5gec0ag9e9dg4fc4g73c9249f2bec" version="1">Heroiczne czary</content>
   <content contentuid="hd517f270gefc4g3302ge7ecge9468f84b00a" version="1">Jesteś wcieleniem legendarnego bohatera, który wsławił się pokonaniem wielu przerażających wrogów, a twoja magia czerpie z tej owianej legendą przeszłości. Powrót do życia za sprawą bogów, niezwykle potężnego maga albo cyklu reinkarnacji obudził w tobie źródło magii i pradawne instynkty bojowe.</content>
   <content contentuid="hb63faa4cg7994gfa72g49ffg512d528710ca" version="1">Poziom 3: Heroiczne czary</content>
-  <content contentuid="h4ed71b8cg3ed3gd84eg3c79gb92ad8cf0e94" version="1">Po osiągnięciu określonych poziomów Zaklinacza zawsze masz przygotowane następujące czary: na 3. poziomie — Ostrze zielonego płomienia, Prawdziwe uderzenie, Heroizm, Magiczna broń, Lustrzane odbicia i Tarcza; na 5. poziomie — &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Przyspieszenie&lt;/LSTag&gt; i Widmowy rumak; na 7. poziomie — Osłona przed śmiercią i Kamienna skóra; a na 9. poziomie — Unieruchomienie potwora. Czary te nie wliczają się do liczby czarów, które możesz przygotować.</content>
+  <content contentuid="h4ed71b8cg3ed3gd84eg3c79gb92ad8cf0e94" version="1">Po osiągnięciu określonych poziomów Zaklinacza zawsze masz przygotowane następujące czary: na 3. poziomie — Ostrze zielonego płomienia, Prawdziwe uderzenie, Heroizm, Magiczna broń, Lustrzane odbicia i Tarcza; na 5. poziomie — &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Przyspieszenie&lt;/LSTag&gt; i Widmowy wierzchowiec; na 7. poziomie — Osłona przed śmiercią i Kamienna skóra; a na 9. poziomie — Unieruchomienie potwora. Czary te nie wliczają się do liczby czarów, które możesz przygotować.</content>
   <content contentuid="h81636128ge683g92f7g0c18g5a4d21a7d6cd" version="1">Poziom 3: Czary walki</content>
   <content contentuid="h269da4dcg7dabg981bg4001gfcda57b7c806" version="1">Bohaterska dusza. Na początku każdej swojej tury możesz wydać 1 punkt zaklinania, aby zyskać tymczasowe punkty wytrzymałości w liczbie równej 1k6 plus twój poziom Zaklinacza (bez użycia akcji).
 
@@ -6225,7 +6225,7 @@ Dyscyplina. Jesteś tarczą przed niekończącymi się terrorami, które kryją 
   <content contentuid="hf005b6eegd9edg12b5g2847g6cb308887662" version="1">Aura Strażnika</content>
   <content contentuid="ha8e6db56ge4ddgc57dgdfdbg53d7f82bba08" version="1">Dopóki nie masz stanu obezwładnienia, emanujesz aurą czujności. Gdy ty oraz wybrane przez ciebie istoty w promieniu 3 m rzucacie na inicjatywę, wszyscy otrzymujecie premię do inicjatywy równą twojej premii z biegłości.</content>
   <content contentuid="he8ec9e49g1ed3g994egd537g4bff52ad40e5" version="1">Poziom 3: Czary Przysięgi Obserwatorów</content>
-  <content contentuid="h7731d2eag11ffg44e4g8569ga5e35e0e6de9" version="1">Paladyni, którzy złożą Przysięgę Obserwatorów, uzyskują dostęp do Ochrony przed Złem i Dobrem oraz Tarczy na 3. poziomie, Księżycowego Promienia i Widzenia Niewidzialności na 5. poziomie oraz Przeciwzaklęcia i Duchowych Strażników na 9. poziomie.</content>
+  <content contentuid="h7731d2eag11ffg44e4g8569ga5e35e0e6de9" version="1">Paladyni, którzy złożą Przysięgę Obserwatorów, uzyskują dostęp do Ochrony przed dobrem i złem oraz Tarczy na 3. poziomie, Księżycowego promienia i Widzenia niewidzialnego na 5. poziomie oraz Przeciwzaklęcia i Duchowych strażników na 9. poziomie.</content>
   <content contentuid="h53bf4744g8817g4dc1g9f65g4ca743366100" version="1">Poziom 3: Wola Obserwatora</content>
   <content contentuid="h55809fbag7bd0g427fgaea4gcc7103f95f2c" version="1">Możesz użyć Mocy przysięgi, aby nasycić swoją obecność ochronną mocą wiary. Wybierz widoczne istoty w promieniu 9 m od siebie w liczbie nieprzekraczającej twojego modyfikatora Charyzmy (co najmniej jedną). Przez 1 minutę ty i wybrane istoty wykonujecie z ułatwieniem rzuty obronne na Inteligencję, Mądrość i Charyzmę.</content>
   <content contentuid="h1c396853g089ag4cf6gaac4g3a465614eb89" version="1">Poziom 3: Porzuć to, co pozaplanarne</content>
@@ -6258,7 +6258,7 @@ Dyscyplina. Jesteś tarczą przed niekończącymi się terrorami, które kryją 
 
 Kapłani, którzy służą tym bóstwom – których przykłady pojawiają się na stole Bóstw Zmierzchu – przynoszą pocieszenie tym, którzy szukają odpoczynku i chronią je, wyruszając w nadciągającą ciemność, aby mieć pewność, że ciemność będzie pocieszeniem, a nie przerażeniem.</content>
   <content contentuid="had547f10gf9b5gc30cg6122g99ef0b90d2ad" version="1">Poziom 3: Czary domeny mroku</content>
-  <content contentuid="h434df1f3gdadag1149g4c36g6bfc2c7a1bec" version="1">Po osiągnięciu określonych poziomów kleryka zawsze masz przygotowane następujące czary: na 3. poziomie — Blask faerie, Uśpienie, Księżycowy promień i Widzenie niewidzialnego; na 5. poziomie — Aura witalności i Uderzenie pustki; na 7. poziomie — Swoboda poruszania się i &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Większa niewidzialność&lt;/LSTag&gt;; a na 9. poziomie — Krąg mocy i Świt. Czary te nie wliczają się do liczby czarów, które możesz przygotować.</content>
+  <content contentuid="h434df1f3gdadag1149g4c36g6bfc2c7a1bec" version="1">Po osiągnięciu określonych poziomów kleryka zawsze masz przygotowane następujące czary: na 3. poziomie — Blask faerie, Uśpienie, Księżycowy promień i Widzenie niewidzialnego; na 5. poziomie — Aura witalności i Uderzenie pustki; na 7. poziomie — Swoboda ruchu i &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Większa niewidzialność&lt;/LSTag&gt;; a na 9. poziomie — Krąg mocy i Świt. Czary te nie wliczają się do liczby czarów, które możesz przygotować.</content>
   <content contentuid="h0060ddb2gfe04g6d96g6e94g9496e7fff0e0" version="2">Poziom 3: Oczy Nocy</content>
   <content contentuid="h73451af6g0c9dge1e4g112ag73be890335ef" version="2">Potrafisz przejrzeć najgłębszy mrok. Masz doskonałe widzenie w ciemności, możesz widzieć w przyćmionym świetle, jak gdyby było jasne, a w ciemności, jakby było przyćmione światło.
 


### PR DESCRIPTION
## Summary

- align composite feature and spell names with the canonical Polish titles used elsewhere in the localization
- correct several literal or inconsistent translations, including Font of Inspiration, Thunderclap, Conflagrant Channel, Moonlight Step, Mind Sliver, Phantom Steed, and Steel Wind Strike
- normalize the Divine Order and Primal Order choice labels and improve a small set of embedded spell lists
- preserve every English `contentuid` and `version`; this PR changes only `Localization/Polish/polish.xml`

## Validation

- 5,355 source entries and 5,355 Polish entries
- no duplicate, missing, extra, empty, version, tag, or placeholder mismatches
- no official Polish BG3 terminology mismatches
- no spell structure, spell language, official spell-title, or official spell-description mismatches
- all 742 duplicate-English groups remain consistent in Polish
- LanguageTool found no actionable issue in the changed strings

## Credits

Please use the TableTop BRAMA Discord link wherever the community is credited on GitHub, including the README and wiki:

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
