### PR TITLE
Align Polish D&D 2024 core class feature titles

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Polish/polish.xml
@@ -48,15 +48,15 @@ Na określonych poziomach klasy zyskujesz możliwość używania właściwości 
 Możesz wpadać w szał tyle razy, ile wskazuje kolumna Szały w tabeli cech barbarzyńcy dla twojego poziomu. Jedno zużyte użycie odzyskujesz po krótkim odpoczynku, a wszystkie po długim odpoczynku.</content>
   <content contentuid="h8abec533g47afgabaag5370ga724a70ed863" version="1">Poziom 1: Obrona bez pancerza</content>
   <content contentuid="hfc1b8fd5g336eg3648g3224g9cae0aaac491" version="1">Poziom 2: Wyczucie zagrożenia</content>
-  <content contentuid="hb6dea583g9359gddf3g2360g74669f67b1a6" version="1">Poziom 3: Wiedza pierwotna</content>
+  <content contentuid="hb6dea583g9359gddf3g2360g74669f67b1a6" version="1">Poziom 3: Pierwotna wiedza</content>
   <content contentuid="h860b399bg558cg749fgb64bg707d53758400" version="2">Zyskujesz biegłość w innej umiejętności według twojego wyboru z listy umiejętności dostępnych dla Barbarzyńcy na 1. poziomie.
 
 Ponadto, gdy twój &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt; jest aktywny, możesz przekazywać pierwotną moc podczas wykonywania określonych zadań; za każdym razem, gdy wykonujesz test umiejętności przy użyciu jednej z poniższych umiejętności, możesz wykonać go jako test Siły, nawet jeśli normalnie korzysta z innej zdolności: &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Akrobatyka&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Zastraszanie&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Percepcja&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Skradanie się&lt;/LSTag&gt; lub &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Sztuka przetrwania&lt;/LSTag&gt;. Kiedy używasz tej zdolności, twoja Siła reprezentuje pierwotną moc przepływającą przez ciebie, doskonalącą twoją zwinność, postawę i zmysły.</content>
   <content contentuid="h3fa58ccfg135bg7a66g14degc3c8b5bb8261" version="1">Poziom 5: Szybki ruch</content>
   <content contentuid="h7c047839g4177g2aaega022g36a5cb07886a" version="1">Poziom 7: Zwierzęcy instynkt</content>
-  <content contentuid="h28d4b453gc36cg810egf9e2g1dbff5d018d8" version="1">Poziom 7: Instynktowny Skok</content>
+  <content contentuid="h28d4b453gc36cg810egf9e2g1dbff5d018d8" version="1">Poziom 7: Instynktowny zryw</content>
   <content contentuid="hdb025275gf26dg03dfg7370g4dddf3f0ffb9" version="1">W ramach akcji dodatkowej, którą wykorzystujesz, aby wpaść w &lt;LSTag Type="Status" Tooltip="RAGE"&gt;szał&lt;/LSTag&gt;, możesz przemieścić się na odległość równą maksymalnie połowie swojej szybkości.</content>
-  <content contentuid="hb6144726g336aga60cg63d6gf6c4bc669e6a" version="1">Poziom 9: Brutalne Uderzenie</content>
+  <content contentuid="hb6144726g336aga60cg63d6gf6c4bc669e6a" version="1">Poziom 9: Brutalne uderzenie</content>
   <content contentuid="h3a320da8g90b9g9714ge237g45c9782afbd0" version="1">Jeśli użyjesz Szaleńczego ataku, cel otrzymuje dodatkowe 1k10 obrażeń tego samego typu co obrażenia zadane przez broń lub atak bez broni, a ty możesz wywołać jeden wybrany efekt Brutalnego uderzenia.
 
 Potężny cios. Cel zostaje odepchnięty o [1] prosto od ciebie. Następnie możesz przemieścić się prosto w stronę celu na odległość równą maksymalnie połowie swojej szybkości, nie prowokując ataków okazyjnych.
@@ -149,11 +149,11 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="hb14ca27eg593ag392fgab27g2186f2a37316" version="2">Raz w każdej twojej turze, kiedy trafisz istotę testem ataku przy użyciu broni, możesz sprawić, że cel otrzyma dodatkowy [1]</content>
   <content contentuid="ha5f17982g16bdg018bg655eg1db1622f5096" version="1">Poziom 7: Błogosławione Uderzenia: Boskie Uderzenie (Nekrotyczne)</content>
   <content contentuid="hd61761e0gbebfg6542gac8bgd70ab3faa548" version="1">Raz na turę, gdy trafisz istotę atakiem bronią, możesz zadać jej dodatkowe 1k8 obrażeń nekrotycznych.</content>
-  <content contentuid="hdbdc1e3fg886agebc7gf898gdd7b5aea06a3" version="1">Poziom 7: Błogosławione Uderzenia: Potężne rzucanie czarów</content>
+  <content contentuid="hdbdc1e3fg886agebc7gf898gdd7b5aea06a3" version="1">Poziom 7: Błogosławione uderzenia: Potężne czarowanie</content>
   <content contentuid="h2d199d0egf3a1ga886gf931gb46f01ab73e5" version="1">Potężne czarowanie. Dodajesz swój modyfikator Mądrości do obrażeń zadawanych dowolną sztuczką kleryka.</content>
   <content contentuid="h4bebd04fg3a81gc270gd50bga237aecd8ef8" version="1">Błogosławione uderzenia</content>
   <content contentuid="h0c4d3581gf44cg6a9ag27f8ge9f2dd54d6ed" version="1">Boska moc napełnia cię w walce. Otrzymujesz jedną z poniższych opcji według własnego wyboru.</content>
