### PR TITLE
Revise Spanish localization for abilities and spells

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Spanish/spanish.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Spanish/spanish.xml
@@ -1020,9 +1020,9 @@ Perno Hiriente. Cuando golpeas a una criatura con un ataque a distancia, tiene p
 
 Tienes &lt;LSTag Tooltip="Resistant"&gt;Resistencia&lt;/LSTag&gt; al daño causado por trampas y &lt;br&gt;&lt;br&gt;puedes ver en la Oscuridad.</content>
   <content contentuid="h3e8e3421g4852g1a98g9d7cgf3947ee60a89" version="1">Resistente</content>
-  <content contentuid="h6299a92eg8049g117bga5b7g17d26b0619d6" version="2">Desafiar a la Muerte. Tienes &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; en las Tiradas de Salvación contra la Muerte.
+  <content contentuid="h6299a92eg8049g117bga5b7g17d26b0619d6" version="3">Desafiar a la Muerte. Tienes &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; en las Tiradas de Salvación contra la Muerte.
 
-Recuperación Rápida. Recuperas el máximo de &lt;LSTag Tooltip="HitPoints"&gt;Puntos de Golpe&lt;/LSTag&gt; posible cuando eres curado.</content>
+Recuperación Rápida. Como Acción Adicional, puedes gastar uno de tus Dados de Puntos de Golpe, tirar el dado y recuperar un número de &lt;LSTag Tooltip="HitPoints"&gt;Puntos de Golpe&lt;/LSTag&gt; igual al resultado.</content>
   <content contentuid="h3f1eb96eg51f4gaf8cg5396g435ffda2161a" version="1">Gran Maestro de Armas Pesadas</content>
   <content contentuid="h00f044d5gf4edgc900g397bgca53d410bdad" version="2">Maestría con Armas Pesadas. Cuando golpeas a una criatura con un arma que posea Propiedad Pesada como parte de la acción de Atacar en tu turno, puedes hacer que el arma inflija daño adicional al objetivo. El daño adicional es igual a tu &lt;LSTag Tooltip="ProficiencyBonus"&gt;Bonificador de Competencia&lt;/LSTag&gt;.
 
@@ -1968,8 +1968,8 @@ Como Acción Adicional, puedes curarte a ti mismo o a una criatura que puedas ve
   <content contentuid="h24e5006bg1411g65a8g188eg3cd830a72dbf" version="1">Tienes &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; en las Tiradas de Salvación que realizas para evitar o terminar la condición &lt;LSTag Type="Status" Tooltip="CHARMED"&gt;Hechizado&lt;/LSTag&gt;.</content>
   <content contentuid="h71c75422gccadg03e2gacb5g05a65c1f8188" version="1">Ingenioso</content>
   <content contentuid="hd06d9d97g3639gb022g0e2eg25f5ab8ca49e" version="1">Obtienes Inspiración Heroica cada vez que completas un &lt;LSTag Tooltip="LongRest"&gt;Descanso Largo&lt;/LSTag&gt;. Si tienes Inspiración Heroica, puedes gastarla para relanzar cualquier dado inmediatamente después de lanzarlo.</content>
-  <content contentuid="h229c085dgef48gd2b7ga8b1g7ed5f027b17a" version="2">Inspiración Heroica: Relanzar con &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; (Tirada de Ataque)</content>
-  <content contentuid="hac21fc5bg9d5cg705egede3g663945541420" version="2">Obtén &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; en tu &lt;LSTag Tooltip="AttackRoll"&gt;Tirada de Ataque&lt;/LSTag&gt;.</content>
+  <content contentuid="h229c085dgef48gd2b7ga8b1g7ed5f027b17a" version="2">Inspiración Heroica: Relanzar con Ventaja: (Tirada de Ataque)</content>
+  <content contentuid="hac21fc5bg9d5cg705egede3g663945541420" version="2">Obtén Ventajaen tu Tirada de Ataque.</content>
   <content contentuid="hd3b6f9bdga558g9498gb53egf8707edcbf80" version="1">Inspiración Heroica</content>
   <content contentuid="h43bcb1b9g7661gd847g5c69g16cf92019e88" version="1">Si tienes Inspiración Heroica, puedes gastarla para relanzar cualquier dado inmediatamente después de lanzarlo.</content>
   <content contentuid="h046f2142g4017g500fg9e5cg829c2bf7808e" version="1">Impulso de Adrenalina</content>
