### PR TITLE
Refine Polish feature-name casing

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -82,7 +82,7 @@ Podcięcie ścięgna. Szybkość celu zostaje zmniejszona o [1] do początku two
   <content contentuid="h0e7ef600g82aegeba0g077eg2ddad69731f8" version="1">Otacza cię dzika magia barbarzyńcy. Twoja &lt;LSTag Tooltip="ArmourClass"&gt;Klasa Pancerza&lt;/LSTag&gt; zwiększa się o wartość równą twojej premii do obrażeń szału, dopóki trwa twój &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt;.</content>
   <content contentuid="hd75d1783g8062gae55g78a6g651f55455f7f" version="1">Poziom 2: Specjalista od wszystkiego</content>
   <content contentuid="h6002075bg4feegb25ag03b5g8e88a4351c0f" version="1">Poziom 5: Źródło inspiracji</content>
-  <content contentuid="h5d1b01ffgd776g8ca4gd2edgb4e5e0068ad7" version="1">Ponadto możesz zużyć komórkę czaru (bez konieczności użycia akcji), aby odzyskać jedno zużyte użycie Bardowskiej inspiracji.</content>
+  <content contentuid="h5d1b01ffgd776g8ca4gd2edgb4e5e0068ad7" version="1">Ponadto możesz zużyć komórkę czaru (bez konieczności użycia akcji), aby odzyskać jedno zużyte użycie bardowskiej inspiracji.</content>
   <content contentuid="h3c4853cag177dg4ea8g0c15gde7e940ee735" version="1">Źródło inspiracji</content>
   <content contentuid="h7c14769cg0f8ag7968g4156g1272fd5b7850" version="3">Zużyj komórkę czaru, aby odzyskać jedno użycie bardowskiej inspiracji.</content>
   <content contentuid="he36b3403gbab9gf77fg17fbg32e95953478c" version="1">Poziom 7: Przeciwzaklęcie</content>
@@ -5467,7 +5467,7 @@ Na wyższych poziomach: twoja szybkość wzrasta o dodatkowe 1,5 m, a obrażenia
   <content contentuid="h0f617ea9g5fc5gff42gae8ag41a6861d59c0" version="1">Nasycasz żarłoczną negatywną energią trzymaną broń albo swoje ataki bez broni. Przez czas trwania efektu, gdy po raz pierwszy w turze trafisz istotę atakiem nasyconą bronią albo atakiem bez broni, cel otrzymuje obrażenia nekrotyczne równe twojemu modyfikatorowi cechy bazowej czarów. Zyskujesz wtedy tymczasowe punkty wytrzymałości w liczbie równej zadanym obrażeniom nekrotycznym.</content>
   <content contentuid="h700ed84bg957fg2a5dg1d50g4d69487d7001" version="1">Głodne ostrze</content>
   <content contentuid="h353f6fe0g981eg9ab6gd5b9g0148d8001530" version="1">Nasycasz żarłoczną negatywną energią trzymaną broń albo swoje ataki bez broni. Przez czas trwania efektu, gdy po raz pierwszy w turze trafisz istotę atakiem nasyconą bronią albo atakiem bez broni, cel otrzymuje obrażenia nekrotyczne równe twojemu modyfikatorowi cechy bazowej czarów. Zyskujesz wtedy tymczasowe punkty wytrzymałości w liczbie równej zadanym obrażeniom nekrotycznym.</content>
-  <content contentuid="hb6e6fab4gd077g545dge824g9e58b1ec530c" version="1">Głodne Ostrze: tymczasowe punkty wytrzymałości</content>
+  <content contentuid="hb6e6fab4gd077g545dge824g9e58b1ec530c" version="1">Głodne ostrze: tymczasowe punkty wytrzymałości</content>
   <content contentuid="h0903fdd3gbfadg55a1gd56cga67f82c909ac" version="1">Otrzymuje [1] &lt;LSTag Tooltip="TemporaryHitPoints"&gt;tymczasowych punktów wytrzymałości&lt;/LSTag&gt;.</content>
   <content contentuid="h4a76861cg2a42g5900gbd08gc593fbb9811e" version="1">Cierniowa zbroja</content>
   <content contentuid="h5f480b91gf52bg2751g6254gdd8113ff8e2e" version="1">Gdy rzucasz ten czar, wokół chętnego celu w zasięgu pojawia się elastyczny egzoszkielet pokryty cierniami. Cel zyskuje [1] tymczasowych punktów wytrzymałości. Jeśli przed końcem czaru istota trafi cel testem ataku wręcz, otrzymuje obrażenia kłute równe liczbie tymczasowych punktów wytrzymałości utraconych wskutek tego ataku. Czar kończy się wcześniej, gdy cel nie ma już żadnych przyznanych przez niego tymczasowych punktów wytrzymałości.</content>
@@ -6396,15 +6396,15 @@ Podobnie jak inne elfy, eladriny mogą żyć ponad 750 lat.</content>
 Podobnie jak inne elfy, eladriny mogą żyć ponad 750 lat.</content>
   <content contentuid="hee892110g8f20gdbb7g60f8g274ed51075aa" version="1">Krok fey</content>
   <content contentuid="h690f28c7gad03g1cdbgd8fegfb090b06f3dd" version="1">Możesz użyć tej cechy tyle razy, ile wynosi twoja premia z biegłości, a odzyskujesz wszystkie użycia po zakończeniu długiego odpoczynku.</content>