-  <content contentuid="hb6ac0f1cg84d4g5137g1a23g92f5941f06dc" version="1">Poziom 5: Podpalaj Nieumarłych</content>
+  <content contentuid="hb6ac0f1cg84d4g5137g1a23g92f5941f06dc" version="1">Poziom 5: Spopielenie Nieumarłych</content>
   <content contentuid="hd9e8561fg5920g7f26g9d66g15b2d44e24f3" version="1">Powstrzymanie śmierci</content>
   <content contentuid="hb742b3aagabfcg536cg10e0g99bbe354e49a" version="1">Uzdrów istotę w zasięgu, która ma 0 punktów wytrzymałości i nie jest martwa.</content>
   <content contentuid="hd085b0deg3cc9g0858gdf14geef98a4164c3" version="1">Słowo blasku</content>
@@ -230,7 +230,7 @@ Przy niepowodzeniu myśli celu zostają również zmącone na 1 minutę. Przez t
   <content contentuid="h3aac9e83g2f2ag85ddgcf84ge7224ea85b8b" version="1">Położenie istoty jest zawsze znane rzucającemu aż do końca czaru. Istota nie może &lt;LSTag Type="Spell" Tooltip="Shout_Hide"&gt;ukryć się&lt;/LSTag&gt; przed rzucającym, a jeśli ma stan &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;niewidzialności&lt;/LSTag&gt;, nie odnosi z niego żadnych korzyści wobec rzucającego.</content>
   <content contentuid="h0eb6a1ccg061cg7757g2ce7gb1ae17ae8a0f" version="1">Szum synaptyczny</content>
   <content contentuid="h9e56e88cg0481g2c87g52e7g140df577385c" version="1">Istota odejmuje 1k6 od swoich testów ataku i cech oraz od rzutów obronnych na Kondycję wykonywanych w celu podtrzymania koncentracji. Na końcu każdej swojej tury wykonuje rzut obronny na Inteligencję; przy powodzeniu efekt się kończy.</content>
-  <content contentuid="h32658116g9dc9g1364g0f58g311a9cad82b8" version="1">Poziom 3: Magia Umysłu</content>
+  <content contentuid="h32658116g9dc9g1364g0f58g311a9cad82b8" version="1">Poziom 3: Magia umysłu</content>
   <content contentuid="h2035dcdeg7b97g47a9gcfb1gb7bc1f9c6cb9" version="2">W ramach akcji Magii możesz zużyć jedno użycie Aktu wiary, aby objawić swoją magiczną wiedzę. Wybierz jeden czar Domeny Wiedzy albo szkoły Wieszczenia. W ramach tej samej akcji rzucasz wybrany czar bez zużywania komórki czaru.</content>
   <content contentuid="h75bd2293g6a4eg35b3g4781gf184d224ea59" version="1">Poziom 6: Nieskrępowany umysł</content>
   <content contentuid="hdd98d6aage020gf00bgcd6fg4be2ad2fd956" version="1">Zyskujesz biegłość w rzutach obronnych na Inteligencję.
@@ -242,7 +242,7 @@ Dodaj połowę swojego modyfikatora Mądrości do &lt;LSTag Tooltip="AbilityChec
   <content contentuid="he44a89e4gd251g9a1dg6abagca1e9807a226" version="1">Istota emituje słabe światło w promieniu [1] i nie może korzystać ze stanu &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;niewidzialności&lt;/LSTag&gt;.</content>
   <content contentuid="h8d4a4bb1g65b7g5025g4514gdfa80f1282ba" version="1">Grzmot</content>
   <content contentuid="h853f3b07gf693g964eg9f97g97a2cfda50ef" version="1">Każda istota w emanacji [1], której źródłem jesteś, wykonuje rzut obronny na Kondycję. Przy niepowodzeniu otrzymuje obrażenia od dźwięku.</content>
-  <content contentuid="hbd2e3aa0g3258g4710g9504gbadee9cd0ea6" version="1">Poziom 1: Druid</content>
+  <content contentuid="hbd2e3aa0g3258g4710g9504gbadee9cd0ea6" version="1">Poziom 1: Język druidyczny</content>
   <content contentuid="h59f8cb26gc1aag4dc3g0939ge1b311504647" version="1">Znasz druidzki — sekretny język Druidów. Podczas nauki tej pradawnej mowy udało ci się również odblokować magię porozumiewania się ze zwierzętami; zawsze masz przygotowany czar Rozmawianie ze zwierzętami.</content>
   <content contentuid="h1193aa13ge0d7ge702g2f85ga0c0527d229d" version="2">Poziom 1: Pierwotny porządek: Strażnik</content>
   <content contentuid="h236eb2e6g63d1g6008gac03gd13912a2af7b" version="1">Strażnik. Wyszkolony do walki, zyskujesz biegłość w żołnierskich broniach i szkolenie w średnich pancerzach.</content>
