### PR TITLE
Align Polish level feature titles with official BG3 terminology

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -46,14 +46,14 @@ Na określonych poziomach klasy zyskujesz możliwość używania właściwości 
   <content contentuid="ha33a602cg9bb2gec42g889dg5983a5346c84" version="1">Możesz nasycić się pierwotną mocą zwaną &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szałem&lt;/LSTag&gt;, która zapewnia niezwykłą siłę i wytrzymałość. Jeśli nie nosisz ciężkiego pancerza, możesz wpaść w szał w ramach akcji dodatkowej.
 
 Możesz wpadać w szał tyle razy, ile wskazuje kolumna Szały w tabeli cech barbarzyńcy dla twojego poziomu. Jedno zużyte użycie odzyskujesz po krótkim odpoczynku, a wszystkie po długim odpoczynku.</content>
-  <content contentuid="h8abec533g47afgabaag5370ga724a70ed863" version="1">Poziom 1: Obrona nieopancerzona</content>
-  <content contentuid="hfc1b8fd5g336eg3648g3224g9cae0aaac491" version="1">Poziom 2: Poczucie zagrożenia</content>
+  <content contentuid="h8abec533g47afgabaag5370ga724a70ed863" version="1">Poziom 1: Obrona bez pancerza</content>
+  <content contentuid="hfc1b8fd5g336eg3648g3224g9cae0aaac491" version="1">Poziom 2: Wyczucie zagrożenia</content>
   <content contentuid="hb6dea583g9359gddf3g2360g74669f67b1a6" version="1">Poziom 3: Wiedza pierwotna</content>
   <content contentuid="h860b399bg558cg749fgb64bg707d53758400" version="2">Zyskujesz biegłość w innej umiejętności według twojego wyboru z listy umiejętności dostępnych dla Barbarzyńcy na 1. poziomie.
 
 Ponadto, gdy twój &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt; jest aktywny, możesz przekazywać pierwotną moc podczas wykonywania określonych zadań; za każdym razem, gdy wykonujesz test umiejętności przy użyciu jednej z poniższych umiejętności, możesz wykonać go jako test Siły, nawet jeśli normalnie korzysta z innej zdolności: &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Akrobatyka&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Zastraszanie&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Percepcja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Skradanie się&lt;/LSTag&gt; lub &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Sztuka przetrwania&lt;/LSTag&gt;. Kiedy używasz tej zdolności, twoja Siła reprezentuje pierwotną moc przepływającą przez ciebie, doskonalącą twoją zwinność, postawę i zmysły.</content>
   <content contentuid="h3fa58ccfg135bg7a66g14degc3c8b5bb8261" version="1">Poziom 5: Szybki ruch</content>
-  <content contentuid="h7c047839g4177g2aaega022g36a5cb07886a" version="1">Poziom 7: Dziki Instynkt</content>
+  <content contentuid="h7c047839g4177g2aaega022g36a5cb07886a" version="1">Poziom 7: Zwierzęcy instynkt</content>
   <content contentuid="h28d4b453gc36cg810egf9e2g1dbff5d018d8" version="1">Poziom 7: Instynktowny Skok</content>
   <content contentuid="hdb025275gf26dg03dfg7370g4dddf3f0ffb9" version="1">W ramach akcji dodatkowej, którą wykorzystujesz, aby wpaść w &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt;, możesz przemieścić się na odległość równą maksymalnie połowie swojej szybkości.</content>
   <content contentuid="hb6144726g336aga60cg63d6gf6c4bc669e6a" version="1">Poziom 9: Brutalne Uderzenie</content>
@@ -69,23 +69,23 @@ Podcięcie ścięgna. Szybkość celu zostaje zmniejszona o [1] do początku two
   <content contentuid="hcd10eb1fgc367ga39egd371g5e071e079549" version="1">Możesz przemieścić się prosto w stronę celu na odległość nie większą niż połowa swojej szybkości ruchu, nie prowokując ataków okazyjnych.</content>
   <content contentuid="hd5311cf0g6f4fg9a03g45f9gf5ba41e2994c" version="1">Uderzenie w ścięgno podkolanowe</content>
   <content contentuid="hcba666bcgdd43g5b9agef09gdcfd2c3d20ff" version="1">Szybkość jest zmniejszana o [1] do rozpoczęcia następnej tury atakującego.</content>
-  <content contentuid="hebad3866ga362g915cge97fg661e8b92ea36" version="1">Poziom 11: Nieustanna wściekłość</content>
+  <content contentuid="hebad3866ga362g915cge97fg661e8b92ea36" version="1">Poziom 11: Niepowstrzymany szał</content>
   <content contentuid="hfd45d1c1g9dd3g206agfb7eg456c6af02ac0" version="1">Raz na &lt;LSTag Tooltip="ShortRest"&gt;krótki odpoczynek&lt;/LSTag&gt;, jeśli liczba twoich &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt; spadnie do [1] podczas &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szału&lt;/LSTag&gt;, zamiast &lt;LSTag Type="Status" Tooltip="DOWNED"&gt;stracić przytomność&lt;/LSTag&gt;, odzyskujesz punkty wytrzymałości w liczbie równej dwukrotności twojego poziomu barbarzyńcy.</content>
-  <content contentuid="h784061e1gf2a8g748bg99cfg9e391dd4569c" version="1">Poziom 3: Szał</content>
+  <content contentuid="h784061e1gf2a8g748bg99cfg9e391dd4569c" version="1">Poziom 3: Furia</content>
   <content contentuid="hd21b5d53gc033g82abgfcdag21730bb83c68" version="1">Jeśli użyjesz Szaleńczego ataku podczas &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szału&lt;/LSTag&gt;, zadajesz dodatkowe obrażenia pierwszemu celowi trafionemu w swojej turze atakiem opartym na Sile. Aby określić dodatkowe obrażenia, rzuć tyloma k6, ile wynosi twoja premia do obrażeń &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szału&lt;/LSTag&gt;, i zsumuj wyniki. Obrażenia są tego samego typu co obrażenia broni albo ataku bez broni użytego do wykonania ataku.</content>
-  <content contentuid="h7f8570c9g2cd6g2327g3c99g18d5c393bf5e" version="1">Poziom 6: Bezmyślna wściekłość</content>
+  <content contentuid="h7f8570c9g2cd6g2327g3c99g18d5c393bf5e" version="1">Poziom 6: Bezmyślny szał</content>
   <content contentuid="h42189866g05d1g89b4g6e9dg1f97d248b2a9" version="1">Poziom 10: Odwet</content>
   <content contentuid="hde644cc1g1dc6g103bg095ege867e6fa22ad" version="1">Gdy otrzymujesz obrażenia od istoty znajdującej się w promieniu [1] od ciebie, możesz w ramach reakcji wykonać przeciwko niej jeden atak bronią do walki wręcz albo atak bez broni.</content>
   <content contentuid="hc8de1446g6777ge942g7572g5cd9d6cc8f14" version="1">But gigantów</content>
   <content contentuid="hf411e734g4162g32ddg2c68g075dce673ed3" version="1">Spróbuj odrzucić kopnięciem cel. Szanse powodzenia zależą od twojego poziomu Atletyki, przy czym są większe, jeśli twoja postać jest ukryta lub niewidzialna.</content>
   <content contentuid="h5acf268bg7a2dgd7c7g4d2dg20caffe2e8a4" version="1">Możesz kopnąć cel ważący maksymalnie dwa razy więcej niż pozwalałoby &lt;LSTag Type="Spell" Tooltip="Target_Shove"&gt;popchnięcie&lt;/LSTag&gt;.</content>
   <content contentuid="h0e7ef600g82aegeba0g077eg2ddad69731f8" version="1">Otacza cię dzika magia barbarzyńcy. Twoja &lt;LSTag Tooltip="ArmourClass"&gt;Klasa Pancerza&lt;/LSTag&gt; zwiększa się o wartość równą twojej premii do obrażeń szału, dopóki trwa twój &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt;.</content>
-  <content contentuid="hd75d1783g8062gae55g78a6g651f55455f7f" version="1">Poziom 2: Specjalista od wszystkiego</content>
+  <content contentuid="hd75d1783g8062gae55g78a6g651f55455f7f" version="1">Poziom 2: Wszechstronność</content>
   <content contentuid="h6002075bg4feegb25ag03b5g8e88a4351c0f" version="1">Poziom 5: Źródło inspiracji</content>
   <content contentuid="h5d1b01ffgd776g8ca4gd2edgb4e5e0068ad7" version="1">Ponadto możesz zużyć komórkę czaru (bez konieczności użycia akcji), aby odzyskać jedno zużyte użycie bardowskiej inspiracji.</content>
   <content contentuid="h3c4853cag177dg4ea8g0c15gde7e940ee735" version="1">Źródło inspiracji</content>
   <content contentuid="h7c14769cg0f8ag7968g4156g1272fd5b7850" version="3">Zużyj komórkę czaru, aby odzyskać jedno użycie bardowskiej inspiracji.</content>
-  <content contentuid="he36b3403gbab9gf77fg17fbg32e95953478c" version="1">Poziom 7: Przeciwzaklęcie</content>
+  <content contentuid="he36b3403gbab9gf77fg17fbg32e95953478c" version="1">Poziom 7: Przeciwurok</content>
   <content contentuid="h1dedae79g3922gbd27g0925g98aec4318fa7" version="1">Możesz użyć nut muzycznych lub słów mocy, aby zakłócić efekty wpływające na umysł. Gdy tobie lub istocie w promieniu 9 m od ciebie nie powiedzie się rzut obronny przeciwko efektowi nakładającemu stan zauroczenia lub przerażenia, możesz użyć reakcji, by wymusić ponowienie rzutu obronnego. Nowy rzut jest wykonywany z ułatwieniem.</content>
   <content contentuid="hf8844bacg4eb3geecdg5fbagf17d5ba9d6b0" version="1">Przeciwurok</content>
   <content contentuid="h0f358bf7g4a10gc77fg43cfg0c187137ef7a" version="1">Możesz użyć nut muzycznych lub słów mocy, aby zakłócić efekty wpływające na umysł. Gdy tobie lub istocie w promieniu 9 m od ciebie nie powiedzie się rzut obronny przeciwko efektowi nakładającemu stan zauroczenia lub przerażenia, możesz użyć reakcji, by wymusić ponowienie rzutu obronnego. Nowy rzut jest wykonywany z ułatwieniem.</content>
@@ -95,7 +95,7 @@ Podcięcie ścięgna. Szybkość celu zostaje zmniejszona o [1] do początku two
 Ponadto bezpośrednio po rzuceniu czaru ze szkoły uroków lub iluzji z użyciem komórki czaru możesz zmusić istotę, którą widzisz w odległości do [1] od siebie, do wykonania rzutu obronnego na Mądrość przeciwko twojemu ST obrony przed czarami. Przy niepowodzeniu cel otrzymuje wybrany przez ciebie stan zauroczenia albo przerażenia na 1 minutę.</content>
   <content contentuid="he30a14f7gb323g888eg2ff5g04b0a7374497" version="1">Urzekająca magia: Zauroczenie</content>
   <content contentuid="haac5a803g73dfg5282g175eg12c90e9a77cd" version="1">Urzekająca magia: Przerażenie</content>