@@ -2025,7 +2025,7 @@ Puedes usar este rasgo un número de veces igual a tu &lt;LSTag Tooltip="Profici
   <content contentuid="hd6b15ae8g883dgdf02gd6abg7ee0b10eb571" version="1">Usar Dados de Puntos de Golpe: D12</content>
   <content contentuid="h4fbdbfa6g8ef2g4e61g0c7bg465466a0df32" version="1">Regla: Dados de Puntos de Golpe</content>
   <content contentuid="hfd791ef7g7534g8fdcgba6ag9741c29e31d4" version="1">La descripción de tu clase te indica el tipo de dado de los Dados de &lt;LSTag Tooltip="HitPoints"&gt;Puntos de Golpe&lt;/LSTag&gt; de tu personaje (o Dados de Golpe para abreviar). Al nivel 1, tu personaje tiene 1 Dado de Golpe. Puedes gastar Dados de Golpe para recuperar &lt;LSTag Tooltip="HitPoints"&gt;Puntos de Golpe&lt;/LSTag&gt;.</content>
-  <content contentuid="hc1919180g48a0ga814g77dega72819b9d91a" version="1">Inspiración Heroica: Relanzar con &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; (Tirada de Salvación)</content>
+  <content contentuid="hc1919180g48a0ga814g77dega72819b9d91a" version="1">Inspiración Heroica: Relanzar con Ventaja (Tirada de Salvación)</content>
   <content contentuid="h665b0831g0a27gcf47g1dafg16ce9df4ed5c" version="1">Obtén &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; en tu &lt;LSTag Tooltip="SavingThrow"&gt;Tirada de Salvación&lt;/LSTag&gt;.</content>
   <content contentuid="h3f7b8985g6d22gafeag4f95gff41b038514a" version="1">Interceptación</content>
   <content contentuid="h2f17ec6fgaccfg9489ga33dg5178d82df62d" version="1">Cuando una criatura que puedes ver golpea a otra criatura a 5 pies de ti con una &lt;LSTag Tooltip="AttackRoll"&gt;Tirada de Ataque&lt;/LSTag&gt;, puedes usar tu Reacción para reducir el daño infligido al objetivo en 1d10 más tu &lt;LSTag Tooltip="ProficiencyBonus"&gt;Bonificador de Competencia&lt;/LSTag&gt;. Debes sostener un Escudo o un arma Simple o Marcial para usar esta Reacción.</content>
@@ -6667,4 +6667,55 @@ Estómago de Hierro. Cada vez que recuperas puntos de golpe a ti mismo, recupera
 Baluarte. Cuando eres objeto de un efecto que te otorgaría la condición &lt;LSTag Type="Status" Tooltip="PRONE"&gt;Derribado&lt;/LSTag&gt;, puedes usar tu reacción para estabilizarte. No tienes la condición &lt;LSTag Type="Status" Tooltip="PRONE"&gt;Derribado&lt;/LSTag&gt;.
 
 Estómago de Hierro. Cada vez que recuperas puntos de golpe a ti mismo, recuperas puntos de golpe adicionales iguales a tu &lt;LSTag Tooltip="AbilityModifier"&gt;modificador&lt;/LSTag&gt; de &lt;LSTag Tooltip="Constitution"&gt;Constitución&lt;/LSTag&gt;.</content>