@@ -315,13 +315,13 @@ Dodaj połowę swojego modyfikatora Mądrości do &lt;LSTag Tooltip="AbilityChec
   <content contentuid="h8d42344bg665dge300g935bg0d9887bee468" version="1">Dzika postać: Niedźwiedź</content>
   <content contentuid="h59a5a380g59f1gfdb0g9a4fgef72e80eb679" version="1">Dzika postać: Borsuk</content>
   <content contentuid="h556b4fb3g5a97gb81cg3f21gd57ac1f02a0d" version="1">PUSTE</content>
-  <content contentuid="h978ef6fag7931g203cg08ccge7b0c344b3e8" version="1">Poziom 3: Formy okręgów</content>
+  <content contentuid="h978ef6fag7931g203cg08ccge7b0c344b3e8" version="1">Poziom 3: Zwierzęce formy kręgu</content>
   <content contentuid="h69bf3828g083cg1e10g408egf0f2ee4c7fe8" version="1">Możesz wykorzystać księżycową magię, gdy przybierasz dziką postać, zyskując poniższe korzyści.
 
 Klasa pancerza: Dopóki pozostajesz w tej postaci, twoja KP wynosi 13 plus twój modyfikator Mądrości, jeśli ta wartość jest wyższa niż KP bestii.
 
 Tymczasowe punkty wytrzymałości: Zyskujesz tymczasowe punkty wytrzymałości w liczbie równej trzykrotności swojego poziomu druida.</content>
-  <content contentuid="h50a84c2agc47eg3409gfbf3g8b9efe860b49" version="1">Poziom 7: Furia Żywiołów: Potężne rzucanie czarów</content>
+  <content contentuid="h50a84c2agc47eg3409gfbf3g8b9efe860b49" version="1">Poziom 7: Furia żywiołów: Potężne czarowanie</content>
   <content contentuid="hdbacd095g40f6g7468g5750g2f164c7506d4" version="1">Potężne rzucanie czarów. Dodaj swój modyfikator Mądrości do obrażeń zadawanych przez dowolną sztuczkę Druida.</content>
   <content contentuid="h623803a7gceadgfb71gf1d2g9f3e3921f3f2" version="1">Poziom 7: Furia Żywiołów: Pierwotne Uderzenie (Zimne)</content>
   <content contentuid="h1cfad235g00bdg10bfgf085g60ac289d2534" version="1">Pierwotne uderzenie. Raz na turę, gdy trafisz istotę testem ataku bronią albo atakiem postaci bestii podczas dzikiej postaci, możesz zadać celowi dodatkowo [1].</content>
@@ -339,7 +339,7 @@ Tymczasowe punkty wytrzymałości: Zyskujesz tymczasowe punkty wytrzymałości w
   <content contentuid="h7a281f4cgfc20gce12g5a55ge741d085a992" version="1">Źródło blasku księżyca</content>
   <content contentuid="hf0a594f4gbcafg3438g8e4cg19d60ca756cd" version="1">Do końca działania czaru masz odporność na obrażenia od światłości, a twoje ataki wręcz zadają przy trafieniu dodatkowo [1].</content>
   <content contentuid="hc9501eaeg3c65g8261gbbbegc5a79478ce47" version="1">Źródło blasku księżyca</content>
-  <content contentuid="h4d3aa54bg7cf4g12d5g0d79g21d13c55e1c1" version="1">Poziom 6: Ulepszone formy okręgu</content>
+  <content contentuid="h4d3aa54bg7cf4g12d5g0d79g21d13c55e1c1" version="1">Poziom 6: Ulepszone Zwierzęce formy kręgu</content>
   <content contentuid="h25a52b4bg965bga6bdgaee9gb81edcb888e9" version="2">W dzikiej postaci zyskujesz następujące korzyści.
 
 Księżycowy blask. Każdy twój atak w dzikiej postaci może zadawać obrażenia zwykłego typu albo obrażenia od światłości. Wybierasz typ obrażeń za każdym razem, gdy trafiasz takim atakiem.
@@ -352,11 +352,11 @@ Zwiększona wytrzymałość. Możesz dodawać swój modyfikator Mądrości do rz
   <content contentuid="hcf67e29ag6032g30cfgf7dbg0fb20210f91d" version="1">Użycie Kroku w blasku księżyca</content>
   <content contentuid="hcd5cf1b2gd583gccb7gb15cg0cd8f525eccb" version="1">Liczba użyć Kroku w blasku księżyca.</content>
   <content contentuid="h019511d5gb330g2cd9gd860g84e25789d117" version="1">Pojawia się na tobie konstelacja mądrego smoka. Gdy wykonujesz &lt;LSTag Tooltip="SavingThrow"&gt;rzut obronny&lt;/LSTag&gt;, aby utrzymać &lt;LSTag Tooltip="Concentration"&gt;koncentrację&lt;/LSTag&gt; na czarze, wynik 9 albo niższy traktujesz jak 10.</content>