-  <content contentuid="h1e9e444agc6b5g3056g6b60g447875f0ec07" version="1">Poziom 3: Płaszcz inspiracji</content>
+  <content contentuid="h1e9e444agc6b5g3056g6b60g447875f0ec07" version="1">Poziom 3: Opończa inspiracji</content>
   <content contentuid="hd68a192ag408cg0b94ge1bcgb6efd87c7b6a" version="2">Możesz wpleść magię fey w pieśń albo taniec, aby napełnić innych wigorem. W ramach akcji dodatkowej możesz zużyć jedno użycie bardowskiej inspiracji i rzucić jej kością. Następnie wybierz maksymalnie tyle innych istot w promieniu [1] od siebie, ile wynosi twój modyfikator Charyzmy (co najmniej jedną).
 
 Każda z tych istot zyskuje tymczasowe punkty wytrzymałości w liczbie równej dwukrotności wyniku rzutu kością bardowskiej inspiracji i do końca swojej następnej tury może się przemieszczać bez prowokowania ataków okazyjnych.</content>
@@ -104,7 +104,7 @@ Każda z tych istot zyskuje tymczasowe punkty wytrzymałości w liczbie równej 
   <content contentuid="hf3f5c8f9g2b3bg1058g7715gee2645709a64" version="1">Każda z tych istot zyskuje tymczasowe punkty wytrzymałości w liczbie równej dwukrotności wyniku rzutu kością bardowskiej inspiracji i do końca swojej następnej tury może się przemieszczać bez prowokowania ataków okazyjnych.</content>
   <content contentuid="h52a153aag53d8g2658g72aegc55c7baffc11" version="1">Każda z tych istot zyskuje tymczasowe punkty wytrzymałości w liczbie równej dwukrotności wyniku rzutu kością bardowskiej inspiracji i do końca swojej następnej tury może się przemieszczać bez prowokowania ataków okazyjnych.</content>
   <content contentuid="h530230d7ge34cg06b9g06a3ge16228b8a608" version="1">Każda z tych istot zyskuje tymczasowe punkty wytrzymałości w liczbie równej dwukrotności wyniku rzutu kością bardowskiej inspiracji i może poruszać się bez prowokowania ataków okazyjnych do końca swojej następnej tury.</content>
-  <content contentuid="hcc01542ag2ea8ge230g53b5g6bae54a352d2" version="1">Poziom 3: Cięcie słów</content>
+  <content contentuid="hcc01542ag2ea8ge230g53b5g6bae54a352d2" version="1">Poziom 3: Cięta riposta</content>
   <content contentuid="hfac955c9g640eg8dc8gfdefgfa559fa195f8" version="3">Dodatkowy atak (sztuczka)</content>
   <content contentuid="he6112d47g8846ge668gbd97g45ddd36eeb46" version="1">Możesz atakować dwa razy zamiast raz, gdy wykonujesz akcję Ataku w swojej turze.
 
@@ -158,9 +158,9 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="hb742b3aagabfcg536cg10e0g99bbe354e49a" version="1">Uzdrów istotę w zasięgu, która ma 0 punktów wytrzymałości i nie jest martwa.</content>
   <content contentuid="hd085b0deg3cc9g0858gdf14geef98a4164c3" version="1">Słowo blasku</content>
   <content contentuid="hbb7ccd06g2737gdcf2gc167g21f32c9615fb" version="1">Z ciebie wybucha płonący blask, tworząc emanację o promieniu [1]. Każda wybrana przez ciebie widoczna istota w jej obrębie wykonuje rzut obronny na Kondycję. Przy niepowodzeniu otrzymuje obrażenia od światłości.</content>
-  <content contentuid="hf652a768gef39g78fdg661dg8ddbb887d3f3" version="1">Poziom 3: Uczeń Życia</content>
+  <content contentuid="hf652a768gef39g78fdg661dg8ddbb887d3f3" version="1">Poziom 3: Akolita życia</content>
   <content contentuid="h748a060egc16cg7d82gf97eg22830dd0c9f1" version="1">Gdy rzucony przez ciebie czar z użyciem komórki czaru przywraca istocie punkty wytrzymałości, w turze rzucenia czaru odzyskuje ona dodatkowe punkty wytrzymałości w liczbie równej 2 plus poziom zużytej komórki czaru.</content>
-  <content contentuid="h45db170cgfec9gad8eg1591gd99ec7aa2b2c" version="1">Poziom 6: Błogosławiony Uzdrowiciel</content>
+  <content contentuid="h45db170cgfec9gad8eg1591gd99ec7aa2b2c" version="1">Poziom 6: Błogosławiony uzdrowiciel</content>
   <content contentuid="h6f58f448gfe00g1b2agab56g46c8bf14ca5f" version="1">Czary leczące, które rzucasz na innych, leczą również ciebie. Natychmiast po rzuceniu z użyciem komórki czaru, który przywraca punkty wytrzymałości co najmniej jednej istocie innej niż ty, odzyskujesz punkty wytrzymałości w liczbie równej 2 plus poziom zużytej komórki czaru.</content>
   <content contentuid="hae1dce65g444ag6a6egf7d3g354c47c64531" version="1">Ochrona życia</content>
   <content contentuid="hf73a03f1g9a62g7708g6ac9ge3ea9b45c4a8" version="1">W ramach akcji Magii przedstawiasz swój Święty Symbol i wykorzystujesz swój Akt wiary, aby przywołać uzdrawiającą energię, która może przywrócić liczbę punktów wytrzymałości równą pięciokrotności twojego poziomu Kleryka. Wybierz Zakrwawione istoty w promieniu [1] od siebie (co może obejmować ciebie) i podziel między nie te punkty wytrzymałości.</content>
@@ -205,13 +205,13 @@ Raz w ciągu następnej godziny, gdy istota nie zda testu k20, może rzucić ko�
 Liczba użyć. Możesz obdarzyć istotę kością bardowskiej inspiracji tyle razy, ile wynosi twój modyfikator Charyzmy (co najmniej raz). Wszystkie użycia odzyskujesz po ukończeniu długiego odpoczynku.
 
 Na wyższych poziomach. Kość bardowskiej inspiracji zmienia się po osiągnięciu określonych poziomów Barda, zgodnie z kolumną Kość bardowskiej inspiracji w tabeli cech Barda: na 5. poziomie staje się k8, na 10. poziomie — k10, a na 15. poziomie — k12.</content>
-  <content contentuid="h9e25c63eg08ebg12a0gfefega65d73c0d540" version="1">Poziom 3: Kapłan Wojny</content>
+  <content contentuid="h9e25c63eg08ebg12a0gfefega65d73c0d540" version="1">Poziom 3: Kapłan wojenny</content>
   <content contentuid="h04fd168age75cg9dadgeb9bgce0ceddefc4c" version="1">W ramach akcji dodatkowej możesz wykonać jeden atak bronią albo atak bez broni. Możesz użyć tej akcji dodatkowej tyle razy, ile wynosi twój modyfikator Mądrości (co najmniej raz). Wszystkie użycia odzyskujesz po krótkim albo długim odpoczynku.</content>
   <content contentuid="h3c0eb0ffga3ccgcf65g862bg01f7c36b74b8" version="1">Kapłan wojenny</content>
   <content contentuid="h8686f980g14cdg48cdg0923g21540c804c00" version="1">W ramach akcji dodatkowej możesz wykonać jeden atak bronią albo atak bez broni.</content>
   <content contentuid="h7ea2f219gec23g1a96ga5efgce5d1bc88951" version="1">Ładunki dodatkowych ataków kapłana bojowego</content>
   <content contentuid="ha96c97feg6fd1gc562g799fgde13a4800459" version="1">Zużyto punkt, aby zyskać jeszcze jeden atak w ramach akcji dodatkowej.</content>
-  <content contentuid="h4dc018cagbaa3ga624g7da2g0a6dab9353ce" version="1">Poziom 3: Uderzenie kierowane</content>
+  <content contentuid="h4dc018cagbaa3ga624g7da2g0a6dab9353ce" version="1">Poziom 3: Celny cios</content>
   <content contentuid="ha052e514g0261g1570g0745g00d44f89cc3d" version="1">Gdy ty albo istota w promieniu 9 m od ciebie chybi testem ataku, możesz zużyć jedno użycie Aktu wiary i zapewnić temu testowi premię +10, dzięki czemu atak może trafić. Jeśli w ten sposób wspierasz test ataku innej istoty, musisz użyć reakcji.</content>
   <content contentuid="h81ab1ec4g5097gf34cg7f12g4d040607771b" version="2">Atak kierowany (samodzielny)</content>
   <content contentuid="h900f0f0bgcd61g0708g6d02gf89738f718de" version="1">Poziom 6: Błogosławieństwo Boga Wojny</content>
@@ -360,7 +360,7 @@ Zwiększona wytrzymałość. Możesz dodawać swój modyfikator Mądrości do rz
   <content contentuid="h34197e5dgf2d4g066fgdb45gb041adb38595" version="1">Gdy w ramach akcji dodatkowej używasz Drugiego oddechu, możesz przemieścić się o maksymalnie połowę swojej szybkości bez prowokowania ataków okazyjnych.</content>
   <content contentuid="h32fafe3dg30eeg2c3agc543g698e6d46c741" version="1">Taktyczne przemieszczenie</content>
   <content contentuid="hfd6115a2g072eg747bg10e1gc93f7616eafe" version="1">Gdy w ramach akcji dodatkowej używasz Drugiego oddechu, możesz przemieścić się o maksymalnie połowę swojej szybkości bez prowokowania ataków okazyjnych.</content>
-  <content contentuid="h62511cd9g27d2g5cbcga820gbb50c459d998" version="1">Poziom 9: Niezłomny</content>
+  <content contentuid="h62511cd9g27d2g5cbcga820gbb50c459d998" version="1">Poziom 9: Nieugięcie</content>
   <content contentuid="hb015b8bcg9783ge81ag0118gaa1388097f11" version="2">Gdy nie zdasz rzutu obronnego, możesz uznać go za udany. Po skorzystaniu z tej cechy nie możesz zrobić tego ponownie, dopóki nie ukończysz długiego odpoczynku.</content>
   <content contentuid="h852a89d3g128fga1e5g2fedg98ddac129936" version="1">Gdy nie zdasz rzutu obronnego, możesz uznać go za udany.</content>
   <content contentuid="h858b33e5g3b62g9b7fg692fg50cb883ac903" version="1">Mistrz taktyki: Popchnięcie</content>
@@ -398,10 +398,10 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="hd383ab64gcd01g6437g4439gcce1bcafb30c" version="1">Możesz atakować trzy razy zamiast raz, gdy wykonujesz akcję Ataku w swojej turze.
 
 Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji zamiast jednego z tych ataków.</content>
-  <content contentuid="h66ceeddfg85e7gf6e6g45fdgf681167aa694" version="1">Poziom 10: Poprawiona przewaga w walce</content>
+  <content contentuid="h66ceeddfg85e7gf6e6g45fdgf681167aa694" version="1">Poziom 10: Zwiększona przewaga bojowa</content>
   <content contentuid="h1a9ea1d9gcca2gd533gd087g0e05473a8b97" version="1">Poziom 1: Obrona bez opancerzenia</content>
   <content contentuid="hb6df1fdbgd732gf839g1534g7c3a49d1d89d" version="1">Kiedy nie nosisz zbroi ani nie dzierżysz tarczy, twoja podstawowa klasa pancerza wynosi 10 plus twoje modyfikatory Zręczności i Mądrości.</content>
