### PR TITLE
Refine Polish druid and class feature terminology

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -215,7 +215,7 @@ Na wyższych poziomach. Kość bardowskiej inspiracji zmienia się po osiągnię
   <content contentuid="ha052e514g0261g1570g0745g00d44f89cc3d" version="1">Gdy ty albo istota w promieniu 9 m od ciebie chybi testem ataku, możesz zużyć jedno użycie Aktu wiary i zapewnić temu testowi premię +10, dzięki czemu atak może trafić. Jeśli w ten sposób wspierasz test ataku innej istoty, musisz użyć reakcji.</content>
   <content contentuid="h81ab1ec4g5097gf34cg7f12g4d040607771b" version="2">Atak kierowany (samodzielny)</content>
   <content contentuid="h900f0f0bgcd61g0708g6d02gf89738f718de" version="1">Poziom 6: Błogosławieństwo Boga Wojny</content>
-  <content contentuid="h0c6d3ec2g7683g7e9fg7d62g08a6874b3c5f" version="1">Możesz zużyć jedno użycie Aktu wiary, aby rzucić Tarczę Wiary albo Broń Duchową bez zużywania komórki czaru. Czar rzucony w ten sposób nie wymaga Koncentracji i trwa 1 minutę, ale kończy się wcześniej, jeśli rzucisz go ponownie, otrzymasz stan obezwładnienia albo zginiesz.</content>
+  <content contentuid="h0c6d3ec2g7683g7e9fg7d62g08a6874b3c5f" version="1">Możesz zużyć jedno użycie Aktu wiary, aby rzucić Tarczę wiary albo Duchową broń bez zużywania komórki czaru. Czar rzucony w ten sposób nie wymaga koncentracji i trwa 1 minutę, ale kończy się wcześniej, jeśli rzucisz ten czar ponownie, otrzymasz stan obezwładnienia albo zginiesz.</content>
   <content contentuid="h3bb1c07ag3913g5b74g9454gdcebc7737556" version="1">Tarcza wiary: błogosławieństwo boga wojny</content>
   <content contentuid="hcaeae1ebgf2c5gb598g6716gb1b7c699916c" version="1">Duchowa broń: błogosławieństwo boga wojny</content>
   <content contentuid="h002f5e57g1181g2dbbg226fgf29f606b801c" version="2">Uderzenie stalowego wichru</content>
@@ -270,10 +270,10 @@ Dodaj połowę swojego modyfikatora Mądrości do &lt;LSTag Tooltip="AbilityChec
   <content contentuid="hb670c3bdg0b18g5834g24e2gce9406adf925" version="1">Przemiany w dziką postać</content>
   <content contentuid="h0e2c2a49gb8a7g78d8gf687gb0cdc6987be7" version="1">Liczba możliwych przemian w dziką postać.</content>
   <content contentuid="h8f1b692bg604cgb34cg9e64g7c5d22aebe85" version="1">Poziom 2: Dzika postać</content>
-  <content contentuid="hc6dea6aag9290gf3cegeb8ag0351bd8d0fc5" version="2">W ramach akcji dodatkowej możesz użyć Dzikiej postaci, aby przemienić się w znaną postać bestii. Przemianę możesz zakończyć wcześniej w ramach akcji dodatkowej. Dzikiej postaci możesz użyć dwukrotnie. Jedno użycie odzyskujesz po krótkim odpoczynku, a wszystkie po długim odpoczynku. Gdy przyjmujesz Dziką postać, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej swojemu poziomowi Druida. Nie możesz rzucać czarów, ale przemiana nie przerywa koncentracji ani w żaden inny sposób nie zakłóca działania wcześniej rzuconego czaru.</content>
+  <content contentuid="hc6dea6aag9290gf3cegeb8ag0351bd8d0fc5" version="2">W ramach akcji dodatkowej możesz użyć dzikiej postaci, aby przemienić się w znaną postać bestii. Przemianę możesz zakończyć wcześniej w ramach akcji dodatkowej. Dzikiej postaci możesz użyć dwukrotnie. Jedno użycie odzyskujesz po krótkim odpoczynku, a wszystkie po długim odpoczynku. Gdy przyjmujesz dziką postać, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej swojemu poziomowi druida. Nie możesz rzucać czarów, ale przemiana nie przerywa koncentracji ani w żaden inny sposób nie zakłóca działania wcześniej rzuconego czaru.</content>
   <content contentuid="h1505dff7gb11cg17eageb5dg29f041ed571a" version="1">Poziom 2: Dzika postać</content>
-  <content contentuid="h8e8ebc40g6f5cg5d29gc885g2f7fb0f2899b" version="2">Witalność Dzikiej postaci</content>
-  <content contentuid="h2e1bf345gb5fcg3bbag17c4g7ac514e8455e" version="1">Gdy przyjmujesz Dziką postać, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej swojemu poziomowi Druida.</content>
+  <content contentuid="h8e8ebc40g6f5cg5d29gc885g2f7fb0f2899b" version="2">Witalność dzikiej postaci</content>
+  <content contentuid="h2e1bf345gb5fcg3bbag17c4g7ac514e8455e" version="1">Gdy przyjmujesz dziką postać, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej swojemu poziomowi druida.</content>
   <content contentuid="h8a519044g61f3g7166g3e0cg6c97799602e4" version="1">Dzika postać: Borsuk</content>
   <content contentuid="h9c56ac47g3984g90a8g0115g3a3000abd94a" version="1">Dzika postać: Niedźwiedź biały</content>
   <content contentuid="h55c8bb9fgab04g0e14gce66g6d7734c64973" version="1">Dzika postać: Kot</content>
@@ -316,24 +316,24 @@ Dodaj połowę swojego modyfikatora Mądrości do &lt;LSTag Tooltip="AbilityChec
   <content contentuid="h59a5a380g59f1gfdb0g9a4fgef72e80eb679" version="1">Dzika postać: Borsuk</content>
   <content contentuid="h556b4fb3g5a97gb81cg3f21gd57ac1f02a0d" version="1">PUSTE</content>
   <content contentuid="h978ef6fag7931g203cg08ccge7b0c344b3e8" version="1">Poziom 3: Formy okręgów</content>
-  <content contentuid="h69bf3828g083cg1e10g408egf0f2ee4c7fe8" version="1">Możesz wykorzystać księżycową magię, gdy przybierasz Dziką Postać, zyskując poniższe korzyści.
+  <content contentuid="h69bf3828g083cg1e10g408egf0f2ee4c7fe8" version="1">Możesz wykorzystać księżycową magię, gdy przybierasz dziką postać, zyskując poniższe korzyści.
 
-Klasa Pancerza: Dopóki nie opuścisz formy, twoje KP wynosi 13 plus twój modyfikator Mądrości, jeśli suma ta jest wyższa niż KP Bestii.
+Klasa pancerza: Dopóki pozostajesz w tej postaci, twoja KP wynosi 13 plus twój modyfikator Mądrości, jeśli ta wartość jest wyższa niż KP bestii.
 
-Tymczasowe punkty wytrzymałości: Zyskujesz liczbę tymczasowych punktów wytrzymałości równą trzykrotności twojego poziomu druida.</content>
+Tymczasowe punkty wytrzymałości: Zyskujesz tymczasowe punkty wytrzymałości w liczbie równej trzykrotności swojego poziomu druida.</content>
   <content contentuid="h50a84c2agc47eg3409gfbf3g8b9efe860b49" version="1">Poziom 7: Furia Żywiołów: Potężne rzucanie czarów</content>
   <content contentuid="hdbacd095g40f6g7468g5750g2f164c7506d4" version="1">Potężne rzucanie czarów. Dodaj swój modyfikator Mądrości do obrażeń zadawanych przez dowolną sztuczkę Druida.</content>
   <content contentuid="h623803a7gceadgfb71gf1d2g9f3e3921f3f2" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Zimne)</content>