-  <content contentuid="hd5282a6cg61c4g9090gb19ag4594d3d35701" version="1">Krok Fey: Jesień</content>
-  <content contentuid="hb284f5d4gf341g5049g2ce3g9ea223e41a38" version="1">Natychmiast po użyciu Kroku Fey maksymalnie dwie wybrane przez ciebie widoczne istoty w promieniu 3 m od ciebie muszą wykonać udany rzut obronny na Mądrość albo otrzymują stan zauroczenia na 1 minutę, do chwili, gdy ty lub twoi towarzysze zadacie im jakiekolwiek obrażenia.</content>
-  <content contentuid="h9aebcc08g580fg3628g9378gf3b3f0400749" version="1">Krok Fey: Lato</content>
-  <content contentuid="heaea9b90g45ccg4408gc5e5g09ea686c3a9c" version="1">Krok Fey: Wiosna</content>
-  <content contentuid="h5e6a75a1ga1edg6dcfge091g620017e990cc" version="1">Krok Fey: Zima</content>
+  <content contentuid="hd5282a6cg61c4g9090gb19ag4594d3d35701" version="1">Krok fey: Jesień</content>
+  <content contentuid="hb284f5d4gf341g5049g2ce3g9ea223e41a38" version="1">Natychmiast po użyciu Kroku fey maksymalnie dwie wybrane przez ciebie widoczne istoty w promieniu 3 m od ciebie muszą wykonać udany rzut obronny na Mądrość albo otrzymują stan zauroczenia na 1 minutę, do chwili, gdy ty lub twoi towarzysze zadacie im jakiekolwiek obrażenia.</content>
+  <content contentuid="h9aebcc08g580fg3628g9378gf3b3f0400749" version="1">Krok fey: Lato</content>
+  <content contentuid="heaea9b90g45ccg4408gc5e5g09ea686c3a9c" version="1">Krok fey: Wiosna</content>
+  <content contentuid="h5e6a75a1ga1edg6dcfge091g620017e990cc" version="1">Krok fey: Zima</content>
   <content contentuid="hfa86f65dg33d6g9ea6g0948gfbf198214a31" version="1">Gdy używasz Kroku fey, przed teleportacją wybierz jedną widoczną istotę w promieniu 1,5 m od siebie. Istota wykonuje rzut obronny na Mądrość. Przy niepowodzeniu otrzymuje do końca twojej następnej tury stan przerażenia, którego źródłem jesteś.</content>
-  <content contentuid="hccff7485gca62gd284gdabagfbef3ee11653" version="1">Krok Fey: Zima</content>
-  <content contentuid="h9cda9df5g341bg90cag16e9gfc25dc9df498" version="1">Gdy używasz Kroku Fey, możesz dotknąć chętnej istoty w promieniu 1,5 m od siebie. Teleportuje się ona zamiast ciebie i pojawia na wybranym przez ciebie widocznym, niezajętym miejscu w promieniu 9 m od ciebie.</content>
-  <content contentuid="h4a8a3d05ged7ag55e3g1276g814259823391" version="1">Natychmiast po użyciu Kroku Fey każda wybrana przez ciebie widoczna istota w promieniu 1,5 m od ciebie otrzymuje obrażenia od ognia równe twojej premii z biegłości.</content>
+  <content contentuid="hccff7485gca62gd284gdabagfbef3ee11653" version="1">Krok fey: Zima</content>
+  <content contentuid="h9cda9df5g341bg90cag16e9gfc25dc9df498" version="1">Gdy używasz Kroku fey, możesz dotknąć chętnej istoty w promieniu 1,5 m od siebie. Teleportuje się ona zamiast ciebie i pojawia na wybranym przez ciebie widocznym, niezajętym miejscu w promieniu 9 m od ciebie.</content>
+  <content contentuid="h4a8a3d05ged7ag55e3g1276g814259823391" version="1">Natychmiast po użyciu Kroku fey każda wybrana przez ciebie widoczna istota w promieniu 1,5 m od ciebie otrzymuje obrażenia od ognia równe twojej premii z biegłości.</content>
   <content contentuid="h5c1e93a7g2f48g4d6bg8e13ga7f4c2b60d95" version="1">Czarowanie przez sobowtóra</content>
   <content contentuid="h9a4f2b81gd37eg46c2gb058ge1d93f7a2c46" version="1">Zużyj akcję i komórkę czaru, aby skierować magię przez swojego sobowtóra. W swojej turze sobowtór może rzucić jeden z przygotowanych przez ciebie czarów, zużywając tę komórkę i korzystając z twojego ST obrony przed czarami oraz premii do ataku czarami. Dzięki temu rzucasz czar tak, jakbyś znajdował się na miejscu iluzji.</content>
   <content contentuid="h3f8a1c72g5e94g4b21ga7c3gd8e51f0b9a46" version="1">Czarowanie przez sobowtóra</content>


### PR DESCRIPTION
## Summary

- standardize `Fey Step` as `Krok fey` across its seasonal titles and descriptions
- keep `bardowska inspiracja` lowercase in ordinary running text while preserving the official BG3 capitalization used inside linked UI labels
- correct the composite title `Głodne ostrze: tymczasowe punkty wytrzymałości`

## Validation

- 5,355/5,355 English and Polish handles present
- no missing, extra, or duplicate handles
- no `version`, tag, or placeholder mismatches
- no untranslated non-whitelisted entries
- no spell structure, spell language, or official spell terminology errors
- 739 duplicate-English groups checked with no inconsistent Polish translations
- full Polish LanguageTool pass completed; no new grammar or punctuation findings in the changed entries

## Credits reminder

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)

Please use these exact linked credits in the README and wiki when updating the translator list.