-  <content contentuid="h9693b20eg4b48g52f3g8ec0gd315398b9984" version="1">Poziom 1: Sztuki walki: Zręczne ataki</content>
+  <content contentuid="h9693b20eg4b48g52f3g8ec0gd315398b9984" version="1">Poziom 1: Sztuki walki: Zwinne ataki</content>
   <content contentuid="h24c5605eg0a01ge915g6899g61b6123a76ea" version="1">Otrzymujesz następujące korzyści, gdy nie używasz broni lub dzierżysz wyłącznie broń mnicha i nie nosisz zbroi ani nie dzierżysz tarczy.</content>
   <content contentuid="h0bdd8181g1932g81d9g02c5g5f889a86df8f" version="1">Poziom 1: Sztuki walki: Kość sztuk walki</content>
   <content contentuid="h8e235ae9geb66g5d58g1353gd372c6850cab" version="1">Otrzymujesz następujące korzyści, gdy nie używasz broni lub dzierżysz wyłącznie broń mnicha i nie nosisz zbroi ani nie dzierżysz tarczy.</content>
@@ -419,8 +419,8 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="h78c4f622gbb2cg3636gb74cg733fbf8d0b37" version="1">Odstąpienie</content>
   <content contentuid="h5248daffg03b1g4eeeg4498gaafc4796eece" version="1">Wykonaj bezpieczny odwrót: twój ruch nie prowokuje &lt;LSTag Tooltip="OpportunityAttack"&gt;ataków okazyjnych&lt;/LSTag&gt;.</content>
   <content contentuid="h62169240g157dg0599gc2d2g3c5611236273" version="1">Poziom 2: Ruch bez opancerzenia</content>
-  <content contentuid="hdd7cc0dcg93b5g2722g9ad5g75eb1fd5edf9" version="1">Poziom 6: Ruch bez opancerzenia</content>
-  <content contentuid="hbb2da776g993fg5373g95abg3f33446175c5" version="1">Poziom 10: Ruch bez opancerzenia</content>
+  <content contentuid="hdd7cc0dcg93b5g2722g9ad5g75eb1fd5edf9" version="1">Poziom 6: Szybkość mnicha</content>
+  <content contentuid="hbb2da776g993fg5373g95abg3f33446175c5" version="1">Poziom 10: Szybkość mnicha</content>
   <content contentuid="hfe07c960gd6d9ga0e1g4facgbbfc0b0a2079" version="1">Poziom 2: Niesamowity metabolizm</content>
   <content contentuid="hfaa042d3gf744gb60fg226bgaec318afadb8" version="1">Odzyskujesz wszystkie wydane punkty skupienia. Następnie rzuć swoją kością Sztuk walki i odzyskaj punkty wytrzymałości w liczbie równej swojemu poziomowi Mnicha plus wynik rzutu.
 
@@ -439,11 +439,11 @@ Jeśli zmniejszy to obrażenia do 0, możesz wydać 1 punkt ki, aby użyć Przek
   <content contentuid="h0f7f1f15gc38bgcaeeg96aegf18e8377c301" version="1">Zmniejsz obrażenia i przekieruj je z powrotem na atakującego.</content>
   <content contentuid="hd8199896gbae1g11ceg6ba1g523b41f8b9ef" version="1">Odbicie ataku: Przekieruj</content>
   <content contentuid="h4487767egdb77g3708g93a8gd0279452056a" version="1">Zmniejsz obrażenia i przekieruj je z powrotem na atakującego.</content>
-  <content contentuid="ha8c51db9g127cg0f8dgf557g402626436b8c" version="1">Poziom 4: Powolny upadek</content>
+  <content contentuid="ha8c51db9g127cg0f8dgf557g402626436b8c" version="1">Poziom 4: Powolne spadanie</content>
   <content contentuid="h726e4c54g614fg70ccg5ebag4c572b51fbe4" version="1">Poziom 6: Wzmocnione Uderzenia</content>
   <content contentuid="h3eabcb35gf264g4f8ag9c30g123cbc8fd2b8" version="3">Za każdym razem, gdy zadajesz obrażenia atakiem bez broni, możesz wybrać, czy zadaje on obrażenia od mocy, czy obrażenia swojego zwykłego typu.</content>
   <content contentuid="hc6a55712gd62cgd5e7g68d8g0007496a3e1e" version="2">Poziom 9: Ruch akrobatyczny</content>
-  <content contentuid="hcb9a361cg3dadgecb2gdae1g23fc5f5c3919" version="1">Poziom 7: Uniki</content>
+  <content contentuid="hcb9a361cg3dadgecb2gdae1g23fc5f5c3919" version="1">Poziom 7: Odskok</content>
   <content contentuid="h33c22a3cg9bbaga9c8g65e2g0701352832a0" version="1">Poziom 10: Zwiększona koncentracja</content>
   <content contentuid="h3bb523e2gc26eg22c2g87e9g4e1e0da5e1af" version="2">Twój Grad ciosów, &lt;LSTag Type="Spell" Tooltip="Shout_PatientDefense"&gt;Cierpliwa obrona&lt;/LSTag&gt; i Krok w powietrzu zyskują następujące korzyści:
 
@@ -453,7 +453,7 @@ Cierpliwa obrona i Krok w powietrzu. Gdy wydajesz punkt skupienia, aby użyć kt
   <content contentuid="hddf40c2dge503g0c52g70e0g81df540da740" version="1">Zwiększone skupienie</content>
   <content contentuid="h96955479gc03cg5656g398ega8e7e632c8a3" version="1">Otrzymujesz liczbę tymczasowych punktów wytrzymałości równą dwóm rzutom twoją kością sztuk walki.</content>
   <content contentuid="hb0d0ae76g515agec5dg8b3fgfef5c6b386f3" version="1">Poziom 10: Samoodnowa</content>
-  <content contentuid="hb6524b85g7c46g835fg5ec8g505bf3a2d396" version="1">Poziom 10: Czystość Ciała</content>
+  <content contentuid="hb6524b85g7c46g835fg5ec8g505bf3a2d396" version="1">Poziom 10: Czystość ciała</content>
   <content contentuid="hc41f1b91gbedcg876fg1542g2c46f2f4be27" version="1">Poziom 3: Sztuki Cienia</content>
   <content contentuid="h62e16743gcb72g9068gb2d0gb1a62ea9d321" version="1">Potrafisz czerpać moc ze Sfery Cieni, dzięki czemu zyskujesz następujące korzyści.
 
@@ -492,7 +492,7 @@ Każda istota w sferze wykonuje rzut obronny na Zręczność. Przy niepowodzeniu
   <content contentuid="hd0321dfag2f41g5984g2a27g4ba878286102" version="1">Poziom 11: Krok Żywiołów</content>
   <content contentuid="h90c565bfgdc8eg1fc2gde60ga457cc60135b" version="1">Dopóki twoja &lt;LSTag Type="Spell" Tooltip="Shout_HarmonyOfFireAndWater"&gt;Harmonia żywiołów&lt;/LSTag&gt; jest aktywna, zyskujesz szybkość lotu i szybkość pływania równe twojej szybkości ruchu.</content>
   <content contentuid="hbe92a07bg1800gd2e8g079fg1e0f39ce73ce" version="1">Integralność ciała</content>
-  <content contentuid="h4feabb8egaa22g3d36gc857g512930772995" version="1">Poziom 6: Całość Ciała</content>
+  <content contentuid="h4feabb8egaa22g3d36gc857g512930772995" version="1">Poziom 6: Integralność ciała</content>
   <content contentuid="hd5f70284g45c5g71b8g7505g337ea5751295" version="1">Zyskujesz zdolność leczenia własnych ran. W ramach akcji dodatkowej możesz rzucić kością sztuk walki. Odzyskujesz punkty wytrzymałości w liczbie równej wynikowi rzutu plus twój modyfikator Mądrości (co najmniej 1 punkt).
 
 Możesz skorzystać z tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości (co najmniej raz), a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
@@ -504,7 +504,7 @@ Możesz skorzystać z tej zdolności tyle razy, ile wynosi twój modyfikator Mą
   <content contentuid="hd97fac61ge406g7715gc8b7g188472b4140a" version="1">Jeśli istota dzierżąca tę broń Ciężką ma Wynik Siły niższy niż [1], ma utrudnienie w testach ataku wykonywanych tą bronią.</content>
   <content contentuid="h73497683g65cdged9eg85abge93a8ba9aede" version="1">Zasada: Wymagana zręczność (ciężka broń dystansowa)</content>
   <content contentuid="h07e8d8cdgee47gf8bdge26eg6ddb468803f3" version="1">Jeśli istota dzierżąca tę ciężką broń ma Zręczność niższą niż [1], ma utrudnienie w testach ataku wykonywanych tą bronią.</content>
-  <content contentuid="hc453b2f8ga64fg8d50g0cb0g4a53f20b32d9" version="2">Poziom 3: Moc przysięgi</content>
+  <content contentuid="hc453b2f8ga64fg8d50g0cb0g4a53f20b32d9" version="2">Poziom 3: Moc Przysięgi</content>
   <content contentuid="ha840fbb3g435eg87ebgd676g3fc781ce7b67" version="1">Możesz kierować energię przysięgi bezpośrednio z Planów Zewnętrznych, używając jej do napędzania magicznych efektów. Zaczynasz od jednego takiego efektu: Boskiego Zmysłu, który opisano poniżej. Inne funkcje Paladyna dają dodatkowe opcje efektu Mocy przysięgi. Za każdym razem, gdy używasz Mocy przysięgi tej klasy, wybierasz, jaki efekt z tej klasy chcesz utworzyć.
 
 Możesz użyć Mocy przysięgi tej klasy dwukrotnie. Odzyskujesz jedno z wykorzystanych użyć, kiedy kończysz krótki odpoczynek, a wszystkie wykorzystane, kiedy kończysz długi odpoczynek. Zyskujesz dodatkowe zastosowanie, gdy osiągniesz poziom Paladyna 11.
@@ -550,7 +550,7 @@ Gdy dosiadasz wierzchowca i otrzymasz obrażenia o wartości co najmniej 4, musi
   <content contentuid="h1b6d335fg71e3g921bg96efgd3563a3e9d4b" version="1">Paladyn i pobliscy sojusznicy mają odporność na obrażenia nekrotyczne, psychiczne i od światłości.</content>
   <content contentuid="he4565ab2g2625gaeb8g694eg929ab02e448c" version="1">Paladyn i pobliscy sojusznicy mają odporność na obrażenia nekrotyczne, psychiczne i od światłości.</content>
   <content contentuid="hae6c4966g7a68ga1edg4bc6gae39ac7aeb6b" version="1">Ty i wszyscy pobliscy sojusznicy macie odporność na obrażenia nekrotyczne, psychiczne i od światłości. Aura znika, jeśli &lt;LSTag Type="Status" Tooltip="DOWNED"&gt;stracisz przytomność&lt;/LSTag&gt;.</content>