-  <content contentuid="h1cfad235g00bdg10bfgf085g60ac289d2534" version="1">Pierwotne uderzenie. Raz na turę, gdy trafisz istotę testem ataku bronią albo atakiem postaci bestii podczas Dzikiej postaci, możesz zadać celowi dodatkowo [1].</content>
+  <content contentuid="h1cfad235g00bdg10bfgf085g60ac289d2534" version="1">Pierwotne uderzenie. Raz na turę, gdy trafisz istotę testem ataku bronią albo atakiem postaci bestii podczas dzikiej postaci, możesz zadać celowi dodatkowo [1].</content>
   <content contentuid="he3035afbgf846g4686gf4e6gc39575739bed" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Ogień)</content>
   <content contentuid="hd0a6f226g6b60g6204gb543g086832d392ff" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Błyskawica)</content>
   <content contentuid="h193b9818gd62dg67b7gf4e0g1d6b13d33a89" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Grzmot)</content>
   <content contentuid="h86990efage02cg7a58gc14dgac02e5274f97" version="1">Poziom 5: Dzikie odrodzenie</content>
-  <content contentuid="hb6ef2813g5893gbc58ga19aga900b5ff9a74" version="1">Możesz przywrócić jedno użycie Dzikiej postaci, wydając komórkę czaru (nie jest wymagana żadna akcja).</content>
+  <content contentuid="hb6ef2813g5893gbc58ga19aga900b5ff9a74" version="1">Możesz odzyskać jedno użycie dzikiej postaci, zużywając komórkę czaru (nie wymaga to akcji).</content>
   <content contentuid="h4fc2af8fg81c5g79b5g40c7gfd252be60f4c" version="1">Dzikie odrodzenie</content>
-  <content contentuid="h70ae88b1gd34eg0e8ag5b7bga526ea0cf7a6" version="1">Możesz przywrócić jedno użycie Dzikiej postaci, wydając komórkę czaru (nie jest wymagana żadna akcja).</content>
+  <content contentuid="h70ae88b1gd34eg0e8ag5b7bga526ea0cf7a6" version="1">Możesz odzyskać jedno użycie dzikiej postaci, zużywając komórkę czaru (nie wymaga to akcji).</content>
   <content contentuid="h8d0f6247g32e9g935cg8e24g277269d5eee0" version="1">Czary Kręgu Księżyca</content>
-  <content contentuid="h97d1904cg83d1gdb83ge2b8gfb2e45881c92" version="1">Podczas Dzikiej postaci możesz rzucać czary Kręgu Księżyca.</content>
+  <content contentuid="h97d1904cg83d1gdb83ge2b8gfb2e45881c92" version="1">Podczas dzikiej postaci możesz rzucać czary Kręgu Księżyca.</content>
   <content contentuid="h81a318d3g7d25ge9f7g6cb8g0d641f9d7d75" version="1">Źródło blasku księżyca</content>
   <content contentuid="h7133dd62g2ff3g5631g286cgfb7c7edec60f" version="1">Do końca działania czaru masz odporność na obrażenia od światłości, a twoje ataki wręcz zadają przy trafieniu dodatkowo [1].</content>
   <content contentuid="h7a281f4cgfc20gce12g5a55ge741d085a992" version="1">Źródło blasku księżyca</content>
@@ -1065,9 +1065,9 @@ Zyskujesz &lt;LSTag Tooltip="Resistant"&gt;odporność&lt;/LSTag&gt; na obrażen
 
 Widzisz w ciemności.</content>
   <content contentuid="h3e8e3421g4852g1a98g9d7cgf3947ee60a89" version="1">Twardziel</content>
-  <content contentuid="h6299a92eg8049g117bga5b7g17d26b0619d6" version="2">Oporny na śmierć. Masz ułatwienie na Rzuty Obronne przeciwko Śmierci.
+  <content contentuid="h6299a92eg8049g117bga5b7g17d26b0619d6" version="2">Oporny na śmierć. Masz ułatwienie w rzutach obronnych przeciwko śmierci.
 
-Szybki powrót do zdrowia. Po wyleczeniu odzyskujesz maksymalną możliwą &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;.</content>
+Szybka regeneracja. Po wyleczeniu odzyskujesz maksymalną możliwą liczbę &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;.</content>
   <content contentuid="h3f1eb96eg51f4gaf8cg5396g435ffda2161a" version="1">Mistrz broni dwuręcznej</content>
   <content contentuid="h00f044d5gf4edgc900g397bgca53d410bdad" version="2">Mistrzostwo w Ciężkiej Broni. Gdy trafisz istotę bronią o właściwości Ciężka w ramach akcji Ataku w swojej turze, możesz sprawić, że broń zada dodatkowe obrażenia celowi. Dodatkowe obrażenia są równe twojej premii z biegłości.
 
@@ -1621,9 +1621,9 @@ Masz &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tool
 
 Widzisz w ciemności na odległość do [1].</content>
   <content contentuid="h1e93417ag9497g58f3ge9aag2e54d8ba4076" version="1">Atut: Twardziel</content>
-  <content contentuid="hf12dc8a9g3079g890agb1ffgdf7b91f3c03d" version="2">Oporny na śmierć. Masz ułatwienie na Rzuty Obronne przeciwko Śmierci.
+  <content contentuid="hf12dc8a9g3079g890agb1ffgdf7b91f3c03d" version="2">Oporny na śmierć. Masz ułatwienie w rzutach obronnych przeciwko śmierci.
 
-Szybki powrót do zdrowia. Po wyleczeniu odzyskujesz maksymalną możliwą &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;.</content>
+Szybka regeneracja. Po wyleczeniu odzyskujesz maksymalną możliwą liczbę &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;.</content>
   <content contentuid="h566e69efg081cg4f88g70abg51276f90b3b7" version="1">Poziom 2: Adept rytuałów</content>
   <content contentuid="h1edea2d1ga8eeg0549g7c32g5718c99dd110" version="1">Na poziomach Maga 2, 4 i 7 dodajesz jedno wybrane czar rytualne do swojej księgi czarów i jest ono zawsze przygotowane.</content>
   <content contentuid="h7e928dcfg9f9cg0dd6g966egff06f62b9e21" version="2">Poziom 3: Potężny sztuczka</content>
@@ -1757,7 +1757,7 @@ Jeśli wybierzesz tropikalną krainę, przygotowujesz następujące czary: na 3.
   <content contentuid="h59bddf9bg3094g2868gce0dgb0fbfbb3fdd4" version="1">Furia żywiołów</content>
   <content contentuid="h22eae394ga5fbg653egff67gee9e5b542914" version="1">Potęga żywiołów przepływa przez ciebie. Zyskujesz jedną z następujących opcji według własnego wyboru.</content>
   <content contentuid="h2b54832cgd102gec1dg521dgc5239b16c5b9" version="1">Pomoc natury</content>
-  <content contentuid="h7d366d57g2abcg334egec99gd574e5abbc31" version="1">W ramach akcji Magii możesz zużyć jedno użycie Dzikiej Postaci i wybrać punkt w promieniu 18 m od siebie. W sferze o promieniu 3 m, której środkiem jest ten punkt, pojawiają się na chwilę życiodajne kwiaty i ciernie wysysające życie. Wrogie istoty w sferze otrzymują 2k6 obrażeń nekrotycznych. Pozostałe istoty na tym obszarze odzyskują 2k6 punktów wytrzymałości.
+  <content contentuid="h7d366d57g2abcg334egec99gd574e5abbc31" version="1">W ramach akcji Magii możesz zużyć jedno użycie dzikiej postaci i wybrać punkt w promieniu 18 m od siebie. W sferze o promieniu 3 m, której środkiem jest ten punkt, pojawiają się na chwilę życiodajne kwiaty i ciernie wysysające życie. Wrogie istoty w sferze otrzymują 2k6 obrażeń nekrotycznych. Pozostałe istoty na tym obszarze odzyskują 2k6 punktów wytrzymałości.
 
 Obrażenia i leczenie zwiększają się o 1k6 na 5. poziomie druida (3k6) i ponownie na 10. poziomie (4k6).</content>
   <content contentuid="h971b2780g3870g87c7g5557ge1126bfcc79b" version="1">Poziom 10: Strażnik Natury</content>