+  <content contentuid="h1d8bc12ega854g9fa6g115fg40f33b2e239c" version="1">Recuperación Rápida</content>
+  <content contentuid="hfb0b810fg2b5egfcf3g6d93ge130d15d3a4b" version="1">Como Acción Adicional, puedes gastar uno de tus Dados de Puntos de Golpe, tirar el dado y recuperar un número de Puntos de Golpe igual al resultado.</content>
+  <content contentuid="h1cfa58a7g0e63gc978gdfebg07ca3910c91d" version="1">Recuperación Rápida: D6</content>
+  <content contentuid="hdc2803e7g3ab7gce12ge2e6g43b054b38cf0" version="1">Recuperación Rápida: D8</content>
+  <content contentuid="hdde6e8d1g2ffbg6a90g60c2g5429dfd26e6d" version="1">Recuperación Rápida: D10</content>
+  <content contentuid="h8abbf551g5ac0g6ad5g3629g6c8cc9989df7" version="1">Recuperación Rápida: D12</content>
+  <content contentuid="ha7e36a64gf9b4ge4cdge8cfg3a2c8714b1f5" version="1">Descansando Corto</content>
+  <content contentuid="hdf3ad6cbg407cg0625gf796gbd2b01f64913" version="1">Hechizar Monstruo</content>
+  <content contentuid="ha49909ccgbb48gcda2gfd1fg1f26911f185f" version="1">Una criatura que puedas ver dentro del alcance realiza una &lt;LSTag Tooltip="SavingThrow"&gt;Tirada de Salvación&lt;/LSTag&gt; de &lt;LSTag Tooltip="Wisdom"&gt;Sabiduría&lt;/LSTag&gt;. Lo hace con &lt;LSTag Tooltip="Advantage"&gt;Ventaja&lt;/LSTag&gt; si tú o tus aliados estáis luchando contra ella. Si falla la salvación, el objetivo es afectado por la condición &lt;LSTag Type="Status" Tooltip="CHARMED"&gt;Hechizado&lt;/LSTag&gt; hasta que termine el conjuro o hasta que tú o tus aliados le inflijáis daño. La criatura Hechizada es Amistosa hacia ti. Cuando termina el conjuro, el objetivo sabe que fue Hechizado por ti.</content>
+  <content contentuid="h2597c9e9g3525g4aabga530g4eff672a1b01" version="1">Pergamino de Hechizar Monstruo</content>
+  <content contentuid="h0cce0e4fgf8f2g4536g8cc2g36c5c3834e7d" version="1">Apto para: Bardo, Druida, Hechicero, Brujo, Mago</content>
+  <content contentuid="h71308e2agebc9ga056g8f3ag64085d165f1c" version="1">Dominio del Dragón</content>
+  <content contentuid="h50808f80gb6f2g1d53g8967g175e0d38d55f" version="1">Dragón</content>
+  <content contentuid="h700ea52eg9c99gd7e6gde4dg273c50946ace" version="1">Aunque los dragones son los principales adoradores del Dominio del Dragón, las deidades dracónicas aceptan la adoración de cualquiera que anhele riqueza o poder. Los clérigos del Dominio del Dragón, a menudo considerados cultistas, pueden canalizar el poder y el aspecto de los dragones, desatando temible magia elemental y manifestando la presencia imponente de un antiguo wyrm.
+
+Los dioses principales del Dominio del Dragón incluyen a Tiamat, la madre de cinco cabezas de los dragones cromáticos, y Bahamut, el dios justo y sabio de los dragones metálicos.</content>
+  <content contentuid="h46b1b3ecg0868g9a06gedcegd7658cf8f65b" version="1">Nivel 3: Afinidad Cromática</content>
+  <content contentuid="hc78a280cge0f8gaed4gabceg8275d4b016b4" version="3">Cada vez que terminas un &lt;LSTag Tooltip="LongRest"&gt;Descanso Largo&lt;/LSTag&gt;, elige Ácido, Frío, Fuego, Rayo o Veneno. Una vez por turno, cuando infliges daño a una criatura, puedes infligir daño adicional de ese tipo igual a tu nivel de Clérigo a esa criatura. Puedes infligir este daño adicional un número de veces igual a tu &lt;LSTag Tooltip="AbilityModifier"&gt;modificador&lt;/LSTag&gt; de &lt;LSTag Tooltip="Wisdom"&gt;Sabiduría&lt;/LSTag&gt; (mínimo una vez). Recuperas todos los usos gastados cuando terminas un Descanso Largo.</content>
+  <content contentuid="hdeeff767g27feg17d7gd19dgdf3ed324b4f9" version="1">Nivel 3: Conjuros del Dominio del Dragón</content>
+  <content contentuid="h13ce1cf5g78b1g36f4ge570g79a78fa8b13f" version="1">Tu conexión con este dominio divino garantiza que siempre tengas ciertos conjuros preparados. Cuando alcanzas un nivel de Clérigo especificado en la tabla de Conjuros del Dominio del Dragón, a partir de entonces siempre tienes preparados los conjuros listados. Al nivel 3, siempre tienes preparados Orbe Cromático, Orden, Visión en la Oscuridad y Aliento de Dragón. Al nivel 5, se añaden Volar y Protección contra la Energía. Al nivel 7, obtienes Destierro y Hechizar Monstruo, y al nivel 9, Dominar Persona y Estática Sináptica.</content>
+  <content contentuid="h7a72c71dge3ceg382dg0d4eg0a3a9f9e8d36" version="1">Nivel 3: Majestad Dracónica</content>
+  <content contentuid="h8291ccc5gfdbegf769g12a5gc01ea2a4cbdd" version="1">Como acción de Magia, puedes presentar tu Símbolo Sagrado y gastar un uso de tu &lt;LSTag Type="ActionResource" Tooltip="ChannelDivinity"&gt;Canalizar Divinidad&lt;/LSTag&gt; para manifestar un aura de autoridad dracónica a tu alrededor en una Emanación de 30 pies. Elige la condición &lt;LSTag Type="Status" Tooltip="CHARMED"&gt;Hechizado&lt;/LSTag&gt; o &lt;LSTag Type="Status" Tooltip="FRIGHTENED"&gt;Asustado&lt;/LSTag&gt;. Cada criatura de tu elección en la Emanación debe superar una &lt;LSTag Tooltip="SavingThrow"&gt;tirada de salvación&lt;/LSTag&gt; de &lt;LSTag Tooltip="Wisdom"&gt;Sabiduría&lt;/LSTag&gt; o tener la condición elegida durante 1 minuto. Una criatura Hechizada o Asustada por este rasgo realiza otra tirada de salvación de Sabiduría al final de cada uno de sus turnos, terminando la condición sobre sí misma si tiene éxito.</content>
+  <content contentuid="h4c2abc64ge336g3c9fgef12g63a76733dcc7" version="1">Nivel 6: Bendición del Wyrm</content>
+  <content contentuid="h9df6513eg20a3ge93age02fg7190bcec269a" version="1">Puedes gastar un uso de tu &lt;LSTag Type="ActionResource" Tooltip="ChannelDivinity"&gt;Canalizar Divinidad&lt;/LSTag&gt; para lanzar Aliento de Dragón o Protección contra la Energía sobre ti mismo en lugar de gastar un espacio de conjuro. Cuando lanzas cualquiera de estos conjuros de esta forma, el conjuro no requiere Concentración. Este conjuro termina antes de tiempo si vuelves a lanzar ese conjuro, tienes la condición Incapacitado o mueres.</content>
+  <content contentuid="h4b5feaf6g9b01g5ee4gd966g55a524693904" version="1">Afinidad Cromática</content>
+  <content contentuid="h917c7e4ag19b5g9911g778dgac0c75a9bba9" version="1">Afinidad Cromática</content>
+  <content contentuid="hf814f210g333ag4aeag5f87g929a9260c5cb" version="2">Cada vez que terminas un &lt;LSTag Tooltip="LongRest"&gt;Descanso Largo&lt;/LSTag&gt;, elige Ácido, Frío, Fuego, Rayo o Veneno. Una vez por turno, cuando infliges daño a una criatura, puedes infligir daño adicional de ese tipo igual a tu nivel de Clérigo a esa criatura.</content>
+  <content contentuid="h95ac559eg6dcdg0056g3f01g9fd5c3cd7651" version="1">Puedes infligir este daño adicional un número de veces igual a tu &lt;LSTag Tooltip="AbilityModifier"&gt;modificador&lt;/LSTag&gt; de &lt;LSTag Tooltip="Wisdom"&gt;Sabiduría&lt;/LSTag&gt; (mínimo una vez). Recuperas todos los usos gastados cuando terminas un &lt;LSTag Tooltip="LongRest"&gt;Descanso Largo&lt;/LSTag&gt;.</content>
+  <content contentuid="hb2f87a7eg90a5g255cg636bg1f5548aff156" version="1">Afinidad Cromática: Ácido</content>
+  <content contentuid="h5cfa6ed7gb49cg717eg9b8eg52489fe685fa" version="1">Afinidad Cromática: Frío</content>
+  <content contentuid="ha0376bb1gdbb7g0bb3ga698gc766dfb4c76d" version="1">Afinidad Cromática: Fuego</content>
+  <content contentuid="he8275a17g6f90ge548g0527g7eb734361d44" version="1">Afinidad Cromática: Rayo</content>
+  <content contentuid="h83d343fag216fgb910gf153gf26139ab8f44" version="1">Afinidad Cromática: Veneno</content>
+  <content contentuid="h09a86c40g734agfef8ga34ag6e9bb7f6107b" version="1">Afinidad Cromática</content>
+  <content contentuid="h6f54d84fg4fd2g1714g3774ge9393a34b2a1" version="2">Una vez por turno, cuando infliges daño a una criatura, puedes infligir daño adicional de ese tipo igual a tu nivel de Clérigo a esa criatura. Puedes infligir este daño adicional un número de veces igual a tu &lt;LSTag Tooltip="AbilityModifier"&gt;modificador&lt;/LSTag&gt; de &lt;LSTag Tooltip="Wisdom"&gt;Sabiduría&lt;/LSTag&gt; (mínimo una vez). Recuperas todos los usos gastados cuando terminas un &lt;LSTag Tooltip="LongRest"&gt;Descanso Largo&lt;/LSTag&gt;.</content>
+  <content contentuid="h8042d3adgdd7eg4c14g16d3gf172853c762d" version="1">Afinidad Cromática: Ácido</content>
+  <content contentuid="hbcae2db7gfa67g091fg9f12gd7c998b920f3" version="1">Puedes infligir daño adicional de ese tipo igual a tu nivel de Clérigo a esa criatura.</content>
+  <content contentuid="hc1a4e31fgc275g5c08g42adgaa576cec3cda" version="1">Afinidad Cromática: Frío</content>
+  <content contentuid="h76b4fd55gd816g6a6bgf036gd751e5af63d9" version="1">Afinidad Cromática: Fuego</content>
+  <content contentuid="hf56293bcgbef0g670dgdc2cgaafbafce938b" version="1">Afinidad Cromática: Rayo</content>
+  <content contentuid="h14d47d15g4714gda83gb886gb2129b493f72" version="1">Afinidad Cromática: Veneno</content>
+  <content contentuid="h5f5a35c1g26a9g4d26gd62dg67f7db26195d" version="1">Majestad Dracónica</content>
+  <content contentuid="h929e2b24g4c43g4ea9g6a85g0a755b1c242c" version="1">Como acción de Magia, puedes presentar tu Símbolo Sagrado y gastar un uso de tu &lt;LSTag Type="ActionResource" Tooltip="ChannelDivinity"&gt;Canalizar Divinidad&lt;/LSTag&gt; para manifestar un aura de autoridad dracónica a tu alrededor en una Emanación de 30 pies. Elige la condición &lt;LSTag Type="Status" Tooltip="CHARMED"&gt;Hechizado&lt;/LSTag&gt; o &lt;LSTag Type="Status" Tooltip="FRIGHTENED"&gt;Asustado&lt;/LSTag&gt;. Cada criatura de tu elección en la Emanación debe superar una &lt;LSTag Tooltip="SavingThrow"&gt;tirada de salvación&lt;/LSTag&gt; de &lt;LSTag Tooltip="Wisdom"&gt;Sabiduría&lt;/LSTag&gt; o tener la condición elegida durante 1 minuto. Una criatura Hechizada o Asustada por este rasgo realiza otra tirada de salvación de Sabiduría al final de cada uno de sus turnos, terminando la condición sobre sí misma si tiene éxito.</content>
+  <content contentuid="hb624c73cg11bag0d81g0177g2934801a6f74" version="1">Majestad Dracónica: Hechizar</content>
+  <content contentuid="h6845e7aag9f14gfc51ga53fg76a2de6fedff" version="1">Majestad Dracónica: Miedo</content>
+  <content contentuid="haeaea6cdg7780g0792g7800g63f6fd5ec861" version="1">Majestad Dracónica: Hechizar</content>
+  <content contentuid="hc2270a33gb236gcf12g676bga9ec6586e785" version="1">Majestad Dracónica: Miedo</content>
+  <content contentuid="ha5ac9c2egbb38gb14cg097ag8ecd055eca21" version="1">Aliento de Dragón (Bendición del Wyrm)</content>
+  <content contentuid="hc79d025ag7d3dg2747g4484gd5d955fd41ce" version="1">Protección contra la Energía (Bendición del Wyrm)</content>
+  <content contentuid="h3c8c473bg26ecg406cg8973g137185d1207f" version="1">Pergamino de Ojo Arcano</content>
+  <content contentuid="hf2447855gf57fg407cga1d1gfc8287530812" version="1">Apto para: Artífice, Mago</content>
 </contentList>


### PR DESCRIPTION
Updated Spanish localization for various abilities and spells, including changes to 'Recuperación Rápida' and 'Majestad Dracónica'.