-  <content contentuid="h36197b70g60e1g9d30g020ag5ebf5202eade" version="1">Poziom 7: Bezlitosny Mściciel</content>
+  <content contentuid="h36197b70g60e1g9d30g020ag5ebf5202eade" version="1">Poziom 7: Nieugięty mściciel</content>
   <content contentuid="h2c05bd1dg9548g9d0ag66dbgd31ce3af6dab" version="1">Gdy trafisz wroga &lt;LSTag Tooltip="OpportunityAttack"&gt;atakiem okazyjnym&lt;/LSTag&gt;, możesz zmniejszyć jego szybkość do 0 do końca bieżącej tury. W swojej następnej turze twoja &lt;LSTag Tooltip="MovementSpeed"&gt;szybkość ruchu&lt;/LSTag&gt; zwiększa się o [1].</content>
   <content contentuid="hd54cf49fg52f9gc82fg23ddg240455666d75" version="1">Bezlitosny wróg Mściciela</content>
   <content contentuid="h4580d441g9dc0gbc53g7a59g25cce7bd8ba2" version="1">Nie można się poruszać. Stan unieruchomienia wywołany &lt;LSTag Tooltip="OpportunityAttack"&gt;atakiem okazyjnym&lt;/LSTag&gt; Nieugiętego mściciela.</content>
@@ -574,8 +574,8 @@ Liczba rzuceń czaru bez zużywania komórki zwiększa się na określonych pozi
   <content contentuid="h3c5b5f7eg291agf227g9011gc0565f5cdd4d" version="1">W ramach akcji Magii możesz zyskać tymczasowe punkty wytrzymałości w liczbie równej sumie 1k8 i twojego modyfikatora Mądrości (co najmniej 1).</content>
   <content contentuid="hcff76038gf183g3e0cg380cgd7a4d9b485d4" version="1">Łowca</content>
   <content contentuid="hbd354410g485cg7eb3gce6cg2beae2ab9c6b" version="1">Łowcy są niezrównanymi zwiadowcami i tropicielami, którzy pielęgnują głęboką więź z naturą, by skutecznie polować na preferowaną przez siebie zwierzynę.</content>
-  <content contentuid="h051d1aa3gfcbeg10d5g5326g1eec2d4e3962" version="1">Poziom 7: Wyjątkowe szkolenie</content>
-  <content contentuid="he1cd6837ge579g13b4g4394g33ea8c725e00" version="1">Poziom 11: Bestialska Furia</content>
+  <content contentuid="h051d1aa3gfcbeg10d5g5326g1eec2d4e3962" version="1">Poziom 7: Wyjątkowa tresura</content>
+  <content contentuid="he1cd6837ge579g13b4g4394g33ea8c725e00" version="1">Poziom 11: Zwierzęca furia</content>
   <content contentuid="h1fe98af2g42d0g348cga592g953cb60ce5e7" version="2">Poziom 3: Więź towarzysza</content>
   <content contentuid="hb6c39153g0c9dg0ddeg1910g4688906cf811" version="1">Poziom 3: Straszliwa zasadzka</content>
   <content contentuid="h761a2d1bgfaa4g6c2fgbda3g198675b6a886" version="1">Mistrzostwo w sztuce zastawiania przerażających zasadzek zapewnia ci następujące korzyści.
@@ -607,14 +607,14 @@ Działasz dość szybko, by zamienić chybienie w kolejne uderzenie. Gdy chybisz
   <content contentuid="h49585eb0g7c75g3df5g4aacg38e6e664edb2" version="1">W ramach akcji dodatkowej zapewniasz sobie ułatwienie w następnym teście ataku w tej turze. Możesz skorzystać z tej cechy tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
   <content contentuid="hdd434d50g0d94g6819ge916g55203c553e86" version="1">Poziom 7: Niezawodny talent</content>
   <content contentuid="h21f511b2g92a9g1aafg61d4g9e8e4ad1e872" version="1">Poziom 5: Niesamowity unik</content>
-  <content contentuid="he94ba142g4f1bg9badge483g5c206c0854b1" version="1">Poziom 7: Uniki</content>
+  <content contentuid="he94ba142g4f1bg9badge483g5c206c0854b1" version="1">Poziom 7: Odskok</content>
   <content contentuid="h97dd1bbcg1ca7g6953g67d7g155182b6526b" version="1">Potrafisz zręcznie unikać niektórych niebezpieczeństw. Gdy podlegasz efektowi, który pozwala wykonać rzut obronny na Zręczność, aby otrzymać tylko połowę obrażeń, przy powodzeniu nie otrzymujesz żadnych obrażeń, a przy niepowodzeniu — tylko połowę. Nie możesz użyć tej zdolności, jeśli masz stan obezwładnienia.</content>
   <content contentuid="h95ef44fegf44dg26b7g490bg4d2254baeba6" version="1">Gdy podlegasz efektowi, który pozwala ci wykonać rzut obronny na Zręczność, aby otrzymać tylko połowę obrażeń, przy powodzeniu nie otrzymujesz żadnych obrażeń, a przy niepowodzeniu — tylko połowę. Nie korzystasz z tej zdolności, jeśli masz stan obezwładnienia.</content>
   <content contentuid="h0523c40bg9f42g36bcg9e1cg6081c59ba79a" version="1">Poziom 11: Ulepszony ukradkowy atak</content>
   <content contentuid="hd984038eg2324g666bg83degd9c1722e9df2" version="3">Kości obrażeń ukradkowego ataku zwiększają się dodatkowo o [1].</content>
   <content contentuid="h29957e67gbc02g6407ga341g2f35096e19da" version="1">Poziom 9: Magiczna zasadzka</content>
   <content contentuid="hfa85e2b2g9e54g0b5ag0128gfecef70e4d09" version="1">Poziom 3: Kuglarstwo magicznej dłoni</content>
-  <content contentuid="hd3262b0cgdce0gf4d4g8fc6g529f4ebed5df" version="1">Poziom 3: Zabójstwo: Inicjatywa</content>
+  <content contentuid="hd3262b0cgdce0gf4d4g8fc6g529f4ebed5df" version="1">Poziom 3: Skrytobójstwo: Inicjatywa</content>
   <content contentuid="hf4183fbcg8e1dg3584gff57g9ebed1bead51" version="2">Masz ułatwienie przy rzutach na Inicjatywę.</content>
   <content contentuid="he1d36468gaf5dg2d18ge59agffc2c79d636d" version="1">Poziom 3: Zabójstwo: Zaskakujące Uderzenia</content>
   <content contentuid="hf357f8d7g161dg5711g5d18gf26bc2d2273f" version="1">W pierwszej rundzie każdej walki masz ułatwienie w testach ataku przeciwko każdej istocie, która nie wykonała jeszcze tury. Jeśli w tej rundzie trafisz dowolny cel ukradkowym atakiem, otrzymuje on dodatkowe obrażenia typu zadawanego przez broń w liczbie równej twojemu poziomowi łotrzyka.</content>
@@ -634,9 +634,9 @@ Działasz dość szybko, by zamienić chybienie w kolejne uderzenie. Gdy chybisz
   <content contentuid="hae41811bg62eeg0a5bge75bgde45ea1213a3" version="1">W ramach akcji dodatkowej dajesz sobie ułatwienie w następnym teście ataku w bieżącej turze.</content>
   <content contentuid="h6e517fa0g6790g8599ga038gec0254c7fae0" version="1">Poziom 9: Wędrujący cel</content>
   <content contentuid="h4ad37d2fg7e63g64e1g0db3g45844045ca7d" version="1">Użycie Stabilnego celowania nie zmniejsza twojej szybkości do 0.</content>
-  <content contentuid="he1072514g2359gf4c9g9ab0gf2fd8d2183ce" version="1">Poziom 3: Szybkie ręce</content>
+  <content contentuid="he1072514g2359gf4c9g9ab0gf2fd8d2183ce" version="1">Poziom 3: Szybkie dłonie</content>
   <content contentuid="h127592e2g23a4gc43cg2c3fgbbf222b3b2d1" version="1">Możesz użyć Rzutu jako akcji dodatkowej. Możesz użyć Zwoju Czarów jako akcji dodatkowej. Wymagania dotyczące używania Zwoju Czarów pozostają niezmienione.</content>
-  <content contentuid="h3cad8c7eg48eeg5692g23c0g79706df73d92" version="1">Poziom 3: Prace na drugim piętrze</content>
+  <content contentuid="h3cad8c7eg48eeg5692g23c0g79706df73d92" version="1">Poziom 3: Praca na wysokości</content>
   <content contentuid="h2fc3807bg34e4gbdbeg88f4gb50fa0facd7e" version="1">Rzut: Szybka ręka</content>
   <content contentuid="h60ea26b2gbcebg085dg4445g8f07a9d3ff4c" version="1">Paladyn</content>
   <content contentuid="h3bda8161g54fbg0765gf90ag164a1cc634ba" version="1">Twoja Przysięga nakazuje ci walczyć z niesprawiedliwością i nieprawością. Czerpiąc z niej siłę, niesiesz nadzieję w czasach mroku i rozpaczy.</content>
@@ -678,16 +678,16 @@ Czasem magia gwałtownie przybiera na sile i zadaje dodatkowe obrażenia. Prawdo
   <content contentuid="h0475c80dgb3d2g65a0g32e3g51e0604b9fae" version="1">Możesz odprawić ezoteryczny rytuał trwający 1 minutę. Po jego zakończeniu odzyskujesz zużyte komórki czarów Magii Paktu, jednak nie więcej niż liczbę równą połowie twojego maksymalnego limitu (zaokrąglając w górę). Po użyciu tej zdolności nie możesz skorzystać z niej ponownie, dopóki nie zakończysz długiego odpoczynku.</content>
   <content contentuid="hbe38acefg243eg2454ge187g5d1c50d4bb2b" version="2">Poziom 1: Niezwykły Umysł</content>
   <content contentuid="h9958bcb7g9126g6467g3b95g0f07e49ea19d" version="1">Masz ułatwienie w rzutach obronnych na Kondycję wykonywanych w celu utrzymania Koncentracji.</content>
-  <content contentuid="ha12d8231ga51ag15b0gaa53g6e00282dc4a2" version="1">Poziom 1: Pakt Ostrza</content>
-  <content contentuid="he1bd3e3eg338fg58d5g3de3g9be05e9302e7" version="1">Poziom 1: Pakt Łańcucha</content>
-  <content contentuid="h9e2924dag8101gd3b2g68a2g6add03aed4dd" version="1">Poziom 1: Pakt Księgi</content>
-  <content contentuid="h25396b5dgdf7bg8d51g09d5g87f669d3be25" version="1">Poziom 1: Zbroja Cieni</content>
-  <content contentuid="h25cfc459ge325g3d22g7037g9a95573234b1" version="1">Poziom 2: Bolesny Wybuch</content>
+  <content contentuid="ha12d8231ga51ag15b0gaa53g6e00282dc4a2" version="1">Poziom 1: Pakt ostrza</content>
+  <content contentuid="he1bd3e3eg338fg58d5g3de3g9be05e9302e7" version="1">Poziom 1: Pakt łańcucha</content>
+  <content contentuid="h9e2924dag8101gd3b2g68a2g6add03aed4dd" version="1">Poziom 1: Pakt księgi</content>
+  <content contentuid="h25396b5dgdf7bg8d51g09d5g87f669d3be25" version="1">Poziom 1: Pancerz cieni</content>
+  <content contentuid="h25cfc459ge325g3d22g7037g9a95573234b1" version="1">Poziom 2: Bolesne uderzenie</content>
   <content contentuid="h56007d5dgf3f2gc9c2g10eegc2fef230c9e6" version="1">Poziom 2: Diabelski wzrok</content>
   <content contentuid="hf94f288fge015g4a15g6c34g367d15c45d89" version="1">Poziom 2: Mistyczna włócznia</content>