@@ -1765,13 +1765,13 @@ Obrażenia i leczenie zwiększają się o 1k6 na 5. poziomie druida (3k6) i pono
   <content contentuid="h993714a3gef7eg3fa3g8208g34aa994bdb90" version="1">Krąg Morza</content>
   <content contentuid="h620c69f6g5443g20cdg6ba6g742691ee6c08" version="1">Druidzi z Kręgu Morza czerpią z burzliwych sił oceanów i burz. Niektórzy uważają się za ucieleśnienia gniewu natury i szukają zemsty na tych, którzy ją rabują. Inni poszukują mistycznej jedności z naturą, dostrajając się do rytmu przypływów i odpływów, podążając za pędem prądów i fal oraz słuchając nieprzeniknionych szeptów i ryków wiatrów.</content>
   <content contentuid="h098af219gb42agf6c9gb202g7d21b599c435" version="1">Poziom 3: Gniew Morza</content>
-  <content contentuid="he83b406cg6857g3e88gd60dg2ef8a8d31d88" version="2">W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby przejawić otaczającą cię emanację morskiej bryzy o promieniu 1,5 m. Emanacja kończy się wcześniej, jeśli ją zakończysz (bez użycia akcji), przejawisz ponownie albo otrzymasz stan obezwładnienia.
+  <content contentuid="he83b406cg6857g3e88gd60dg2ef8a8d31d88" version="2">W ramach akcji dodatkowej możesz zużyć jedno użycie dzikiej postaci, aby przejawić otaczającą cię emanację morskiej bryzy o promieniu 1,5 m. Emanacja kończy się wcześniej, jeśli ją zakończysz (bez użycia akcji), przejawisz ponownie albo otrzymasz stan obezwładnienia.
 
 Gdy przejawiasz emanację, a także w ramach akcji dodatkowej w kolejnych turach, możesz wybrać inną widoczną istotę w jej obrębie. Cel musi wykonać rzut obronny na Kondycję przeciwko twojemu ST obrony przed czarami; w razie niepowodzenia otrzymuje obrażenia od zimna, a jeśli ma rozmiar duży lub mniejszy, zostaje odepchnięty do 4,5 m od ciebie. Aby określić obrażenia, rzuć tyloma k6, ile wynosi twój modyfikator Mądrości.</content>
   <content contentuid="hf1921250gb124g8471g9413g503117f1b821" version="1">Dzika postać: Morze</content>
-  <content contentuid="h57810054gfe7fgd3feg857agf79b5362dc6c" version="1">W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby przejawić otaczającą cię emanację morskiej bryzy o promieniu 1,5 m. Emanacja kończy się wcześniej, jeśli ją zakończysz (bez użycia akcji), przejawisz ponownie albo otrzymasz stan obezwładnienia.</content>
+  <content contentuid="h57810054gfe7fgd3feg857agf79b5362dc6c" version="1">W ramach akcji dodatkowej możesz zużyć jedno użycie dzikiej postaci, aby przejawić otaczającą cię emanację morskiej bryzy o promieniu 1,5 m. Emanacja kończy się wcześniej, jeśli ją zakończysz (bez użycia akcji), przejawisz ponownie albo otrzymasz stan obezwładnienia.</content>
   <content contentuid="h2441e241g48f9g90deg04f4gc1d4278870d3" version="1">Dzika postać: Morze</content>
-  <content contentuid="hf8470c53gc4a7gf584g96f0g33c340603191" version="1">W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby przejawić otaczającą cię emanację morskiej bryzy o promieniu 1,5 m. Emanacja kończy się wcześniej, jeśli ją zakończysz (bez użycia akcji), przejawisz ponownie albo otrzymasz stan obezwładnienia.</content>
+  <content contentuid="hf8470c53gc4a7gf584g96f0g33c340603191" version="1">W ramach akcji dodatkowej możesz zużyć jedno użycie dzikiej postaci, aby przejawić otaczającą cię emanację morskiej bryzy o promieniu 1,5 m. Emanacja kończy się wcześniej, jeśli ją zakończysz (bez użycia akcji), przejawisz ponownie albo otrzymasz stan obezwładnienia.</content>
   <content contentuid="h3c20f33cgc7dag94d0ge8cag9a5b89fd4b90" version="1">Gniew morza</content>
   <content contentuid="hfce3b1a5gd494ge7ddge2b2gaa37f42771ce" version="1">Cel musi wykonać rzut obronny na Kondycję przeciwko twojemu ST obrony przed czarami; w razie niepowodzenia otrzymuje obrażenia od zimna, a jeśli ma rozmiar duży lub mniejszy, zostaje odepchnięty do 4,5 m od ciebie. Aby określić obrażenia, rzuć tyloma k6, ile wynosi twój modyfikator Mądrości.</content>
   <content contentuid="hb8de1b6fge14agdb53gd966gfe3270131b62" version="1">Poziom 6: Powinowactwo wodne</content>
@@ -2109,7 +2109,7 @@ Po użyciu tej cechy nie możesz zrobić tego ponownie, dopóki nie ukończysz k
   <content contentuid="h9df0d5e3gb8b4g35c0g6ef3gc428f067f2a7" version="1">Użyj kości wytrzymałości: k10</content>
   <content contentuid="hd6b15ae8g883dgdf02gd6abg7ee0b10eb571" version="1">Użyj kości wytrzymałości: k12</content>
   <content contentuid="h4fbdbfa6g8ef2g4e61g0c7bg465466a0df32" version="1">Zasada: Kości wytrzymałości</content>
-  <content contentuid="hfd791ef7g7534g8fdcgba6ag9741c29e31d4" version="1">Opis klasy określa rodzaj kości wytrzymałości twojej postaci (zwanych też kośćmi wytrzymałości). Na 1. poziomie postać ma 1 taką kość. Możesz wydawać kości wytrzymałości, aby odzyskiwać punkty wytrzymałości.</content>
+  <content contentuid="hfd791ef7g7534g8fdcgba6ag9741c29e31d4" version="1">Opis klasy określa rodzaj kości punktów wytrzymałości twojej postaci (w skrócie: kości wytrzymałości). Na 1. poziomie postać ma 1 taką kość. Możesz wydawać kości wytrzymałości, aby odzyskiwać punkty wytrzymałości.</content>
   <content contentuid="hc1919180g48a0ga814g77dega72819b9d91a" version="1">Heroiczna Inspiracja: Przerzuć z ułatwieniem (rzut obronny)</content>
   <content contentuid="h665b0831g0a27gcf47g1dafg16ce9df4ed5c" version="1">Zyskaj &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; na swoim &lt;LSTag Tooltip="SavingThrow"&gt;rzut obronny&lt;/LSTag&gt;.</content>
   <content contentuid="h3f7b8985g6d22gafeag4f95gff41b038514a" version="1">Przechwycenie</content>