-  <content contentuid="h539b326cga713g3705gbe13g1aa9f8c71bde" version="1">Poziom 2: Umysł taktyczny</content>
+  <content contentuid="h539b326cga713g3705gbe13g1aa9f8c71bde" version="1">Poziom 2: Taktyczny umysł</content>
   <content contentuid="h61388cf8g2c44ge32ege2c8gd43ed94d46c8" version="1">Masz talent do taktyki na polu bitwy i poza nim. Możesz zużyć jedno użycie Drugiego oddechu, aby zwiększyć szanse powodzenia testu cechy. Rzuć 1k10 i dodaj wynik do testu, co może zmienić niepowodzenie w powodzenie.</content>
   <content contentuid="h25de2a50g4c8dg2b55gea44gd2074336ba6a" version="1">Użycie Drugiego oddechu</content>
   <content contentuid="h1ef6a3c5gfadagaff9gd6e8gf62d1e802c10" version="1">Liczba użyć Drugiego oddechu lub Umysłu taktycznego.</content>
-  <content contentuid="h33994fb3gfae3gde33g720fg2e4b5fa64c9d" version="1">Poziom 5: Zmiana taktyczna</content>
+  <content contentuid="h33994fb3gfae3gde33g720fg2e4b5fa64c9d" version="1">Poziom 5: Taktyczne przemieszczenie</content>
   <content contentuid="h34197e5dgf2d4g066fgdb45gb041adb38595" version="1">Gdy w ramach akcji dodatkowej używasz Drugiego oddechu, możesz przemieścić się o maksymalnie połowę swojej szybkości bez prowokowania ataków okazyjnych.</content>
   <content contentuid="h32fafe3dg30eeg2c3agc543g698e6d46c741" version="1">Taktyczne przemieszczenie</content>
   <content contentuid="hfd6115a2g072eg747bg10e1gc93f7616eafe" version="1">Gdy w ramach akcji dodatkowej używasz Drugiego oddechu, możesz przemieścić się o maksymalnie połowę swojej szybkości bez prowokowania ataków okazyjnych.</content>
@@ -376,13 +376,13 @@ Zwiększona wytrzymałość. Możesz dodawać swój modyfikator Mądrości do rz
   <content contentuid="h412ee86dgfedcga2beg54adgbd1f6bc466f9" version="1">Zasada: Wymagana siła (zbroja szynowa)</content>
   <content contentuid="h1855925eg36d7g774cg4917gc8135001356f" version="1">Zasada: Wymagania dotyczące siły (zbroja płytowa)</content>
   <content contentuid="h36e05e75gb0acgebbeg511ag25cc56fcde31" version="1">Jeśli istota nosząca tę ciężką zbroję ma wynik Siły niższy niż [1], jej szybkość zostaje zmniejszona o [2].</content>
-  <content contentuid="h1378b9e1g8e8cgbb1eg3cb7g5aad15a2e9d3" version="1">Poziom 3: Niezwykły sportowiec</content>
+  <content contentuid="h1378b9e1g8e8cgbb1eg3cb7g5aad15a2e9d3" version="1">Poziom 3: Niezwykły atleta</content>
   <content contentuid="h8a4c8a20gcc89g49e5g2025g934de8342619" version="1">Dzięki swojej atletyce masz ułatwienie w testach na inicjatywę i siłę (&lt;LSTag Type="Skills" Tooltip="Athletics"&gt;Atletyka&lt;/LSTag&gt;).
 
 Ponadto natychmiast po uzyskaniu trafienia krytycznego możesz przesunąć się o dystans równy połowie swojej szybkości bez prowokowania ataków okazyjnych.</content>
   <content contentuid="h070ecbffg0669ge021gd9f2gf9d31bf77f88" version="1">Niezwykły atleta</content>
   <content contentuid="h20fe10e3g6a5cg1394g9602g64f7640b6f6d" version="1">Natychmiast po otrzymaniu Trafienia Krytycznego możesz poruszyć się maksymalnie o połowę, nie prowokując ataków okazyjnych.</content>
-  <content contentuid="hdc98f803g35c5gf1e3g8979g2a5e77165301" version="1">Poziom 10: Bohaterski wojownik</content>
+  <content contentuid="hdc98f803g35c5gf1e3g8979g2a5e77165301" version="1">Poziom 10: Heroiczny wojownik</content>
   <content contentuid="ha8f342f0g6dafg2cb0g07ffg5de2b08f710e" version="1">Dreszcz bitwy popycha cię ku zwycięstwu. Podczas walki możesz dać sobie &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;heroiczną inspirację&lt;/LSTag&gt; za każdym razem, gdy rozpoczynasz swoją turę bez niej.</content>
   <content contentuid="h6ae0967eg345cg0ef5g653cg5c51675a3b5a" version="1">Bohaterski wojownik: przerzuć kość atakującego</content>
   <content contentuid="h7e67754bg739bg3c96gcd25g72c30f60a4d8" version="1">Zmuś istotę do ponownego wykonania &lt;LSTag Tooltip="AttackRoll"&gt;testu ataku&lt;/LSTag&gt;.</content>
@@ -399,7 +399,7 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
 
 Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji zamiast jednego z tych ataków.</content>
   <content contentuid="h66ceeddfg85e7gf6e6g45fdgf681167aa694" version="1">Poziom 10: Zwiększona przewaga bojowa</content>