-  <content contentuid="hc803f28bg3024g3fd8gc979gbeb1263f4991" version="1">Poziom 2: Maska wielu twarzy</content>
+  <content contentuid="hc803f28bg3024g3fd8gc979gbeb1263f4991" version="1">Poziom 2: Maska o wielu twarzach</content>
   <content contentuid="ha97e7097gda9cgc3eegbb86g9bf88d36ee68" version="1">Poziom 2: Nieziemski skok</content>
-  <content contentuid="hd47c4e1cg1e7ag651cg8c57g7deb405ec80c" version="1">Poziom 2: Odpychający Wybuch</content>
+  <content contentuid="hd47c4e1cg1e7ag651cg8c57g7deb405ec80c" version="1">Poziom 2: Odpychające uderzenie</content>
   <content contentuid="h425487e0g16b7ga256gb63ag56872a5ea672" version="1">Poziom 5: Mistyczne ugodzenie</content>
   <content contentuid="h4d483577g0d77g722dg50ddga9f231b29ec2" version="1">Raz na turę, gdy trafisz istotę bronią paktu, możesz zużyć komórkę czaru Magii Paktu, aby zadać celowi dodatkowe 1k8 obrażeń od mocy oraz kolejne 1k8 za każdy poziom zużytej komórki. Jeśli cel jest Ogromny lub mniejszy, możesz również nadać mu stan powalenia.</content>
   <content contentuid="hc0ad688dged59g744fgf3e6g1e706f4ee29c" version="1">Poziom 5: Jedność z cieniem</content>
@@ -695,7 +695,7 @@ Czasem magia gwałtownie przybiera na sile i zadaje dodatkowe obrażenia. Prawdo
   <content contentuid="ha794dab4gf433ga08bg7d82gda68964c691c" version="1">Otrzymujesz zdolność dodatkowego ataku tylko dla swojej broni paktu. Dzięki tej zdolności możesz zaatakować tą bronią dwa razy zamiast jednego, gdy wykonujesz akcję Ataku w swojej turze.</content>
   <content contentuid="h0c1dba3ag239egef50g0d52g47241e4e6016" version="1">Poziom 5: Inwestycja Mistrza Łańcucha</content>
   <content contentuid="he5f3196agc9ccg5177gedd9ged594f4d1f5a" version="1">Poziom 5: Dar Głębin</content>
-  <content contentuid="h307a5339gff1ag9485g5387gfb0813a818b3" version="1">Poziom 7: Szepty z grobu</content>
+  <content contentuid="h307a5339gff1ag9485g5387gfb0813a818b3" version="1">Poziom 7: Szept zza grobu</content>
   <content contentuid="hd7310e4agc213gc092gf6fag5e8c8130b34d" version="1">Poziom 9: Dar Obrońców</content>
   <content contentuid="h87d4e985gc3a3g6b66g2385g07e2b48896df" version="1">Możesz rzucić &lt;LSTag Type="Spell" Tooltip="Target_DeathWard"&gt;Osłonę przed śmiercią&lt;/LSTag&gt; bez zużywania &lt;LSTag Tooltip="SpellSlot"&gt;komórki czaru&lt;/LSTag&gt;.</content>
   <content contentuid="hd84b885bge9e8g3573gd4ffg49076a30df65" version="1">Warunek: Czarownik poziomu 2 lub wyższego</content>
@@ -711,27 +711,27 @@ Czasem magia gwałtownie przybiera na sile i zadaje dodatkowe obrażenia. Prawdo
   <content contentuid="ha94435d8g091cgce68gaca4gc20e3eea7844" version="1">Warunek: Czarownik poziomu 5 lub wyższego, Inwokacja Paktu Łańcucha</content>
   <content contentuid="h5c3434c5ge1cfg2712gf301g25080935ac60" version="1">Warunek: Czarownik poziomu 5 lub wyższego, Inwokacja Paktu Księgi</content>
   <content contentuid="h79064293gdc22g33fcgf577g81a7411a9720" version="1">Warunek: Czarownik na 9. poziomie+</content>
-  <content contentuid="hb8aec518g6d45g1454g58cbgbac23fec6617" version="1">Poziom 9: Pijący życie</content>
+  <content contentuid="hb8aec518g6d45g1454g58cbgbac23fec6617" version="1">Poziom 9: Wyssanie życia</content>
   <content contentuid="h35551526g84e1g78f3g1277g241f3a6077bb" version="3">Raz na turę, gdy trafiasz istotę swoją bronią paktu, możesz zadać jej dodatkowe 1k6 obrażeń. Możesz też wydać jedną ze swoich kości wytrzymałości, rzucić nią i odzyskać punkty wytrzymałości w liczbie równej sumie wyniku oraz swojego modyfikatora Kondycji (co najmniej 1 punkt).</content>
   <content contentuid="hb7444fe8g6554g6a31ged37g03cc050ef8d3" version="1">Warunek: Czarownik na 9. poziomie+, Inwokacja Paktu Ostrza</content>
   <content contentuid="hd69af339g9d2bg91b6gba38g8dbeb8503f7b" version="1">Poziom 12: Pożerające Ostrze</content>
   <content contentuid="haf78a66bg2f9bg5fb7g8c9ag5da07aa459f4" version="1">Dodatkowy atak wywołany przez Spragnione Ostrza zapewnia dwa dodatkowe ataki zamiast jednego.</content>
   <content contentuid="hc579ca24g72d1g35dfg46c5g5274d47b30cc" version="1">Warunek: Czarownik na 12. poziomie+, Inwokacja Spragnionego Ostrza</content>
-  <content contentuid="h007cf464gd375gf74bg38ccgdc14ddbc38cf" version="1">Poziom 1: Mowa Bestii</content>
+  <content contentuid="h007cf464gd375gf74bg38ccgdc14ddbc38cf" version="1">Poziom 1: Mowa zwierząt</content>
   <content contentuid="h0f9d1ae5g4592g2f49gb8c7g87c552837f15" version="1">Poziom 1: Zniewalający wpływ</content>
-  <content contentuid="h6657b78egb581g0244g06feg115830c4d5fe" version="1">Poziom 2: Złodziej pięciu losów</content>
+  <content contentuid="h6657b78egb581g0244g06feg115830c4d5fe" version="1">Poziom 2: Złodziej dobrego losu</content>
   <content contentuid="h96b23ed5g9f6eg5ed9gc731gf83643845844" version="1">Warunek: Czarownik poziomu 2 lub wyższego</content>
-  <content contentuid="hda228a0eg1468g0defg7675gfa912f042658" version="1">Poziom 5: Ugruntuj umysł</content>
+  <content contentuid="hda228a0eg1468g0defg7675gfa912f042658" version="1">Poziom 5: Grzęznący umysł</content>
   <content contentuid="h8dd81e23g9a97gc012g10f6g34aea3e1b3be" version="1">Warunek: Czarownik na 5. poziomie lub wyższym</content>
-  <content contentuid="hdb88100cgafa2g940ag4433gb000edb33a07" version="1">Poziom 5: Znak Złego Omenu</content>
+  <content contentuid="hdb88100cgafa2g940ag4433gb000edb33a07" version="1">Poziom 5: Zły omen</content>
   <content contentuid="h1b7fb0eag8d29g4cf4g04fag91b2e056cf0c" version="1">Warunek: Czarownik na 5. poziomie lub wyższym</content>
-  <content contentuid="hda504259gf2e4g3266g40fdge92c642b1182" version="1">Poziom 5: Księga Starożytnych Tajemnic</content>
+  <content contentuid="hda504259gf2e4g3266g40fdge92c642b1182" version="1">Poziom 5: Księga pradawnych tajemnic</content>
   <content contentuid="hdc954407ge07fg170agc027gb3ac7e6afda9" version="1">Warunek: Czarownik na 5. poziomie lub wyższym</content>
-  <content contentuid="h0738ad5cg28e2g4092gfc87gc94c75bc8f5b" version="1">Poziom 7: Straszne Słowo</content>
+  <content contentuid="h0738ad5cg28e2g4092gfc87gc94c75bc8f5b" version="1">Poziom 7: Przerażające słowo</content>
   <content contentuid="h1e82dd96g79f2g67a9g365dgc089cab1b728" version="1">Warunek: Czarownik poziomu 7 lub wyższego</content>
-  <content contentuid="h1fb30dc3ge20dgcb22g34d0gcdd0e387793b" version="1">Poziom 7: Rzeźbiarz Ciała</content>
+  <content contentuid="h1fb30dc3ge20dgcb22g34d0gcdd0e387793b" version="1">Poziom 7: Rzeźbiarz ciała</content>
   <content contentuid="hd6f07d39ge321g7e13gcdabgbcbf12aaa406" version="1">Warunek: Czarownik poziomu 7 lub wyższego</content>
-  <content contentuid="h5ebc0953g6724g72fageab4g7f5682f9fb32" version="1">Poziom 9: Sługi Chaosu</content>
+  <content contentuid="h5ebc0953g6724g72fageab4g7f5682f9fb32" version="1">Poziom 9: Słudzy chaosu</content>
   <content contentuid="hf1a63187g9766gc5aeg0b86g693324a45025" version="1">Warunek: Czarownik na 9. poziomie+</content>
   <content contentuid="h3098d03bg9b76gd04eg7ef8g689022ec62ad" version="1">Inwokacja: Dar Obrońców</content>
   <content contentuid="had9ee1e5g5369g47b5g65c4g37b956523a59" version="1">Myślowy odłamek</content>
@@ -775,8 +775,8 @@ Czasem magia gwałtownie przybiera na sile i zadaje dodatkowe obrażenia. Prawdo
 Na 9. poziomie barda zyskujesz znawstwo w dwóch kolejnych wybranych umiejętnościach, w których masz biegłość.</content>
   <content contentuid="h1d573d0cg0ef8gc58cg5d87gf7b0ce7fc23d" version="1">Poziom 10: Magiczne tajemnice</content>
   <content contentuid="hd5715a4dge184g890agee7ag4f904fb90c6b" version="1">Znasz sekrety rozmaitych tradycji magicznych. Za każdym razem, gdy osiągasz poziom barda — w tym również ten poziom — i zwiększa się wartość w kolumnie Przygotowane czary w tabeli cech barda, możesz wybrać dowolne nowe przygotowane czary z list czarów barda, kleryka, druida i maga. Wybrane czary są dla ciebie czarami barda (listę czarów każdej klasy znajdziesz w jej opisie). Ponadto za każdym razem, gdy zastępujesz czar przygotowany dla tej klasy, możesz zastąpić go czarem z jednej z tych list.</content>
-  <content contentuid="hd4f3b039g6204g1bbagd21fgb72f806b54d8" version="1">Poziom 3: Inspiracja bojowa</content>
-  <content contentuid="hd0e61f8bg955fgda33g3e08gc99c259c8a16" version="1">Poziom 3: Błogosławieństwa wiedzy</content>
+  <content contentuid="hd4f3b039g6204g1bbagd21fgb72f806b54d8" version="1">Poziom 3: Bitewna inspiracja</content>
+  <content contentuid="hd0e61f8bg955fgda33g3e08gc99c259c8a16" version="1">Poziom 3: Błogosławieństwo wiedzy</content>
   <content contentuid="hc9341211ge6c1g1fd9gddbeg13315817fedb" version="1">Zyskujesz biegłość w dwóch wybranych umiejętnościach spośród następujących: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Wiedza tajemna&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;Historia&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Przyroda&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religia&lt;/LSTag&gt;. Zyskujesz znawstwo w obu wybranych umiejętnościach.</content>
   <content contentuid="ha8b64524g7467g0f1eg9214gbd3da8ce6302" version="1">Poziom 1: Znawstwo</content>
   <content contentuid="h75d54fe5g6285g141fgd2b8gca722e196ecc" version="1">Zyskujesz znawstwo w dwóch wybranych umiejętnościach, w których masz biegłość. &lt;LSTag Type="Skills" Tooltip="SleightOfHand"&gt;Zwinne dłonie&lt;/LSTag&gt; i &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Skradanie się&lt;/LSTag&gt; są zalecane, jeśli masz w nich biegłość.