@@ -2211,7 +2211,7 @@ Mgła wojny. ST wymagane do uzyskania stanu niewidzialności za pomocą akcji Uk
   <content contentuid="hb81653bdgbf89g4d3eg8b44g1d6392df53a6" version="1">Zyskaj korzyści z krótkiego odpoczynku.</content>
   <content contentuid="h8d8901f6g2e5cg9e63gccfag9986aa35774d" version="1">Zyskaj korzyści z krótkiego odpoczynku.</content>
   <content contentuid="h29b83689gfd3bg5f53g17f0g9a9d6b677256" version="1">Zyskaj korzyści z krótkiego odpoczynku.</content>
-  <content contentuid="h9e1946a3g463agb8b7g75e7gd94f9c36f9f7" version="1">Gdy używasz czarów Porażenia, zyskujesz &lt;LSTag Tooltip="TemporaryHitPoints"&gt;tymczasowe punkty wytrzymałości&lt;/LSTag&gt; w liczbie równej twojemu &lt;LSTag Tooltip="AbilityModifier"&gt;modyfikatorowi&lt;/LSTag&gt; Charyzmy.</content>
+  <content contentuid="h9e1946a3g463agb8b7g75e7gd94f9c36f9f7" version="1">Gdy używasz czarów ugodzenia, zyskujesz &lt;LSTag Tooltip="TemporaryHitPoints"&gt;tymczasowe punkty wytrzymałości&lt;/LSTag&gt; w liczbie równej twojemu &lt;LSTag Tooltip="AbilityModifier"&gt;modyfikatorowi&lt;/LSTag&gt; Charyzmy.</content>
   <content contentuid="h49c4cec7gb617g6a1eg491fgb75829e376fa" version="1">Atut: Smoczy Strach</content>
   <content contentuid="h1e4b1002g6774g3698g6495gb47ef39af956" version="2">Zyskujesz jedno użycie zionięcia.
 
@@ -2242,13 +2242,13 @@ Na końcach palców wyrastają ci chowane pazury. Ich wysunięcie lub schowanie 
 Z czubków palców wyrastają chowane pazury. Wysuwanie lub cofanie pazurów nie wymaga żadnych działań. Pazury to naturalna broń, którą możesz wykorzystać do wykonywania ataków bez broni. Kiedy uderzasz nieuzbrojonym atakiem za pomocą tych pazurów, atak zadaje dodatkowe obrażenia cięte 1k4.</content>
   <content contentuid="hff5fa241g78c2g2414gf5caga9f8235efc8d" version="1">Atut: Smocza Skóra</content>
   <content contentuid="h2f58c2a0g1fd8gcbc6g65e4g15015618e4f6" version="1">Atut: Krasnoludzka siła</content>
-  <content contentuid="haa8d3917gd15fg261dg5b19g07a62de6a88f" version="1">Za każdym razem, gdy w walce wykonasz akcję Uniku, możesz wydać jedną Kostkę Trafienia, aby się wyleczyć. Rzuć kostką, dodaj swój modyfikator Kondycji i odzyskaj liczbę punktów wytrzymałości równą sumie (co najmniej 1).</content>
+  <content contentuid="haa8d3917gd15fg261dg5b19g07a62de6a88f" version="1">Za każdym razem, gdy w walce wykonasz akcję Uniku, możesz wydać jedną kość wytrzymałości, aby się wyleczyć. Rzuć kością, dodaj swój modyfikator Kondycji i odzyskaj punkty wytrzymałości w liczbie równej sumie (co najmniej 1).</content>
   <content contentuid="h399266afg5858g5079g1067g6fd5b17e38ef" version="1">Krasnoludzka siła</content>
   <content contentuid="h5d6d057fg00c7g16f2g3e29g4815f812225a" version="3">Warunek: Krasnolud
 
 W twoich żyłach płynie krew krasnoludzkich bohaterów.
 
-Za każdym razem, gdy w walce wykonasz akcję Uniku, możesz wydać jedną Kostkę Trafienia, aby się wyleczyć. Rzuć kostką, dodaj swój modyfikator Kondycji i odzyskaj liczbę punktów wytrzymałości równą sumie (co najmniej 1).</content>
+Za każdym razem, gdy w walce wykonasz akcję Uniku, możesz wydać jedną kość wytrzymałości, aby się wyleczyć. Rzuć kością, dodaj swój modyfikator Kondycji i odzyskaj punkty wytrzymałości w liczbie równej sumie (co najmniej 1).</content>
   <content contentuid="h59ec731bg946dg1c9eg2b5fg04fb49032eb0" version="1">Atut: Elfia dokładność</content>
   <content contentuid="h7568c386gf212ga40dg691eg69b66c143ccb" version="1">Ilekroć masz ułatwienie w teście ataku za pomocą Zręczności, Inteligencji, Mądrości lub Charyzmy, możesz raz przerzucić jedną z kości.</content>
   <content contentuid="h871574cdg815eg20feg9c4bg90c69f23267f" version="1">Elfia dokładność</content>
@@ -3042,27 +3042,27 @@ Na 9. poziomie rewolwerowca ataki bronią dystansową kończą się trafieniem k
   <content contentuid="hae35f153g7a35g4565ga666g79bb16da7dd3" version="1">Kształt smoka</content>
   <content contentuid="hb5de1336geb7cg937fg5ba9g13226b34f6df" version="1">Zionięcie</content>
   <content contentuid="h82f57f8fg4253ga79egce21gde7d5fe72f73" version="2">W ramach akcji wydychasz strumień potężnej energii. Każda istota w stożku o długości 4,5 m wykonuje rzut obronny na Zręczność przeciwko ST rzutu obronnego przeciwko twoim czarom. Przy niepowodzeniu otrzymuje obrażenia od ognia, a przy powodzeniu połowę tej wartości.</content>
-  <content contentuid="h6d46b975ga195gac49gab4cg2ff48ea0ff54" version="1">Twoja broń oddechowa poprawia się na pewnych poziomach. Na 6. poziomie twoja broń oddechowa zadaje 3k6 obrażeń. Na 10. poziomie zadaje 4k6 obrażeń.</content>
+  <content contentuid="h6d46b975ga195gac49gab4cg2ff48ea0ff54" version="1">Twoje zionięcie staje się potężniejsze na określonych poziomach. Na 6. poziomie zadaje 3k6 obrażeń, a na 10. poziomie — 4k6 obrażeń.</content>
   <content contentuid="ha7a4dc42gd5c2g913bg0030gb9bacfc6f4d8" version="1">Kształt smoka</content>
-  <content contentuid="hea98e86cg6f0eg6fa9gd366g94bd7a432ec2" version="2">Możesz w ramach akcji dodatkowej zużyć jedno użycie Dzikiej postaci, aby przybrać wyjątkową formę smoka. W tej postaci twój rozmiar zmienia się na Średni, poruszasz się na czterech łapach, ale zachowujesz zwykłe statystyki i zmysły postaci.
+  <content contentuid="hea98e86cg6f0eg6fa9gd366g94bd7a432ec2" version="2">Możesz w ramach akcji dodatkowej zużyć jedno użycie dzikiej postaci, aby przybrać wyjątkową formę — kształt smoka. W tej formie stajesz się smokiem rozmiaru średniego poruszającym się na czterech łapach, ale zachowujesz zwykłe statystyki i zmysły swojej postaci.
 