-  <content contentuid="h1a9ea1d9gcca2gd533gd087g0e05473a8b97" version="1">Poziom 1: Obrona bez opancerzenia</content>
+  <content contentuid="h1a9ea1d9gcca2gd533gd087g0e05473a8b97" version="1">Poziom 1: Obrona bez pancerza</content>
   <content contentuid="hb6df1fdbgd732gf839g1534g7c3a49d1d89d" version="1">Kiedy nie nosisz zbroi ani nie dzierżysz tarczy, twoja podstawowa klasa pancerza wynosi 10 plus twoje modyfikatory Zręczności i Mądrości.</content>
   <content contentuid="h9693b20eg4b48g52f3g8ec0gd315398b9984" version="1">Poziom 1: Sztuki walki: Zwinne ataki</content>
   <content contentuid="h24c5605eg0a01ge915g6899g61b6123a76ea" version="1">Otrzymujesz następujące korzyści, gdy nie używasz broni lub dzierżysz wyłącznie broń mnicha i nie nosisz zbroi ani nie dzierżysz tarczy.</content>
@@ -418,7 +418,7 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
   <content contentuid="hdfc28510gf4cdgb66eg531fg3918cc8b3df9" version="1">Pokonaj w tej turze większy dystans: podwój swoją &lt;LSTag Tooltip="MovementSpeed"&gt;szybkość ruchu&lt;/LSTag&gt;.</content>
   <content contentuid="h78c4f622gbb2cg3636gb74cg733fbf8d0b37" version="1">Odstąpienie</content>
   <content contentuid="h5248daffg03b1g4eeeg4498gaafc4796eece" version="1">Wykonaj bezpieczny odwrót: twój ruch nie prowokuje &lt;LSTag Tooltip="OpportunityAttack"&gt;ataków okazyjnych&lt;/LSTag&gt;.</content>
-  <content contentuid="h62169240g157dg0599gc2d2g3c5611236273" version="1">Poziom 2: Ruch bez opancerzenia</content>
+  <content contentuid="h62169240g157dg0599gc2d2g3c5611236273" version="1">Poziom 2: Szybkość mnicha</content>
   <content contentuid="hdd7cc0dcg93b5g2722g9ad5g75eb1fd5edf9" version="1">Poziom 6: Szybkość mnicha</content>
   <content contentuid="hbb2da776g993fg5373g95abg3f33446175c5" version="1">Poziom 10: Szybkość mnicha</content>
   <content contentuid="hfe07c960gd6d9ga0e1g4facgbbfc0b0a2079" version="1">Poziom 2: Niesamowity metabolizm</content>
@@ -427,7 +427,7 @@ Ponadto możesz rzucić jedną ze swoich sztuczek, która ma czas rzucania akcji
 Po użyciu tej cechy nie możesz użyć jej ponownie aż do zakończenia długiego odpoczynku.</content>
   <content contentuid="h6d5fdddcg3d1bg2ed8g0bebgcfcf2293742c" version="1">Niesamowity metabolizm</content>
   <content contentuid="h48a9451fg4097gddefg1177g77b625d48f82" version="1">Możesz odzyskać wszystkie wydane Punkty Skupienia. Kiedy to zrobisz, rzuć swoją kością Sztuk Walki i odzyskaj liczbę punktów wytrzymałości równą twojemu poziomowi Mnicha plus wyrzucona liczba.</content>
-  <content contentuid="h399b9569g4416g07fbg0cd6ga4f008d8e40c" version="1">Poziom 3: Odbijaj ataki</content>
+  <content contentuid="h399b9569g4416g07fbg0cd6ga4f008d8e40c" version="1">Poziom 3: Odbijanie ataków</content>
   <content contentuid="h363f8861g503bg174cgc576g28e60841fa32" version="3">Gdy atak trafia cię i zadaje obrażenia obuchowe, kłute albo cięte, możesz w ramach reakcji zmniejszyć łączną wartość otrzymywanych obrażeń o 1k10 + twój modyfikator Zręczności + twój poziom mnicha.
 
 Jeśli zmniejszy to obrażenia do 0, możesz wydać 1 punkt ki, aby użyć Przekierowania ataku.</content>
@@ -440,11 +440,11 @@ Jeśli zmniejszy to obrażenia do 0, możesz wydać 1 punkt ki, aby użyć Przek
   <content contentuid="hd8199896gbae1g11ceg6ba1g523b41f8b9ef" version="1">Odbicie ataku: Przekieruj</content>
   <content contentuid="h4487767egdb77g3708g93a8gd0279452056a" version="1">Zmniejsz obrażenia i przekieruj je z powrotem na atakującego.</content>
   <content contentuid="ha8c51db9g127cg0f8dgf557g402626436b8c" version="1">Poziom 4: Powolne spadanie</content>
-  <content contentuid="h726e4c54g614fg70ccg5ebag4c572b51fbe4" version="1">Poziom 6: Wzmocnione Uderzenia</content>
+  <content contentuid="h726e4c54g614fg70ccg5ebag4c572b51fbe4" version="1">Poziom 6: Wzmocnione uderzenia</content>
   <content contentuid="h3eabcb35gf264g4f8ag9c30g123cbc8fd2b8" version="3">Za każdym razem, gdy zadajesz obrażenia atakiem bez broni, możesz wybrać, czy zadaje on obrażenia od mocy, czy obrażenia swojego zwykłego typu.</content>
-  <content contentuid="hc6a55712gd62cgd5e7g68d8g0007496a3e1e" version="2">Poziom 9: Ruch akrobatyczny</content>
+  <content contentuid="hc6a55712gd62cgd5e7g68d8g0007496a3e1e" version="2">Poziom 9: Akrobatyczny ruch</content>
   <content contentuid="hcb9a361cg3dadgecb2gdae1g23fc5f5c3919" version="1">Poziom 7: Odskok</content>