@@ -1626,9 +1626,9 @@ Widzisz w ciemności na odległość do [1].</content>
 Szybka regeneracja. Po wyleczeniu odzyskujesz maksymalną możliwą liczbę &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;.</content>
   <content contentuid="h566e69efg081cg4f88g70abg51276f90b3b7" version="1">Poziom 2: Adept rytuałów</content>
   <content contentuid="h1edea2d1ga8eeg0549g7c32g5718c99dd110" version="1">Na poziomach Maga 2, 4 i 7 dodajesz jedno wybrane czar rytualne do swojej księgi czarów i jest ono zawsze przygotowane.</content>
-  <content contentuid="h7e928dcfg9f9cg0dd6g966egff06f62b9e21" version="2">Poziom 3: Potężny sztuczka</content>
+  <content contentuid="h7e928dcfg9f9cg0dd6g966egff06f62b9e21" version="2">Poziom 3: Potężna sztuczka</content>
   <content contentuid="h480dcb8bge39dg992bgfa3bg9f0cf957ce9c" version="1">Poziom 6: Rzeźbienie czarów</content>
-  <content contentuid="h4df2acb8g6e7eg6b07ga5afg05bc5f965277" version="1">Poziom 10: Wzmocniona Ewokacja</content>
+  <content contentuid="h4df2acb8g6e7eg6b07ga5afg05bc5f965277" version="1">Poziom 10: Wzmocnione wywoływanie</content>
   <content contentuid="haf5be1bagceecg0615g9988g0af66eb534ad" version="1">Wywoływacz</content>
   <content contentuid="h135ef26bgf199g1ad5g7571gfe75a8983f9c" version="2">Twoje studia koncentrują się na magii, która tworzy potężne efekty żywiołów, takie jak przenikliwy chłód, palący płomień, grzmiący huk, trzaskające pioruny i żrący kwas. Niektórzy Wywoływacze znajdują zatrudnienie w siłach militarnych, służąc jako artyleria do niszczenia armii z daleka. Inni używają swojej mocy, by chronić innych, podczas gdy niektórzy dążą do własnych korzyści.</content>
   <content contentuid="ha6d01a56gfaf0g86a4g2382g2a35c4b61006" version="1">Styl walki: Strzelectwo</content>
@@ -1960,15 +1960,15 @@ Osłona trwa, dopóki nie zakończysz długiego odpoczynku lub nie użyjesz tej 
   <content contentuid="h063372f4g1033g08f6g55abgb32a96fe2615" version="1">Osłonę reprezentuje tyle k8, ile punktów zaklinania wydano na jej utworzenie. Gdy osłonięta istota otrzymuje obrażenia, może zużyć dowolną liczbę tych kości i nimi rzucić, aby zmniejszyć obrażenia o sumę wyników.</content>
   <content contentuid="hfc97be68g0890g2eb4g60ceg4fcde289a6f3" version="1">Poziom 3: Smocza Odporność</content>
   <content contentuid="h1f6491c1gcf0ag5432gd45cg4c396aeb83ed" version="1">Części twojego ciała pokrywają również łuski przypominające smocze. Gdy nie nosisz pancerza, twoja bazowa Klasa Pancerza wynosi 10 plus twoje modyfikatory Zręczności i Charyzmy.</content>
-  <content contentuid="h7a832abfgfed6g1f5fgab2ag1ba65771f70f" version="1">Poziom 3: Fale Chaosu</content>
+  <content contentuid="h7a832abfgfed6g1f5fgab2ag1ba65771f70f" version="1">Poziom 3: Pływy chaosu</content>
   <content contentuid="h5d220f70g754fg8fc3g0596ge5dd3a6a27a9" version="1">Możesz manipulować samym chaosem, aby zapewnić sobie ułatwienie w jednym teście k20, zanim rzucisz k20. Gdy to zrobisz, musisz rzucić czar Zaklinacza z komórką czaru lub zakończyć długi odpoczynek, zanim będziesz mógł ponownie skorzystać z tej zdolności.
 
 Jeśli rzucisz czar Zaklinacza z komórką czaru przed zakończeniem długiego odpoczynku, automatycznie rzucasz na tabelę Przypływu dzikiej magii.</content>
-  <content contentuid="hdc8c75ffg7a02g2926g526bgd090debe8ddf" version="1">Poziom 3: Dziki Przypływ Magii</content>
+  <content contentuid="hdc8c75ffg7a02g2926g526bgd090debe8ddf" version="1">Poziom 3: Przypływ dzikiej magii</content>
   <content contentuid="h4f44c253geed3g7c67g3a13g4d233307de70" version="1">Twoje czarowanie może uwolnić wybuchy dzikiej magii. Raz na turę, możesz rzucić 1k20 bezpośrednio po rzuceniu czaru Zaklinacza za pomocą Komórki Czaru. Jeśli wyrzucisz 20, rzuć na tabeli Przypływu Dzikiej Magii, aby stworzyć efekt magiczny.</content>
   <content contentuid="h244e3990gdb04g5925g28c5g71c83b2f29f9" version="1">Pływy chaosu</content>
   <content contentuid="h552c9325gee4bg961cg2d50g7acb0983f1ce" version="1">Dostępność użycia Pływów chaosu.</content>
-  <content contentuid="h3cab5040g2f51gf20bg9f65ge152e797670f" version="1">Poziom 6: Nakręć szczęście</content>
+  <content contentuid="h3cab5040g2f51gf20bg9f65ge152e797670f" version="1">Poziom 6: Naginanie szczęścia</content>
   <content contentuid="h3fa61546gfe2agba6cga260g8953a67a0644" version="1">Poziom 11: Kontrolowany chaos</content>
   <content contentuid="h7e8a436fg7af5g1f7eg57f2g2e9aeaf85bd9" version="1">Poziom 6: Powinowactwo żywiołów (obrażenia)</content>
   <content contentuid="hd62b7853g8592g9285gb42bgac6b36b210fb" version="1">Poziom 6: Powinowactwo żywiołów (odporność)</content>
@@ -1987,7 +1987,7 @@ Ponadto za każdym razem, gdy rzucasz ten czar, możesz wybrać jeden z poniższ
 Ożywczy krok. Natychmiast po teleportacji ty i jedna widoczna istota w promieniu 3 m od ciebie zyskujecie po 1k10 tymczasowych punktów wytrzymałości.
 
 Prowokujący krok. Istoty w promieniu 3 m od opuszczonego przez ciebie pola muszą wykonać udany rzut obronny na Mądrość przeciwko twojemu ST obrony przed czarami. W przeciwnym razie do początku twojej następnej tury mają utrudnienie w testach ataku przeciwko istotom innym niż ty.</content>
-  <content contentuid="h6115b3f2g010ag8559g7318gc2394c1971ed" version="1">Poziom 6: Mglista ucieczka</content>
+  <content contentuid="h6115b3f2g010ag8559g7318gc2394c1971ed" version="1">Poziom 6: Ucieczka w mgłę</content>
   <content contentuid="h6dbe3baeg32b7g2be3gc059gc25854510170" version="3">Możesz rzucić Krok przez mgłę w ramach reakcji, gdy otrzymujesz obrażenia.
 
 Ponadto zyskujesz następujące opcje Kroków fey.
@@ -2067,8 +2067,8 @@ Możesz użyć tej cechy tyle razy, ile wynosi twoja premia z biegłości, a wsz
   <content contentuid="hde74c01eg8bb3gbf23g8416g7da16527c0d5" version="1">Błogosławieństwo Mrocznego</content>
   <content contentuid="he0b3dcccga1b5gd89bgf47ag768a98964bc3" version="1">Gdy ktoś inny niż ty sprowadzi istotę w promieniu 3 m od ciebie do 0 punktów wytrzymałości, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej sumie twojego modyfikatora Charyzmy i poziomu czarownika (co najmniej 1).</content>
   <content contentuid="hbbedb4f1g60d4g6ed0gb97bg90c73d16c026" version="1">Poziom 6: Własne szczęście Mrocznego</content>
-  <content contentuid="h975e39acg9a17g2ad0g477cgf30fdb0bf07d" version="1">Poziom 10: Diabelska odporność</content>
-  <content contentuid="hbfafa7a4g3ea7g96f1gcfebg2da208843ab2" version="1">Poziom 3: Śmiertelne Przypomnienie</content>
+  <content contentuid="h975e39acg9a17g2ad0g477cgf30fdb0bf07d" version="1">Poziom 10: Czarcia odporność</content>
+  <content contentuid="hbfafa7a4g3ea7g96f1gcfebg2da208843ab2" version="1">Poziom 3: Śmiertelne przypomnienie</content>
   <content contentuid="h2af9e353ga54bg35f7gcc87g05adfcd9b61a" version="1">Poziom 6: Entropiczna ochrona</content>
   <content contentuid="he825a41dg5c3bgb501g5e02gc52e109b7efa" version="1">Poziom 10: Tarcza Myśli</content>
   <content contentuid="hbb495285gca5fg5ea5g19a8g7daed758d05f" version="1">Nikt nie może odczytać twoich myśli telepatycznie ani w inny sposób, chyba że na to pozwolisz. Masz również odporność na obrażenia psychiczne, a gdy istota zadaje ci takie obrażenia, otrzymuje taką samą ich liczbę.</content>
@@ -2091,7 +2091,7 @@ Po użyciu tej zdolności nie możesz użyć jej ponownie do zakończenia krótk
   <content contentuid="h3c6667d4gfa1bgc9b9g5be0gb270c5c555d5" version="1">Istota otrzymuje od czarującego dodatkowe [1]. Ma też &lt;LSTag Tooltip="Disadvantage"&gt;utrudnienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; Mądrości i &lt;LSTag Tooltip="SavingThrow"&gt;rzutach obronnych&lt;/LSTag&gt; na Mądrość.</content>
   <content contentuid="hb09d35e6g4dd1g0784g8c7fgc7f20e0d9670" version="1">Plugawy urok: Charyzma</content>
   <content contentuid="h99239365g1e0eg35cfgc2edg0a2bbfb668ae" version="1">Istota otrzymuje od czarującego dodatkowe [1]. Ma też &lt;LSTag Tooltip="Disadvantage"&gt;utrudnienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="AbilityCheck"&gt;testach&lt;/LSTag&gt; Charyzmy i &lt;LSTag Tooltip="SavingThrow"&gt;rzutach obronnych&lt;/LSTag&gt; na Charyzmę.</content>