-W formie smoka możesz atakować pazurami i używać broni oddechowej. Zyskujesz szybkość latania równą dwukrotności swojej szybkości oraz odporność na obrażenia od kwasu, zimna, ognia, elektryczności i trucizny.</content>
-  <content contentuid="hc56adb28g1c39g4a79g84bbgc0a1b6238a22" version="1">Kiedy osiągniesz poziom Druida 6 i 10, twój Kształt Smoka stanie się potężniejszy.</content>
-  <content contentuid="h8a2a463cg9e0fg4e84gefd3g2307577a9b84" version="1">Krąg Smoków</content>
-  <content contentuid="h4dcc12fag7d0cgb63ag23cfg441ee129b6df" version="1">Krąg Smoków to stary zakon druidów przesiąknięty sztywną tradycją. Ci związani honorem strażnicy natury i smoczego dziedzictwa są członkami tajnego stowarzyszenia, które miało wpływ na zarządzanie, wojny i kulturę na całym świecie. Wysoko postawieni członkowie tego Kręgu są powiązani z królewskimi rodami sięgającymi pokoleń wstecz, co jest subtelnie ukazane w herbach i insygniach rodziny królewskiej.
+W kształcie smoka możesz atakować pazurami i używać zionięcia. Zyskujesz szybkość lotu równą dwukrotności swojej szybkości oraz odporność na obrażenia od kwasu, zimna, ognia, elektryczności i trucizny.</content>
+  <content contentuid="hc56adb28g1c39g4a79g84bbgc0a1b6238a22" version="1">Na 6. i 10. poziomie druida twój kształt smoka staje się potężniejszy.</content>
+  <content contentuid="h8a2a463cg9e0fg4e84gefd3g2307577a9b84" version="1">Krąg smoków</content>
+  <content contentuid="h4dcc12fag7d0cgb63ag23cfg441ee129b6df" version="1">Krąg smoków to stary zakon druidów o sztywnych tradycjach. Ci związani honorem strażnicy natury i smoczego dziedzictwa należą do tajnego stowarzyszenia, które wpływało na rządy, wojny i kulturę na całym świecie. Wysoko postawieni członkowie tego kręgu mają związki z rodami królewskimi sięgające wielu pokoleń wstecz, czego subtelnym świadectwem są herby i insygnia rodzin królewskich.
 
-Druidzi z tego Kręgu wiedzą, że smoki i smocza magia są tak samo połączone ze światem jak rośliny czy zwierzęta, i wykorzystują to połączenie, aby przekształcić się w wyjątkową i potężną smoczą formę.</content>
-  <content contentuid="hea0350ecg3563gf151g3949ge2a04d0eb3da" version="1">Poziom 3: Smocza Wiedza</content>
+Druidzi z tego kręgu wiedzą, że smoki i smocza magia są tak samo związane ze światem jak rośliny czy bestie, i wykorzystują tę więź, aby przybrać własną, wyjątkową i potężną smoczą postać.</content>
+  <content contentuid="hea0350ecg3563gf151g3949ge2a04d0eb3da" version="1">Poziom 3: Smocza wiedza</content>
   <content contentuid="hda6df4cdg93a3gab23g3fd8ga7f8a4585d19" version="1">Zyskujesz znawstwo w testach &lt;LSTag Type="Skills" Tooltip="History"&gt;Historii&lt;/LSTag&gt;.</content>
-  <content contentuid="h8ea85d5eg5bc3gd5aagf3e6g7179f506b3ef" version="1">Poziom 3: Kształt Smoka</content>
-  <content contentuid="hc9360440gfe54g46f9gbb9dge1b352d710ba" version="2">W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby przybrać wyjątkową Smoczą Postać. Stajesz się wówczas średnim smokiem poruszającym się na czterech łapach, ale zachowujesz swoje zwykłe statystyki i zmysły.
+  <content contentuid="h8ea85d5eg5bc3gd5aagf3e6g7179f506b3ef" version="1">Poziom 3: Kształt smoka</content>
+  <content contentuid="hc9360440gfe54g46f9gbb9dge1b352d710ba" version="2">W ramach akcji dodatkowej możesz zużyć jedno użycie dzikiej postaci, aby przybrać wyjątkową formę — kształt smoka. W tej formie stajesz się smokiem rozmiaru średniego poruszającym się na czterech łapach, ale zachowujesz zwykłe statystyki i zmysły.
 
-Po przybraniu Smoczej Postaci zyskujesz tymczasowe punkty wytrzymałości w liczbie równej trzykrotności swojego poziomu druida. Możesz atakować pazurami i używać zionięcia. Zyskujesz szybkość latania równą dwukrotności swojej szybkości oraz odporność na obrażenia od kwasu, zimna, ognia, elektryczności i trucizny.</content>
-  <content contentuid="hcb4664e4g5158g21d8ga6dcgb912ed163b0d" version="1">Kiedy osiągniesz poziom Druida 6 i 10, twój Kształt Smoka stanie się potężniejszy.</content>
+Gdy przybierasz kształt smoka, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej trzykrotności swojego poziomu druida. W kształcie smoka możesz atakować pazurami i używać zionięcia. Zyskujesz szybkość lotu równą dwukrotności swojej szybkości oraz odporność na obrażenia od kwasu, zimna, ognia, elektryczności i trucizny.</content>
+  <content contentuid="hcb4664e4g5158g21d8ga6dcgb912ed163b0d" version="1">Na 6. i 10. poziomie druida twój kształt smoka staje się potężniejszy.</content>
   <content contentuid="h1dfb4f40g1c13gaa7fg1d57g9a9c0d160f6b" version="1">Poziom 6: Ulepszony kształt smoka</content>
-  <content contentuid="h188fcbccg032fg827cg4fc8g0526eb475df0" version="1">Będąc w Kształcie Smoka, twoje ataki liczą się jako magiczne w celu pokonania &lt;LSTag Tooltip="Resistant"&gt;odporność&lt;/LSTag&gt; i &lt;LSTag Tooltip="Immune"&gt;niepodatność&lt;/LSTag&gt; na obrażenia niemagiczne, a twoje AC wzrasta o 1.</content>
+  <content contentuid="h188fcbccg032fg827cg4fc8g0526eb475df0" version="1">W kształcie smoka twoje ataki są uznawane za magiczne na potrzeby przełamywania &lt;LSTag Tooltip="Resistant"&gt;odporności&lt;/LSTag&gt; i &lt;LSTag Tooltip="Immune"&gt;niepodatności&lt;/LSTag&gt; na obrażenia niemagiczne, a twoja KP zwiększa się o 1.</content>
   <content contentuid="hd3ad95cbg5d22g8cf8g0922gb17a3e44311f" version="1">Poziom 10: Smocza Magia</content>
-  <content contentuid="h8a430f87g813dg7f42g06f9gd34f0e6f79f3" version="1">Będąc w Kształcie Smoka, możesz rzucać przygotowane czary Druida, a twoje KP wzrasta o 2.</content>
+  <content contentuid="h8a430f87g813dg7f42g06f9gd34f0e6f79f3" version="1">W kształcie smoka możesz rzucać przygotowane czary druida, a twoja KP zwiększa się o 2.</content>
   <content contentuid="h7ee8c4acge213gdc57g0743g89e268308429" version="1">Kliknij ikonę komórki czarów na pasku skrótów, aby użyć przygotowanych czarów.</content>
   <content contentuid="he87fc2b8g89e0g6349gbba8g169827090bfc" version="1">Jeździec autostradą</content>
   <content contentuid="h71ff1a29gf725g3e28gb5bfg5096950ebc3f" version="1">Podążając zaułkami, Autostrada zasiewa strach w sercu każdego podróżnika i żądnego grosza kupca. Zbiegają ze zdobyczą na szybkim i lojalnym rumaku, a następnie szybko uciekają.</content>
@@ -3311,10 +3311,10 @@ Niektóre dobrodziejstwa wymagają minimalnego poziomu Illriggera. Kiedy osiągn
   <content contentuid="h6b7c5b42gc865g9a66g25bcgcf6498b47b95" version="1">Ożywiaj</content>
   <content contentuid="ha334fba5ge039gfb31g1b15g55b8f07d80f4" version="1">Poświęć połowę swoich pozostałych &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;, aby przywrócić celowi taką samą ich ilość.</content>
   <content contentuid="h29248f55g9799g09d8ge529g06704f76d155" version="1">Poziom 10: Cena krwi</content>