-  <content contentuid="h33c22a3cg9bbaga9c8g65e2g0701352832a0" version="1">Poziom 10: Zwiększona koncentracja</content>
+  <content contentuid="h33c22a3cg9bbaga9c8g65e2g0701352832a0" version="1">Poziom 10: Zwiększone skupienie</content>
   <content contentuid="h3bb523e2gc26eg22c2g87e9g4e1e0da5e1af" version="2">Twój Grad ciosów, &lt;LSTag Type="Spell" Tooltip="Shout_PatientDefense"&gt;Cierpliwa obrona&lt;/LSTag&gt; i Krok w powietrzu zyskują następujące korzyści:
 
 Grad ciosów. Możesz wydać 1 punkt skupienia, aby użyć Gradu ciosów i wykonać trzy ataki bez broni zamiast dwóch.
@@ -452,9 +452,9 @@ Grad ciosów. Możesz wydać 1 punkt skupienia, aby użyć Gradu ciosów i wykon
 Cierpliwa obrona i Krok w powietrzu. Gdy wydajesz punkt skupienia, aby użyć którejkolwiek z tych zdolności, zyskujesz tymczasowe punkty wytrzymałości w liczbie równej wynikowi dwóch rzutów kością sztuk walki.</content>
   <content contentuid="hddf40c2dge503g0c52g70e0g81df540da740" version="1">Zwiększone skupienie</content>
   <content contentuid="h96955479gc03cg5656g398ega8e7e632c8a3" version="1">Otrzymujesz liczbę tymczasowych punktów wytrzymałości równą dwóm rzutom twoją kością sztuk walki.</content>
-  <content contentuid="hb0d0ae76g515agec5dg8b3fgfef5c6b386f3" version="1">Poziom 10: Samoodnowa</content>
+  <content contentuid="hb0d0ae76g515agec5dg8b3fgfef5c6b386f3" version="1">Poziom 10: Samouzdrowienie</content>
   <content contentuid="hb6524b85g7c46g835fg5ec8g505bf3a2d396" version="1">Poziom 10: Czystość ciała</content>
-  <content contentuid="hc41f1b91gbedcg876fg1542g2c46f2f4be27" version="1">Poziom 3: Sztuki Cienia</content>
+  <content contentuid="hc41f1b91gbedcg876fg1542g2c46f2f4be27" version="1">Poziom 3: Sztuki cienia</content>
   <content contentuid="h62e16743gcb72g9068gb2d0gb1a62ea9d321" version="1">Potrafisz czerpać moc ze Sfery Cieni, dzięki czemu zyskujesz następujące korzyści.
 
 Ciemność. Możesz wydać 1 punkt skupienia, aby rzucić czar Ciemność bez komponentów. Gdy rzucasz go za pomocą tej cechy, widzisz w jego obszarze. Dopóki czar trwa, na początku każdej swojej tury możesz przenieść jego obszar na wybrane pole w promieniu [1] od siebie.
@@ -489,7 +489,7 @@ Każda istota w sferze wykonuje rzut obronny na Zręczność. Przy niepowodzeniu
   <content contentuid="h20cb80c4gd3bag353egbaeagfc09e502126d" version="1">Wybuch żywiołów: Ogień</content>
   <content contentuid="hb75cfe1fg5fb8gb857g1067ge5e38e4b4046" version="1">Wybuch żywiołów: Elektryczność</content>
   <content contentuid="ha9461978g325bg8b56g0b7fga747967bcf5b" version="1">Wybuch żywiołów: Dźwięk</content>
-  <content contentuid="hd0321dfag2f41g5984g2a27g4ba878286102" version="1">Poziom 11: Krok Żywiołów</content>
+  <content contentuid="hd0321dfag2f41g5984g2a27g4ba878286102" version="1">Poziom 11: Pęd żywiołów</content>
   <content contentuid="h90c565bfgdc8eg1fc2gde60ga457cc60135b" version="1">Dopóki twoja &lt;LSTag Type="Spell" Tooltip="Shout_HarmonyOfFireAndWater"&gt;Harmonia żywiołów&lt;/LSTag&gt; jest aktywna, zyskujesz szybkość lotu i szybkość pływania równe twojej szybkości ruchu.</content>
   <content contentuid="hbe92a07bg1800gd2e8g079fg1e0f39ce73ce" version="1">Integralność ciała</content>
   <content contentuid="h4feabb8egaa22g3d36gc857g512930772995" version="1">Poziom 6: Integralność ciała</content>
@@ -498,7 +498,7 @@ Każda istota w sferze wykonuje rzut obronny na Zręczność. Przy niepowodzeniu
 Możesz skorzystać z tej zdolności tyle razy, ile wynosi twój modyfikator Mądrości (co najmniej raz), a odzyskujesz wszystkie użycia po długim odpoczynku.</content>
   <content contentuid="h25c230c0g01dbg6406g2c50gfc3e4aa92e7f" version="1">Integralność ciała</content>
   <content contentuid="h202adf83g5a60g677dg2f14g1cbdfc06aeab" version="1">W ramach akcji dodatkowej możesz rzucić kością Sztuk Walki. Odzyskujesz punkty wytrzymałości w liczbie równej sumie wyniku rzutu i twojego modyfikatora Mądrości (co najmniej 1 punkt).</content>