-  <content contentuid="h2fccb783g0014g25e8g73fbg7879e3ab30ce" version="1">Poziom 10: Iluzoryczne Ja</content>
+  <content contentuid="h2fccb783g0014g25e8g73fbg7879e3ab30ce" version="1">Poziom 10: Iluzyjny sobowtór</content>
   <content contentuid="hd251b05fg755bge84dgf97egf45679814510" version="1">Gdy istota trafia cię testem ataku, możesz w ramach reakcji stworzyć między sobą a napastnikiem swojego iluzorycznego sobowtóra. Atak automatycznie chybia, po czym iluzja znika.
 
 Po użyciu tej cechy nie możesz zrobić tego ponownie, dopóki nie ukończysz krótkiego albo długiego odpoczynku. Możesz również odnowić jej użycie, zużywając komórkę czaru co najmniej 2. poziomu.</content>
@@ -2827,7 +2827,7 @@ Zyskujesz także biegłość w jednej z wybranych umiejętności: &lt;LSTag Type
   <content contentuid="h2882b8f2g2c4dg9432gc6b0gd97aa3d6ec17" version="1">Teleportujesz się do widocznego, niezajętego miejsca w promieniu 9 m i do końca swojej następnej tury przybierasz półmaterialną postać. W tej postaci masz odporność na obrażenia obuchowe, kłute i cięte oraz niewrażliwość na Powalenie i Unieruchomienie.</content>
   <content contentuid="hab8ce398geb65gdcbbgc14ega6cd5dd5da1c" version="1">Aura żywiołowej osłony</content>
   <content contentuid="h9b2090d2g2df9ga6b6g06e6g8c2dc62f5763" version="1">Mają odporność na obrażenia od kwasu, zimna, ognia, elektryczności i dźwięku.</content>
-  <content contentuid="hd699c237g9c18g83b1g6f1dg6cc399770254" version="1">Poziom 3: Pieśń Ostrzy</content>
+  <content contentuid="hd699c237g9c18g83b1g6f1dg6cc399770254" version="1">Poziom 3: Pieśń klingi</content>
   <content contentuid="h3b87eea0g36e0gf638g04c0gc6f56f797e73" version="2">W ramach akcji dodatkowej przywołujesz elfią magię zwaną Pieśnią Ostrzy, pod warunkiem że nie nosisz zbroi ani nie używasz Tarczy.
 
 Pieśń Ostrzy trwa 1 minutę i kończy się wcześniej, jeśli masz stan obezwładnienia, jeśli nosisz zbroję lub Tarczę, lub jeśli używasz dwóch rąk do ataku bronią. Możesz odrzucić Pieśń Ostrzy w dowolnym momencie (nie jest wymagane żadne działanie).
@@ -2849,7 +2849,7 @@ Kunszt klingi. Gdy atakujesz bronią, którą biegle się posługujesz, możesz 
 Skupienie. Gdy wykonujesz rzut obronny na Kondycję, aby utrzymać Koncentrację, możesz dodać do wyniku swój modyfikator Inteligencji.</content>
   <content contentuid="h55238b55g2b39g51dcg5270gfe86eeeec5e8" version="1">Kunszt klingi</content>
   <content contentuid="hede9123cg6b75g7af2ge6a9g09aa7751575f" version="1">Gdy atakujesz bronią, którą biegle się posługujesz, możesz używać modyfikatora Inteligencji zamiast Siły albo Zręczności w testach ataku i rzutach na obrażenia.</content>
-  <content contentuid="h2bf11353gf199g41edg8f9eg584aaad22078" version="1">Poziom 3: Szkolenie w zakresie wojny i pieśni</content>
+  <content contentuid="h2bf11353gf199g41edg8f9eg584aaad22078" version="1">Poziom 3: Szkoła boju i pieśni</content>
   <content contentuid="h352f38e9g6190gf239gf947g79ecb474c84f" version="1">Zyskujesz biegłość we wszystkich żołnierskich broniach do walki wręcz, które nie mają właściwości Dwuręczna ani Ciężka. Możesz używać broni do walki wręcz, którą biegle się posługujesz, jako magicznego skupienia dla swoich czarów maga.
 
 Zyskujesz też biegłość w jednej wybranej umiejętności spośród następujących: &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Akrobatyka&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Athletics"&gt;Atletyka&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Występy&lt;/LSTag&gt; albo &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Perswazja&lt;/LSTag&gt;.</content>
@@ -3310,7 +3310,7 @@ Niektóre dobrodziejstwa wymagają minimalnego poziomu Illriggera. Kiedy osiągn
   <content contentuid="h8fd47ec3gac34g4144g6243g234bbbbbb9ae" version="2">Cel musi wykonać rzut obronny na Kondycję. Przy niepowodzeniu otrzymuje [1], a ty odzyskujesz punkty wytrzymałości w liczbie równej zadanym obrażeniom. Przy powodzeniu cel otrzymuje połowę tych obrażeń, a ty odzyskujesz punkty wytrzymałości w liczbie równej zadanym obrażeniom.</content>
   <content contentuid="h6b7c5b42gc865g9a66g25bcgcf6498b47b95" version="1">Ożywiaj</content>
   <content contentuid="ha334fba5ge039gfb31g1b15g55b8f07d80f4" version="1">Poświęć połowę swoich pozostałych &lt;LSTag Tooltip="HitPoints"&gt;punktów wytrzymałości&lt;/LSTag&gt;, aby przywrócić celowi taką samą ich ilość.</content>
-  <content contentuid="h29248f55g9799g09d8ge529g06704f76d155" version="1">Poziom 10: Cena krwi</content>
+  <content contentuid="h29248f55g9799g09d8ge529g06704f76d155" version="1">Poziom 10: Krwawa zapłata</content>
   <content contentuid="h6bdae4c0g3fcdg259fgefa5g636614568bc0" version="1">Możesz wzmocnić swoją obronę kosztem żywotności. Za każdym razem, gdy nie powiedzie ci się rzut obronny, możesz wydać jedną ze swoich kości wytrzymałości, rzucić nią i dodać wynik do tego rzutu obronnego.</content>
   <content contentuid="h8a78754bge4a1gbe50g8f26g0bd670acd7cc" version="1">Cena krwi: k8</content>
   <content contentuid="h357af6fegcc60g52adgea2agd98b8ed57793" version="1">Cena krwi: k6</content>
@@ -3542,7 +3542,7 @@ Magia podlega mojej woli. Przebiegłość jest równie potężna jak stal. Wład
   <content contentuid="h31f01a11ge447g9caegdcb4g2adfe1ce29e6" version="1">Raz na każdą swoją turę możesz rzucić jedną ze swoich sztuczek illriggera zamiast jednego z ataków zapewnianych przez zdolność Dodatkowego Ataku.</content>
   <content contentuid="h9727eb4bg1c42g18b1gb937gf2efc10d9fec" version="2">Poziom 7: Pieczęcie aksjomatyczne</content>
   <content contentuid="h2bafe613g30e6g3792g15edgaa3d3658c4b6" version="1">Sekrety Asmodeusza pozwalają ci napełnić twoje pieczęcie jawną mocą. Kiedy spalisz jedną lub więcej pieczęci, aby zadać obrażenia istocie, możesz aktywować tę łaskę (nie jest wymagana żadna akcja), aby dodać swój modyfikator Charyzmy (co najmniej 1) do rzutu na obrażenia każdej pieczęci.</content>
-  <content contentuid="h528f5094gf88ag08d3ge649gc14b423059e7" version="2">Poziom 11: Prześlij</content>
+  <content contentuid="h528f5094gf88ag08d3ge649gc14b423059e7" version="2">Poziom 11: Ulegnij</content>
   <content contentuid="h0688f440gd1d1g007egd6e0g79bf22aff2aa" version="1">Kiedy rzucisz czar illriggera, możesz spalić dwie pieczęcie na przeklętej istocie (nie jest wymagana żadna akcja), aby utrudnić jego rzut obronny na czar.</content>
   <content contentuid="h8c14193dg02e1g6afbg94c5g63fe44038fa3" version="1">Pieczęcie aksjomatyczne: Ogień</content>
   <content contentuid="h3e91d02cg9178geb72g919bgd2f45a5bb6ea" version="1">Pieczęcie aksjomatyczne: nekrotyczne</content>
@@ -3722,14 +3722,14 @@ Z tej reakcji możesz skorzystać tyle razy, ile wynosi twój modyfikator Inteli
   <content contentuid="h90c82523g4a46gb71ag6f88gc835ddaae5d8" version="1">Poziom 2: Gogle Nocy</content>
   <content contentuid="h10e5725bg4bd0g61f2g780ag5b6d6bf91837" version="1">Poziom 2: Magiczna Tarcza</content>
   <content contentuid="hef24c59dg255fg00dag4607gcb6c909dc686" version="1">Poziom 2: Różdżka Maga Wojny</content>
-  <content contentuid="h2b9135b0g2582g6163g9b6dgc3583a49f204" version="1">Poziom 2: Magiczna Broń</content>
+  <content contentuid="h2b9135b0g2582g6163g9b6dgc3583a49f204" version="1">Poziom 2: Magiczna broń</content>
   <content contentuid="ha154c820gb9fcg9b4bgb15fg12ccad5e4c6d" version="1">Poziom 2: Okłady Nieuzbrojonej Mocy</content>
   <content contentuid="h4dd05c9eg77b9gce4fg1fc8gd73ab0ee9845" version="1">Poziom 6: Magiczna Zbroja</content>
   <content contentuid="hc0a46c23g2511gfbe6g798dg1af91d95f246" version="1">Poziom 6: Hełm Świadomości</content>
   <content contentuid="hc5dd5954g8435gfe43ga00fgee1b1e264b58" version="1">Poziom 6: Wyostrzacz umysłu</content>
   <content contentuid="h8ca2e942gfe74g20f3g5b03gaaa73c5316d3" version="1">Poziom 10: Pancerz Oporu</content>
-  <content contentuid="h33216644g8040g2af7g56f4g08c88f2466f6" version="1">Poziom 10: Pierścień Wolnej Akcji</content>
-  <content contentuid="h68b7dd57g5b1fg1c11g6a7egfa0f952d5948" version="1">Poziom 10: Pierścień Ochrony</content>
+  <content contentuid="h33216644g8040g2af7g56f4g08c88f2466f6" version="1">Poziom 10: Pierścień swobodnego działania</content>
+  <content contentuid="h68b7dd57g5b1fg1c11g6a7egfa0f952d5948" version="1">Poziom 10: Pierścień ochrony</content>
   <content contentuid="h0cdde128gb8edgf880g31f8gff48fb784ff2" version="1">Poziom 6: Latarnia Odkrycia</content>
   <content contentuid="hde22d914g9417gd953g3098g37bd1907e34c" version="1">Replikacja magicznego przedmiotu</content>
   <content contentuid="h4b191d6dgbd05g6ddag5c61g939a2ce25012" version="1">Poznajesz tajemne plany magicznych przedmiotów, co pozwala ci tworzyć ich repliki i przekazywać je sobie lub swoim sojusznikom. Replikowany magiczny przedmiot traci swoją magię po zakończeniu długiego odpoczynku.