-  <content contentuid="h6bdae4c0g3fcdg259fgefa5g636614568bc0" version="1">Możesz wzmocnić swoją obronę kosztem swojej żywotności. Za każdym razem, gdy nie powiedzie się rzut obronny, możesz wydać jedną ze swoich Kostek Wytrzymałości, rzucić nią i dodać wyrzuconą liczbę do wyniku rzutu obronnego.</content>
+  <content contentuid="h6bdae4c0g3fcdg259fgefa5g636614568bc0" version="1">Możesz wzmocnić swoją obronę kosztem żywotności. Za każdym razem, gdy nie powiedzie ci się rzut obronny, możesz wydać jedną ze swoich kości wytrzymałości, rzucić nią i dodać wynik do tego rzutu obronnego.</content>
   <content contentuid="h8a78754bge4a1gbe50g8f26g0bd670acd7cc" version="1">Cena krwi: k8</content>
   <content contentuid="h357af6fegcc60g52adgea2agd98b8ed57793" version="1">Cena krwi: k6</content>
-  <content contentuid="h6975a894g14d4g0b4dga8ecg80a20b85ad85" version="1">Możesz wzmocnić swoją obronę kosztem swojej żywotności. Za każdym razem, gdy nie powiedzie się rzut obronny, możesz wydać jedną ze swoich Kostek Wytrzymałości, rzucić nią i dodać wyrzuconą liczbę do wyniku rzutu obronnego.</content>
+  <content contentuid="h6975a894g14d4g0b4dga8ecg80a20b85ad85" version="1">Możesz wzmocnić swoją obronę kosztem żywotności. Za każdym razem, gdy nie powiedzie ci się rzut obronny, możesz wydać jedną ze swoich kości wytrzymałości, rzucić nią i dodać wynik do tego rzutu obronnego.</content>
   <content contentuid="h89f9d62cgd6f0g46b6g9bdbgeb45a121b113" version="1">Cena krwi: k10</content>
   <content contentuid="h018dfa63g9034g560eg6daegcc0414738e0e" version="1">Cena krwi: k12</content>
   <content contentuid="hf204ad45gef57gf823g5fbdg2aadc2b21ace" version="1">Poziom 11: Terroryzująca siła (zimno)</content>
@@ -3689,14 +3689,14 @@ Choć druidzi ci noszą w sobie chaos natury, trening i dyscyplina pozwalają im
   <content contentuid="he9c252edgc46cg4450gfb88g57508151df65" version="1">Poziom 3: Czary Kręgu Niezłomnych</content>
   <content contentuid="head50b7eg3179gbc89g1334gbee0de9d925c" version="1">Więź z Kręgiem Niezłomnych sprawia, że zawsze masz przygotowane określone czary. Po osiągnięciu poziomu druida wskazanego w tabeli Czarów Kręgu Niezłomnych zawsze masz przygotowane wymienione w niej czary: na 3. poziomie — Pętające uderzenie, Shillelagh, Lśniące ugodzenie i Prawdziwe uderzenie; na 5. poziomie — &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Przyspieszenie&lt;/LSTag&gt;; na 7. poziomie — Tarcza ognia; a na 9. poziomie — Słup ognia.</content>
   <content contentuid="h8ed0d8e9g85baga28cg5d7eg2778cf1bbf0a" version="1">Poziom 3: Dziki powrót do zdrowia</content>
-  <content contentuid="heb2a7f7ag521bg6a02g5dffg52cdf49a9788" version="2">Uczysz się regenerować dzięki dzikiej, zwierzęcej magii płynącej w twoich żyłach. W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby odzyskać punkty wytrzymałości w liczbie równej sumie 2k6 i twojego poziomu druida. Leczenie zwiększa się o 1k6 na 5. poziomie druida (3k6 plus poziom druida) i ponownie na 10. poziomie (4k6 plus poziom druida).</content>
+  <content contentuid="heb2a7f7ag521bg6a02g5dffg52cdf49a9788" version="2">Uczysz się regenerować dzięki dzikiej, zwierzęcej magii płynącej w twoich żyłach. W ramach akcji dodatkowej możesz zużyć jedno użycie dzikiej postaci, aby odzyskać punkty wytrzymałości w liczbie równej sumie 2k6 i twojego poziomu druida. Leczenie zwiększa się o 1k6 na 5. poziomie druida (3k6 plus poziom druida) i ponownie na 10. poziomie (4k6 plus poziom druida).</content>
   <content contentuid="h7fe6e3e8gb94ag15c5g406eg227fcfa3c807" version="1">Poziom 6: Mistrzostwo Shillelagh</content>
   <content contentuid="h7e8ca440g858fg8122g6567g8dbda7a1b2f0" version="1">Możesz zaatakować tą bronią dwa razy, a nie raz, za każdym razem, gdy w swojej turze wykonasz akcję Ataku.</content>
   <content contentuid="hd5f1b8cag18ffgb6f6g47ffg3b8c0b38f590" version="1">Poziom 10: Druid Wojenny</content>
   <content contentuid="hf86fda08gd41fg7378gec9bg99ec11e5214f" version="1">Kiedy w swojej turze wykonasz akcję Ataku, możesz zastąpić jeden z ataków rzuceniem jednej ze swoich sztuczek Druida, której czas rzucania jest określony.</content>
   <content contentuid="h33d907d8gd0a0gaee7g061fg578448183f33" version="1">Ulepszenie Shillelagh</content>
   <content contentuid="h698d6323ge92fg1fd9g8d8bg36d7db994d94" version="1">Dzikie odzyskiwanie</content>
-  <content contentuid="hc24409fagede8g0aaag1ad3g32c2949bb667" version="2">Uczysz się regenerować dzięki dzikiej, zwierzęcej magii płynącej w twoich żyłach. W ramach akcji dodatkowej możesz zużyć jedno użycie Dzikiej Postaci, aby odzyskać punkty wytrzymałości w liczbie równej sumie 2k6 i twojego poziomu druida. Leczenie zwiększa się o 1k6 na 5. poziomie druida (3k6 plus poziom druida) i ponownie na 10. poziomie (4k6 plus poziom druida).</content>
+  <content contentuid="hc24409fagede8g0aaag1ad3g32c2949bb667" version="2">W ramach akcji dodatkowej możesz zużyć jedno użycie dzikiej postaci, aby odzyskać punkty wytrzymałości w liczbie równej sumie 2k6 i twojego poziomu druida. Leczenie zwiększa się o 1k6 na 5. poziomie druida (3k6 plus poziom druida) i ponownie na 10. poziomie (4k6 plus poziom druida).</content>
   <content contentuid="hc064fa21ge684g65c0g9633g796b118177b3" version="1">Żrące uderzenie</content>
   <content contentuid="h33a83d2bg7e97g9bebg4b1ag640c88459c92" version="1">Zadajesz dodatkowe obrażenia od kwasu w liczbie równej twojej &lt;LSTag Tooltip="ProficiencyBonus"&gt;premii z biegłości&lt;/LSTag&gt;. Przy trafieniu tworzysz wokół celu kałużę kwasu, która zmniejsza jego &lt;LSTag Tooltip="ArmourClass"&gt;Klasę Pancerza&lt;/LSTag&gt; o [1].</content>
   <content contentuid="h93ef7658ga110g9063ga99fg02ab90d1135d" version="1">Trująca Mgła</content>