-  <content contentuid="hbbdecd13gacf6ga6bcge4dfga9e9fdd39678" version="1">Poziom 11: Krok Floty</content>
+  <content contentuid="hbbdecd13gacf6ga6bcge4dfga9e9fdd39678" version="1">Poziom 11: Szybki krok</content>
   <content contentuid="h9f4fd43dgb96cg804dg3440g15b0a150a3ec" version="1">Możesz użyć Kroku Wiatru bez wydawania akcji dodatkowej.</content>
   <content contentuid="h0e9a944dgb216gb539gf48dg822147b343bd" version="1">Zasada: Wymagana siła (ciężka broń biała)</content>
   <content contentuid="hd97fac61ge406g7715gc8b7g188472b4140a" version="1">Jeśli istota dzierżąca tę broń Ciężką ma Wynik Siły niższy niż [1], ma utrudnienie w testach ataku wykonywanych tą bronią.</content>
@@ -514,7 +514,7 @@ Jeśli efekt Mocy przysięgi wymaga rzutu obronnego, ST jest równy ST rzutu obr
   <content contentuid="hab240831g4170g3e19gaf78ge733be05a5f1" version="1">Zawsze masz przygotowany czar Boskie ugodzenie. Możesz go również rzucić bez zużywania komórki czaru, lecz po takim użyciu musisz ukończyć długi odpoczynek, zanim zrobisz to ponownie.</content>
   <content contentuid="h39de8d3fgd862g0342g0a3ag9205f4e7bf55" version="1">Uderzenie Paladyna</content>
   <content contentuid="haaa7e52ege832ge271gecfdge010d65df535" version="1">Możesz rzucić Boskie Uderzenie bez wydawania komórki czaru, ale musisz zakończyć długi odpoczynek, zanim będziesz mógł go ponownie rzucić w ten sposób.</content>
-  <content contentuid="hd777f361gcaa7g7dbegeb0agb9179de1ba4b" version="1">Poziom 5: Wierny rumak</content>
+  <content contentuid="hd777f361gcaa7g7dbegeb0agb9179de1ba4b" version="1">Poziom 5: Wierny wierzchowiec</content>
   <content contentuid="h8d9bb995gd364g7b4fgd6f8gb78ed0bdda9b" version="1">Możesz przywołać na pomoc nieziemskiego wierzchowca. Zawsze masz przygotowany czar Znalezienie wierzchowca.
 
 Możesz go również rzucić raz bez zużywania komórki czaru, a możliwość tę odzyskujesz po długim odpoczynku.</content>
@@ -541,11 +541,11 @@ Gdy dosiadasz wierzchowca i otrzymasz obrażenia o wartości co najmniej 4, musi
   <content contentuid="h5c0401b6g3fc4gaadagf4bbg097715066c52" version="1">Skupienie na unikaniu ataków.
 
 &lt;LSTag Tooltip="AttackRoll"&gt;Testy ataku&lt;/LSTag&gt; przeciwko tej istocie są wykonywane z &lt;LSTag Tooltip="Disadvantage"&gt;utrudnieniem&lt;/LSTag&gt;, a ona sama ma &lt;LSTag Tooltip="Advantage"&gt;ułatwienie&lt;/LSTag&gt; w &lt;LSTag Tooltip="SavingThrow"&gt;rzutach obronnych&lt;/LSTag&gt; na Zręczność.</content>
-  <content contentuid="h3d4848abgc60eg631cgc713g605af144c9ee" version="1">Poziom 9: Wyrzeknij się wrogów</content>
+  <content contentuid="h3d4848abgc60eg631cgc713g605af144c9ee" version="1">Poziom 9: Odpędzenie wrogów</content>
   <content contentuid="h060adb3eg6617g9283g226fg6d070eb47c88" version="1">W ramach akcji Magii możesz zużyć jedno użycie Mocy przysięgi tej klasy, aby przepełnić wrogów trwogą. Unosząc Święty Symbol albo broń, wybierasz maksymalnie tyle widocznych istot w promieniu [1] od siebie, ile wynosi twój modyfikator Charyzmy (co najmniej jedną). Każdy cel musi wykonać rzut obronny na Mądrość; w razie niepowodzenia otrzymuje stan przerażenia na 1 minutę.</content>
   <content contentuid="ha4ade769g56f1g989dg4a5dgc980f0453d08" version="1">Odpędzenie wrogów</content>
   <content contentuid="hf0938809g82f6ge8a7gea01gff762cf6f570" version="1">W ramach akcji Magii możesz zużyć jedno użycie Mocy przysięgi tej klasy, aby przepełnić wrogów trwogą. Unosząc Święty Symbol albo broń, wybierasz maksymalnie tyle widocznych istot w promieniu [1] od siebie, ile wynosi twój modyfikator Charyzmy (co najmniej jedną). Każdy cel musi wykonać rzut obronny na Mądrość; w razie niepowodzenia otrzymuje stan przerażenia na 1 minutę.</content>