@@ -4682,7 +4682,7 @@ Ty i twoi sojusznicy znajdujący się w projekcji zyskujecie premię +2 do rzut�
   <content contentuid="h822a72b8g17f5g73a6gd5f7g245ac996eb94" version="1">Po osiągnięciu poziomu Zaklinacza wskazanego w tabeli Czarów Cienia zawsze masz przygotowane wymienione w niej czary: na 3. poziomie — &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Zguba&lt;/LSTag&gt;, Ciemność, Zadawanie ran i Przejście bez śladu; na 5. poziomie — Głód Hadara i Strach; na 7. poziomie — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Większa niewidzialność&lt;/LSTag&gt; i Urojony zabójca; a na 9. poziomie — &lt;LSTag Type="Spell" Tooltip="Target_Contagion"&gt;Zaraza&lt;/LSTag&gt; i Zabójcza chmura.</content>
   <content contentuid="hce90f19eg2ee2g0ff4g4c21g7ebf85d46c9d" version="1">Na 3. poziomie zawsze masz przygotowane Zgubę, Ciemność, Zadawanie ran i Przejście bez śladu; na 5. poziomie — Głód Hadara i Strach; na 7. poziomie — &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Większą niewidzialność&lt;/LSTag&gt; i Urojonego zabójcę; a na 9. poziomie — Zarazę i Zabójczą chmurę.</content>
   <content contentuid="h312226b3g88ffg25afg2137g749c468fee54" version="1">Poziom 3: Oczy ciemności</content>
-  <content contentuid="ha1f41cf1g38dagde18ga234gcff8d509b5e3" version="1">Poziom 3: Siła grobu</content>
+  <content contentuid="ha1f41cf1g38dagde18ga234gcff8d509b5e3" version="1">Poziom 3: Siła znad grobu</content>
   <content contentuid="h8169cd0cg492cg6dbeg7bafg507ce72f8ac4" version="1">Czary Cienia</content>
   <content contentuid="hae8c9a5cgf06dg6b71gb093ge2e25716f7d2" version="1">Twoja wrodzona magia wywodzi się z najbardziej mglistych i nieprzeniknionych mocy Sfery Cieni albo z innych krain nadprzyrodzonego mroku. Być może pochodzisz od istoty z takiego miejsca albo przemienia cię złowroga energia smoka cienia. Twoja cienista magia pozwala ci władać ciemnością, nieumarłością i niedolą.</content>
   <content contentuid="h442cd917g6095gef57g713bg55e902c18ad3" version="1">Dzika magia</content>
@@ -4740,9 +4740,9 @@ Zwoje Ożywianie są zawsze zwolnione z tego ograniczenia i mogą być używane 
   <content contentuid="h06f01e3agcbd9g2520gaaf4g5e982034ef42" version="1">Wybierz chętnego sojusznika, który cię zobaczy lub usłyszy, oraz wroga, którego ten sojusznik ma zaatakować, a następnie wydaj jedną kość przewagi. Twój sojusznik może natychmiast użyć swojej reakcji, aby wykonać jeden atak bronią przeciwko wybranemu wrogowi, dodając Kość Przewagi do rzutu obrażeń ataku przy trafieniu.</content>
   <content contentuid="h1af1fe5bg50e6g268fgff66g9f945c926502" version="1">Cel uderzeniowy dowódcy</content>
   <content contentuid="h71081eb5g3790g2aa9g3de0g457518c610e4" version="1">Rozkaz ataku</content>
-  <content contentuid="h9570e7b5gd9ceg5a34g04aagac5235955484" version="1">Poziom 6: Eksperckie wróżenie</content>
+  <content contentuid="h9570e7b5gd9ceg5a34g04aagac5235955484" version="1">Poziom 6: Wprawny wieszcz</content>
   <content contentuid="h15504b2agf3a9gc7f3g51e1g6775163e7006" version="1">Gdy za pomocą komórki co najmniej 2. poziomu rzucasz czar ze szkoły Wieszczenia, odzyskujesz jedną zużytą komórkę czaru o jeden poziom niższą od użytej do rzucenia tego czaru. Za pomocą tej cechy nie możesz odzyskać komórki wyższej niż 5. poziomu.</content>
-  <content contentuid="hae8e8ce3g458fg9150gdb09g00c46fe3fe62" version="1">Poziom 3: Zwiastun</content>
+  <content contentuid="hae8e8ce3g458fg9150gdb09g00c46fe3fe62" version="1">Poziom 3: Omen</content>
   <content contentuid="hd419a5dcg621bg5ccagb91bgf4b3862d5fde" version="1">Wieszcz</content>
   <content contentuid="h082d1855ga658g2a35g05a7g0252200ad020" version="1">Porady wieszcza zasięgają ci, którzy pragną lepiej zrozumieć przeszłość, teraźniejszość i przyszłość. Jako wieszcz starasz się uchylić zasłony przestrzeni, czasu i świadomości. Dążysz do opanowania czarów pozwalających dostrzegać to, co ukryte, widzieć odległe miejsca, zdobywać nadprzyrodzoną wiedzę i przewidywać przyszłość.</content>
   <content contentuid="hff219b81gb634gcfe0g4f39gf3e454dd21c9" version="1">Mag odpychania</content>
@@ -4848,7 +4848,7 @@ Podczas rzucania tego czaru możesz wskazać istoty, na które nie będzie on dz
   <content contentuid="h1d580cb5gc915g8f13g3f12g57d46d07e991" version="2">Zniknie do czerni</content>
   <content contentuid="h0e8b7698gbb37g834bge366g5db24efbb56c" version="1">W ramach akcji dodatkowej możesz magicznie zyskać niewidzialność na 1 minutę.</content>
   <content contentuid="h7eca827eg60a1g2e15ga615g5750ad9f5621" version="1">Zniknie do czerni</content>
-  <content contentuid="h075cad75ge0b8g8089g7a0bge757b2193df5" version="1">Poziom 10: Boska Interwencja</content>
+  <content contentuid="h075cad75ge0b8g8089g7a0bge757b2193df5" version="1">Poziom 10: Boska interwencja</content>
   <content contentuid="h8dfac8b3gdd9aga779ga229g8159a97e610e" version="2">Kiedy wzywasz swoje bóstwo do Boskiej Interwencji, twój bóg odpowiada, przywracając część twojej boskiej mocy. Natychmiast odzyskujesz jedną komórkę czaru 5. poziomu.</content>
   <content contentuid="hb220d543g0de9ga76cg8f82gc0f939ce0a89" version="1">Ulepszony ochronny rozbłysk</content>
   <content contentuid="he222d284gfebfg2d88g1574g14e9d5ea7c35" version="1">Zyskaj tymczasowe punkty wytrzymałości równe 2k6 + modyfikator Mądrości Kleryka.</content>
@@ -6022,11 +6022,11 @@ Rządź żelazną pięścią. Kiedy już zwyciężysz, nie toleruj sprzeciwu. Tw
 Siła przede wszystkim. Będziesz rządził, dopóki nie powstanie silniejszy. Musisz więc stać się potężniejszy i stawić czoła wyzwaniu, w przeciwnym razie popadniesz w ruinę.</content>
   <content contentuid="h903867a1g3cfdg2b4fge6ebg7a3e79936727" version="1">Poziom 3: Czary Przysięgi Podboju</content>
   <content contentuid="hbf3f7449g1ed3gab0dgc670g9f81ada8e42a" version="1">Paladyni, którzy złożą Przysięgę Podboju, uzyskują dostęp do Zbroi Agathys i Rozkazu na 3. poziomie, Unieruchomienia osoby i Duchowej broni na 5. poziomie oraz Nałożenia klątwy i Strachu na 9. poziomie.</content>
-  <content contentuid="ha9bb3551ge412g5c19g5e97g106901d50282" version="1">Poziom 3: Pokonywanie obecności</content>
+  <content contentuid="ha9bb3551ge412g5c19g5e97g106901d50282" version="1">Poziom 3: Ujarzmiająca obecność</content>
   <content contentuid="h5bee8c93gf2c8gd340g65cfge6d42d8c4a32" version="2">Możesz użyć Mocy przysięgi, aby emanować aurą grozy. Zmuszasz każdą wybraną przez siebie widoczną istotę w promieniu 9 m od ciebie do wykonania rzutu obronnego na Mądrość. Przy niepowodzeniu istota otrzymuje stan przerażenia na 1 minutę. Na koniec każdej swojej tury może powtórzyć rzut obronny; powodzenie kończy ten stan.</content>
-  <content contentuid="h996c924egb5b7g1b84g76a7g77794f881ec6" version="1">Poziom 3: Uderzenie kierowane</content>
+  <content contentuid="h996c924egb5b7g1b84g76a7g77794f881ec6" version="1">Poziom 3: Celny cios</content>
   <content contentuid="h0f884270g61b3g274fg3068g30e5ff265b7a" version="2">Możesz użyć Mocy przysięgi, aby uderzyć z nadprzyrodzoną precyzją. Kiedy wykonujesz test ataku, możesz użyć swojego Aktu wiary, aby zyskać premię +10 do rzutu.</content>
-  <content contentuid="h73506d7ega609g97beg9101g93708e3a082e" version="1">Poziom 7: Aura Podboju</content>
+  <content contentuid="h73506d7ega609g97beg9101g93708e3a082e" version="1">Poziom 7: Aura podboju</content>
   <content contentuid="h999836e2gda36g81ebg8675g32c73bf93de3" version="2">Nieustannie emanujesz groźną aurą, dopóki nie masz stanu obezwładnienia. Aura rozciąga się na odległość 3 m w każdym kierunku, ale nie przez całkowitą osłonę.
 
 Jeśli istota się ciebie boi, ma utrudnienie w testach umiejętności i testach ataku, gdy znajduje się w aurze, a ta istota otrzymuje obrażenia psychiczne równe połowie twojego poziomu paladyna, jeśli zaczyna w tym miejscu swoją turę.</content>
@@ -6436,7 +6436,7 @@ Twoja wytrwałość może osłabić nawet najbardziej odpornych wrogów. Gdy tra
 
 Łamacz hordy
 Raz w każdej swojej turze, gdy wykonujesz atak bronią, możesz wykonać jeszcze jeden atak tą samą bronią przeciwko innej istocie, która znajduje się w promieniu 1,5 m od pierwotnego celu i w zasięgu broni oraz nie była jeszcze celem twojego ataku w tej turze.</content>
-  <content contentuid="h77e1e333gb3cdg56acg9362g02fb95f15b3c" version="1">Poziom 7: Taktyka defensywna</content>
+  <content contentuid="h77e1e333gb3cdg56acg9362g02fb95f15b3c" version="1">Poziom 7: Taktyka obronna</content>
   <content contentuid="h30d5708dgfa9eg4556ga8b6g4baa0e34f874" version="1">Wybierz jedną z poniższych opcji zdolności. Po każdym krótkim albo długim odpoczynku możesz zastąpić wybraną opcję drugą.
 
 Ucieczka przed hordą


### PR DESCRIPTION
## Summary

- align 73 `Level N:` feature headings with the official Polish Baldur's Gate 3 terminology
- keep previously reviewed post-refinement exceptions intact
- fix the Architect of Ruin feature `Submit` from the unrelated UI sense `Prześlij` to the contextual imperative `Ulegnij`
- change only `Localization/Polish/polish.xml`

Examples include `Wszechstronność`, `Cięta riposta`, `Opończa inspiracji`, `Odskok`, `Pakt ostrza`, and `Pieśń klingi`.

## Validation

- 5,355 source and 5,355 Polish handles
- no missing, extra, duplicate, empty, version-mismatched, tag-mismatched, or placeholder-mismatched entries
- no translation coverage, spell structure, spell language, or official spell-title errors
- all 742 duplicate-English groups remain internally consistent
- all 74 changed handles classified as 73 official level-feature titles plus the one contextual `Submit` correction

## Credits

Please use these exact README/wiki entries:

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)