@@ -3877,19 +3877,17 @@ Jeden z paladynów zasłynął z wypowiedzi, w której jego święty mściciel b
   <content contentuid="hae58b170g1a86g562dg9c15gc5a91fb03fe1" version="1">&lt;LSTag Tooltip="Resistant"&gt;Odporność&lt;/LSTag&gt; na obrażenia od czarów rzucanych w promieniu [1] od paladyna.</content>
   <content contentuid="hda8b38bag9499g847bgcf99g9febaba0926a" version="1">Poziom 3: Czary płatnerza</content>
   <content contentuid="hee79b7c5g14dagd8ecg3444ge2c7d3d25745" version="1">Po osiągnięciu określonych poziomów Wynalazcy zawsze masz przygotowane czary wskazane w tabeli Czarów Płatnerza: na 3. poziomie — Magiczny pocisk i Fala gromu; na 5. poziomie — Lustrzane odbicia i Trzask; a na 9. poziomie — Hipnotyczny wzór i Błyskawica.</content>
-  <content contentuid="h5e04a4b5g175bgdd37g3e7dgce0dab6d5f40" version="1">Poziom 3: Tajemna Zbroja</content>
-  <content contentuid="h2d1fac5ag5486g7185gac07g348c2ae033ff" version="1">Jeśli zbroja zwykle wymaga siły, tajemna zbroja nie spełnia tego wymagania.</content>
+  <content contentuid="h5e04a4b5g175bgdd37g3e7dgce0dab6d5f40" version="1">Poziom 3: Magiczny pancerz</content>
+  <content contentuid="h2d1fac5ag5486g7185gac07g348c2ae033ff" version="1">Jeśli pancerz zwykle wymaga określonej wartości Siły, magiczny pancerz nie nakłada na ciebie tego wymogu.</content>
   <content contentuid="hca9785d1g9483g710egfc60ga2d4f1dfeef6" version="1">Poziom 3: Model zbroi</content>
-  <content contentuid="h3757893egada1gdcfdgf81egfaecbf54b4e4" version="2">Możesz dostosować swoją magiczną zbroję. Wybierz jeden z następujących modeli: Drednot, Strażnik albo Infiltrator. Wybrany model zapewnia ci szczególne korzyści, gdy nosisz tę zbroję.
+  <content contentuid="h3757893egada1gdcfdgf81egfaecbf54b4e4" version="2">Możesz dostosować swój magiczny pancerz. Wybierz jeden z następujących modeli pancerza: Drednot, Strażnik albo Infiltrator. Wybrany model zapewnia ci szczególne korzyści, gdy nosisz magiczny pancerz.
 
-Każdy model obejmuje specjalną broń. Gdy nią atakujesz, możesz używać modyfikatora Inteligencji zamiast modyfikatora Siły lub Zręczności w testach ataku i rzutach obrażeń.</content>
+Każdy model obejmuje specjalną broń. Gdy atakujesz za pomocą tej broni, możesz używać modyfikatora Inteligencji zamiast modyfikatora Siły lub Zręczności w testach ataku i rzutach obrażeń.</content>
   <content contentuid="h916a21e8gd025g4c4eg788agd117ac8d425a" version="1">Model pancerza</content>
   <content contentuid="h268b26f7gae12g5da6gc6cbgfc918bbeed59" version="1">Drednot</content>
   <content contentuid="h9d4fd894g81e1g69a7gb31ag685f124bd58d" version="1">Strażnik</content>
   <content contentuid="h9a58f47cgb03cg53ddg2bdfgba12dcd9a2e5" version="1">Infiltrator</content>
-  <content contentuid="hcc906553g972bg8298gd9cfga6a42e0fdb7c" version="2">Możesz dostosować swoją magiczną zbroję. Wybierz jeden z następujących modeli: Drednot, Strażnik albo Infiltrator. Wybrany model zapewnia ci szczególne korzyści, gdy nosisz tę zbroję.
-
-Każdy model obejmuje specjalną broń. Gdy nią atakujesz, możesz używać modyfikatora Inteligencji zamiast modyfikatora Siły lub Zręczności w testach ataku i rzutach obrażeń.</content>
+  <content contentuid="hcc906553g972bg8298gd9cfga6a42e0fdb7c" version="2">Możesz dostosować swój magiczny pancerz. Wybierz jeden z następujących modeli pancerza: Drednot, Strażnik albo Infiltrator. Wybrany model zapewnia ci szczególne korzyści, gdy nosisz magiczny pancerz. Każdy model obejmuje specjalną broń. Gdy atakujesz za pomocą tej broni, możesz używać modyfikatora Inteligencji zamiast modyfikatora Siły lub Zręczności w testach ataku i rzutach obrażeń.</content>
   <content contentuid="he2a10ea7ge923ge756g16a5gec995e896057" version="1">Projektujesz zbroję tak, by w walce przemieniała cię w górującego nad wrogami kolosa. Zapewnia następujące zdolności:
 
 Siłowy niszczyciel. Ze zbroi wysuwa się magiczna kula wyburzeniowa albo młot. Niszczyciel jest prostą bronią do walki wręcz z właściwością Dalekosiężna i przy trafieniu zadaje 1k10 obrażeń od mocy. Gdy trafisz nim istotę mniejszą od ciebie o co najmniej jedną kategorię rozmiaru, możesz odepchnąć ją od siebie albo przyciągnąć do siebie na odległość do 3 m.
@@ -3904,7 +3902,7 @@ Wyrzutnia błyskawic. Na zbroi pojawia się węzeł przypominający klejnot, z k
 Wzmocniony krok. Twoja szybkość zwiększa się o 1,5 m.
 Pole tłumiące. Masz ułatwienie w testach Zręczności (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Skradanie się&lt;/LSTag&gt;).</content>
   <content contentuid="hae5b8629gb6dege582gb0b6g59da26e4eb55" version="1">Poziom 9: Ulepszony płatnerz</content>
-  <content contentuid="hf03822e2g7af0g67edg9165g36461a798fbc" version="4">Twoja magiczna zbroja zyskuje dodatkowe korzyści zależne od modelu.
+  <content contentuid="hf03822e2g7af0g67edg9165g36461a798fbc" version="4">Twój magiczny pancerz zyskuje dodatkowe korzyści zależne od modelu.
 
 Drednot. Kość obrażeń Siłowego niszczyciela zwiększa się do 2k6 obrażeń od mocy, a twój zasięg zwiększa się o 3 m.
 
@@ -5413,7 +5411,7 @@ Wykonaj przeciwko celowi test ataku czarem dystansowym. Po trafieniu cel otrzymu
   <content contentuid="ha3d984fag9166g3a51gbc9fg45fc0d47e563" version="1">Cienista macka</content>
   <content contentuid="h243a5f49gc364g1981gbc7fge75041c302f9" version="1">Zyskaj tymczasowe punkty wytrzymałości.</content>
   <content contentuid="h6c91c1d0geff6g49ddg9fd0gd5d83740ee64" version="1">Wtajemniczony: Cienista macka</content>
-  <content contentuid="h28992689gab7eg0bcega955gb5ee06d7deaf" version="1">Możesz wydawać Kostki Wytrzymałości podczas krótkiego odpoczynku, aby odzyskać punkty wytrzymałości.</content>
+  <content contentuid="h28992689gab7eg0bcega955gb5ee06d7deaf" version="1">Możesz wydawać kości wytrzymałości podczas krótkiego odpoczynku, aby odzyskiwać punkty wytrzymałości.</content>
   <content contentuid="hbd79e588g85a8ga317gab92g1dc3ec782773" version="1">Związana broń: podstawowa</content>
   <content contentuid="h6193eaa0gbef3g3810gc2ffg05099e13d0ea" version="1">Związana broń: drugorzędna</content>
   <content contentuid="h886aaa36gd8ecg34edg11dbga02b0ae1f0f9" version="1">Związana broń: podstawowa</content>