-  <content contentuid="hdd546b3bg87ddg0b0eg91d9g7dd5bb69d0d5" version="1">Poziom 11: Promienne Uderzenia</content>
+  <content contentuid="hdd546b3bg87ddg0b0eg91d9g7dd5bb69d0d5" version="1">Poziom 11: Uderzenia światłości</content>
   <content contentuid="he923c53cgfecbgb456g1ee5gbc97fd5f5a9a" version="1">Twoje uderzenia niosą teraz nadprzyrodzoną moc. Gdy trafisz cel testem ataku przy użyciu broni do walki w zwarciu lub uderzenia bez broni, cel otrzymuje dodatkowe 1k8 obrażeń od światłości.</content>
   <content contentuid="h1b6d335fg71e3g921bg96efgd3563a3e9d4b" version="1">Paladyn i pobliscy sojusznicy mają odporność na obrażenia nekrotyczne, psychiczne i od światłości.</content>
   <content contentuid="he4565ab2g2625gaeb8g694eg929ab02e448c" version="1">Paladyn i pobliscy sojusznicy mają odporność na obrażenia nekrotyczne, psychiczne i od światłości.</content>
@@ -603,7 +603,7 @@ Działasz dość szybko, by zamienić chybienie w kolejne uderzenie. Gdy chybisz
   <content contentuid="h8b43db08gaf12gc02agb86cge29d6c39df7f" version="1">W ramach akcji dodatkowej zapewniasz sobie ułatwienie w następnym teście ataku w tej turze. Możesz skorzystać z tej cechy tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
   <content contentuid="h8cfd42a3ge9ddg2a7bg7928g2b06b4cc30ec" version="1">Stabilne celowanie</content>
   <content contentuid="haf3b75e3g8f42g8af5ge959ga8ee656088f7" version="1">W ramach akcji dodatkowej zapewniasz sobie ułatwienie w następnym teście ataku w tej turze. Możesz skorzystać z tej cechy tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
-  <content contentuid="h4c5295e0g7006g010bg62b8gfa3c901f3027" version="1">Poziom 3: Stały cel</content>
+  <content contentuid="h4c5295e0g7006g010bg62b8gfa3c901f3027" version="1">Poziom 3: Stabilne celowanie</content>
   <content contentuid="h49585eb0g7c75g3df5g4aacg38e6e664edb2" version="1">W ramach akcji dodatkowej zapewniasz sobie ułatwienie w następnym teście ataku w tej turze. Możesz skorzystać z tej cechy tylko przed wykonaniem ruchu w tej turze. Po jej użyciu twoja szybkość wynosi 0 do końca tury.</content>
   <content contentuid="hdd434d50g0d94g6819ge916g55203c553e86" version="1">Poziom 7: Niezawodny talent</content>
   <content contentuid="h21f511b2g92a9g1aafg61d4g9e8e4ad1e872" version="1">Poziom 5: Niesamowity unik</content>
@@ -664,7 +664,7 @@ Możesz skorzystać z tej zdolności dwukrotnie. Odzyskujesz wszystkie użycia p
 Na 10. poziomie Czarownika zyskujesz dwie dodatkowe opcje.</content>
   <content contentuid="ha0496c74g4123g62d8ge5a6ga853a650ab6c" version="1">Przywrócenie mocy</content>
   <content contentuid="h5ef71f37g9eeeg0a14g2f05g417ed20720ed" version="1">Odzyskujesz punkty zaklinania równe połowie maksymalnej liczby punktów.</content>
-  <content contentuid="hea7a291eg87bag417cg8ac2gdece9fc65308" version="1">Poziom 7: Wcielenie magii</content>
+  <content contentuid="hea7a291eg87bag417cg8ac2gdece9fc65308" version="1">Poziom 7: Ucieleśnienie magii</content>
   <content contentuid="hd8409099g42e6g3a17g9b47gc6bd4fec7de5" version="1">Jeśli nie masz już użyć Wrodzonej magii, możesz ją aktywować, wydając 2 punkty zaklinania podczas wykonywania związanej z nią akcji dodatkowej.
 
 Ponadto, gdy Wrodzona magia jest aktywna, ST rzutów obronnych przeciwko twoim czarom zwiększa się o 2 zamiast o 1.</content>


### PR DESCRIPTION
## Summary

- align 29 D&D 2024 core-class level-up headings that have no direct entry in the shipped Polish BG3 corpus
- use the established Polish D&D 2024 community terminology for Barbarian, Cleric, Druid, Fighter, Monk, Paladin, Rogue, and Sorcerer features
- correct the community-source typo in `Steady Aim` as `Stabilne celowanie`
- leave uncertain community candidates out for separate review
- change only `Localization/Polish/polish.xml`

Examples include `Pierwotna wiedza`, `Język druidyczny`, `Taktyczne przemieszczenie`, `Odbijanie ataków`, `Odpędzenie wrogów`, and `Ucieleśnienie magii`.

## Validation

- exactly 29 selected handles changed, with 29/29 matching the reviewed terminology table
- 5,355 source and 5,355 Polish handles
- no missing, extra, duplicate, empty, version-mismatched, tag-mismatched, or placeholder-mismatched entries
- no translation coverage, spell structure, spell language, or official spell-title errors
- all 742 duplicate-English groups remain internally consistent

## Credits

Please use these exact README/wiki entries:

- **Polish Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)
- **Ukrainian Translation**: [TableTop BRAMA community](https://discord.gg/VxSvMqQ6sS)