@@ -5455,7 +5453,7 @@ Na wyższych poziomach: twoja szybkość wzrasta o dodatkowe 1,5 m, a obrażenia
   <content contentuid="hebba7f87g6370g87ceg8319g29430a465253" version="1">Magiczna krzepa: k8</content>
   <content contentuid="h61c3e42cg02b0g7f38gda65gdc3642939a49" version="1">Magiczna krzepa: k10</content>
   <content contentuid="h2c125804g85eegc3ecgdd44g25edc8c0bb5c" version="1">Magiczna krzepa: k12</content>
-  <content contentuid="h2826d606g7d49g321cg9686gfc615a4ba31d" version="1">Liczba niewykorzystanych Kostek Wytrzymałości, którymi możesz rzucić, zwiększa się o jeden za każdy poziom komórki czaru powyżej 2.</content>
+  <content contentuid="h2826d606g7d49g321cg9686gfc615a4ba31d" version="1">Liczba niewykorzystanych kości wytrzymałości, którymi możesz rzucić, zwiększa się o jeden za każdy poziom komórki czaru powyżej 2.</content>
   <content contentuid="h68cc0961gb6ceg3e67g1ae5g31162e46016b" version="1">Wypaczenie ciała Gorgorotha</content>
   <content contentuid="h2ee464d4g6606g2b85g7008gfc6f4aaa15b0" version="1">Wybierz humanoida swojego rozmiaru, którego widzisz w zasięgu. Fizycznie przekształcasz się, aby stać się dokładną kopią tej istoty na czas trwania. Nawet dokładne badanie fizykalne nie wykazuje żadnych różnic między tobą a celem.</content>
   <content contentuid="h35b9b915g3bf7g0d1dg728fg2be8d9ced715" version="1">Wypaczenie ciała Gorgorotha</content>
@@ -6498,7 +6496,7 @@ Przerażający awatar. Raz na turę, gdy trafisz istotę testem ataku, możesz z
   <content contentuid="h77baae07gb508ga5a7g250fg1e4e4b4a196c" version="1">Gdy twoje punkty wytrzymałości spadną do 0, ale nie zginiesz od razu, możesz sprawić, że twoje ciało wybuchnie śmiercionośną energią. Każda wybrana przez ciebie istota w emanacji o promieniu 9 m, której źródłem jesteś, wykonuje rzut obronny na Kondycję przeciwko twojemu ST obrony przed czarami. Przy niepowodzeniu otrzymuje obrażenia nekrotyczne równe sumie 2k10 i twojego modyfikatora Charyzmy, a przy powodzeniu — połowę tych obrażeń. Następnie twoje punkty wytrzymałości wynoszą dwukrotność twojego poziomu czarownika, a ty zyskujesz 1 poziom Wyczerpania.</content>
   <content contentuid="h0f4e5dbfgfb84gaa42gc66eg6660538c6909" version="1">Bezbożne wskrzeszenie</content>
   <content contentuid="h4e247c5ag5398g03f2g7a9cgf569bf3a693e" version="1">Księżycowy blask</content>
-  <content contentuid="h334bd2c8g7709g2b93g78b1g773fe3b8ebf1" version="1">Każdy z twoich ataków w formie Dzikiej postaci może zadać normalne obrażenia lub obrażenia od światłości. Dokonujesz tego wyboru za każdym razem, gdy uderzasz tymi atakami.</content>
+  <content contentuid="h334bd2c8g7709g2b93g78b1g773fe3b8ebf1" version="1">Każdy twój atak w dzikiej postaci może zadawać obrażenia zwykłego typu albo obrażenia od światłości. Wybierasz typ obrażeń za każdym razem, gdy trafiasz takim atakiem.</content>
   <content contentuid="h1bf178cfg495fgc014g2a3dg87805ddb3ddc" version="1">Rzucanie czarów jest zablokowane.</content>
   <content contentuid="h112c7e0eg78abgd915gaaeag4b58bbd6c408" version="2">Gdy korzystasz z tej akcji, nie podlegasz ograniczeniu &lt;LSTag Type="Status" Tooltip="ONE_SPELL_WITH_A_SPELL_SLOT_PER_TURN"&gt;Jeden czar z komórką czaru na turę&lt;/LSTag&gt;.</content>
   <content contentuid="h33a18d4cgdf06g9238gf504ge24a7a01dabc" version="1">Gdy wykonujesz rzut na inicjatywę, możesz dodać do wyniku swoją premię z biegłości.</content>
@@ -6534,7 +6532,7 @@ Ponadto obszar emanacji jest trudnym terenem dla twoich wrogów.</content>
   <content contentuid="h510fe56fgce89g4c30g9446g93901bf4db4c" version="1">Dostępne klasy: Mag</content>
   <content contentuid="h8933e173gb36agbf40ge97fg7e76f31c0d5c" version="1">Istotę nawiedzają jej najgorsze koszmary.&lt;br&gt;&lt;br&gt;Otrzymuje [1] na turę i ma &lt;LSTag Tooltip="Disadvantage"&gt;utrudnienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach cech&lt;/LSTag&gt; oraz &lt;LSTag Tooltip="AttackRoll"&gt;testach ataku&lt;/LSTag&gt;.</content>
   <content contentuid="h7d9f76degac92g087cg01abg39b7a8899657" version="1">Jedna wybrana przez ciebie widoczna istota w zasięgu słyszy w swoim umyśle dysonansową melodię. Cel wykonuje rzut obronny na Mądrość. Przy niepowodzeniu otrzymuje obrażenia psychiczne i musi poświęcić swoją następną turę, aby oddalić się od ciebie tak bardzo, jak zdoła. Przy powodzeniu otrzymuje tylko połowę obrażeń.</content>
-  <content contentuid="hbaabf179g575bg3c69g6b39ge57aa643ebf4" version="1">Za każdym razem, gdy otrzymujesz obrażenia od światłości, twój atakujący otrzymuje obrażenia od ognia równe dwukrotności jego własnej premii z biegłości.</content>
+  <content contentuid="hbaabf179g575bg3c69g6b39ge57aa643ebf4" version="1">Za każdym razem, gdy otrzymujesz obrażenia od światłości, atakująca cię istota otrzymuje obrażenia od ognia równe dwukrotności swojej premii z biegłości.</content>
   <content contentuid="hd8f158fcg0f26g89adg3cb8g224c43224f85" version="1">Czar testowy</content>
   <content contentuid="h974a5e6ag1e52gc326gd4b2g92e4681ec152" version="1">Ten czar jest technicznym wpisem bez żadnego działania. Gdy za pomocą zdolności Erudyta wybierasz czar dodawany do księgi, nie można ukończyć awansu, jeśli wszystkie dostępne czary zostały już poznane w inny sposób, na przykład przez przepisywanie zwojów, i nie pozostał żaden możliwy wybór. Ten wpis dodano jako obejście takiej sytuacji.</content>
   <content contentuid="h23556c36gae43g3a3eg0a6fg70a7d3ec3bd8" version="1">Geniusz</content>


### PR DESCRIPTION
## Summary

- standardize Arcane Armor as Magiczny pancerz using the established Polish D&D 2024 term
- align Wild Shape, Dragon Shape, Breath Weapon, spell names, AC/KP, and feature-name casing with the official Polish BG3 localization
- correct semantic and grammatical issues in Strength requirements, Death Saving Throws, Hit Dice, Radiant retaliation, and druid feature descriptions
- remove an introductory sentence from one Wild Recovery handle because it is not present in the English source

## Validation

- 5,355 English entries / 5,355 Polish entries
- no missing, extra, or duplicate handles
- no version, tag, placeholder, coverage, or spell-audit errors
- duplicate English groups have consistent Polish translations
- this PR changes only polish.xml

## Credits

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)